### PR TITLE
Rebased Globe View branch: Allow globe view and non-mercator projections to coexist

### DIFF
--- a/bench/benchmarks/symbol_layout.js
+++ b/bench/benchmarks/symbol_layout.js
@@ -42,7 +42,7 @@ export default class SymbolLayout extends Layout {
                                             this.parser.style.listImages(),
                                             tileResult.tileID.canonical,
                                             tileResult.tileZoom,
-                                            getProjection('mercator'));
+                                            'mercator');
                     }
                 }
             });

--- a/bench/benchmarks/symbol_layout.js
+++ b/bench/benchmarks/symbol_layout.js
@@ -4,7 +4,7 @@ import Layout from './layout.js';
 import SymbolBucket from '../../src/data/bucket/symbol_bucket.js';
 import {performSymbolLayout} from '../../src/symbol/symbol_layout.js';
 import {OverscaledTileID} from '../../src/source/tile_id.js';
-import getProjection from '../../src/geo/projection/index.js';
+import {getProjection} from '../../src/geo/projection/index.js';
 
 export default class SymbolLayout extends Layout {
     parsedTiles: Array<any>;

--- a/bench/benchmarks/symbol_layout.js
+++ b/bench/benchmarks/symbol_layout.js
@@ -42,7 +42,7 @@ export default class SymbolLayout extends Layout {
                                             this.parser.style.listImages(),
                                             tileResult.tileID.canonical,
                                             tileResult.tileZoom,
-                                            'mercator');
+                                            getProjection({name: 'mercator'}));
                     }
                 }
             });

--- a/bench/lib/tile_parser.js
+++ b/bench/lib/tile_parser.js
@@ -15,6 +15,7 @@ import type {StyleSpecification} from '../../src/style-spec/types.js';
 import type {WorkerTileResult} from '../../src/source/worker_source.js';
 import type {OverscaledTileID} from '../../src/source/tile_id.js';
 import type {TileJSON} from '../../src/types/tilejson.js';
+import {getProjection} from '../../src/geo/projection/index.js';
 
 class StubMap extends Evented {
     _requestManager: RequestManager;
@@ -132,7 +133,8 @@ export default class TileParser {
             cameraToTileDistance: 0,
             returnDependencies,
             promoteId: undefined,
-            isSymbolTile: false
+            isSymbolTile: false,
+            projection: getProjection({name: 'mercator'})
         });
 
         const vectorTile = new VT.VectorTile(new Protobuf(tile.buffer));

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -49,10 +49,7 @@ export default function loadGeometry(feature: FeatureWithGeometry, canonical?: C
     const extent = feature.extent;
     const extentScale = EXTENT / extent;
 
-    if (canonical && tileTransform &&
-        // FIXME: move this as part of the projection interface
-        tileTransform.projection.name !== 'mercator' &&
-        tileTransform.projection.name !== 'globe') {
+    if (canonical && tileTransform && tileTransform.projection.isReprojectedInTileSpace) {
         const z2 = 1 << canonical.z;
         const {scale, x, y, projection} = tileTransform;
 

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -49,9 +49,8 @@ export default function loadGeometry(feature: FeatureWithGeometry, canonical?: C
     const extent = feature.extent;
     const extentScale = EXTENT / extent;
 
-    // TODO: Cleanup check against 'mercator' or 'globe', make it part of the projection
-    // interface
     if (canonical && tileTransform &&
+        // FIXME: move this as part of the projection interface
         tileTransform.projection.name !== 'mercator' &&
         tileTransform.projection.name !== 'globe') {
         const z2 = 1 << canonical.z;

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -49,7 +49,11 @@ export default function loadGeometry(feature: FeatureWithGeometry, canonical?: C
     const extent = feature.extent;
     const extentScale = EXTENT / extent;
 
-    if (canonical && tileTransform && tileTransform.projection.name !== 'mercator') {
+    // TODO: Cleanup check against 'mercator' or 'globe', make it part of the projection
+    // interface
+    if (canonical && tileTransform &&
+        tileTransform.projection.name !== 'mercator' &&
+        tileTransform.projection.name !== 'globe') {
         const z2 = 1 << canonical.z;
         const {scale, x, y, projection} = tileTransform;
 

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -42,7 +42,7 @@ export default {
         const r = Math.sqrt(c - 2 * n * Math.sin(phi)) / n;
         const x = r * Math.sin(lambda * n);
         const y = r * Math.cos(lambda * n) - r0;
-        return {x, y};
+        return {x, y, z: 0};
     },
 
     unproject(x: number, y: number) {

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -3,6 +3,16 @@ import LngLat from '../lng_lat.js';
 import {clamp, wrap, degToRad, radToDeg} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 import {vec2} from 'gl-matrix';
+import {
+    mercatorXfromLng,
+    mercatorYfromLat,
+    mercatorZfromAltitude,
+    lngFromMercatorX,
+    latFromMercatorY
+} from '../mercator_coordinate.js';
+import type Transform from '../../geo/transform.js';
+import Point from '@mapbox/point-geometry';
+import FlatTileTransform from './flat_tile_transform.js';
 
 export default {
     name: 'albers',
@@ -58,5 +68,47 @@ export default {
         const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 
         return new LngLat(lng, lat);
+    },
+
+    projectTilePoint(x: number, y: number): {x: number, y: number, z: number} {
+        return {x, y, z: 0};
+    },
+
+    locationPoint(tr: Transform, lngLat: LngLat): Point {
+        return tr._coordinatePoint(tr.locationCoordinate(lngLat), false);
+    },
+
+    pixelsPerMeter(lat: number, worldSize: number) {
+        return mercatorZfromAltitude(1, lat) * worldSize;
+    },
+
+    farthestPixelDistance(tr: Transform): number {
+        const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
+
+        // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
+        // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
+        // 1 Z unit is equivalent to 1 horizontal px at the center of the map
+        // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
+        const groundAngle = Math.PI / 2 + tr._pitch;
+        const fovAboveCenter = tr.fovAboveCenter;
+
+        // Adjust distance to MSL by the minimum possible elevation visible on screen,
+        // this way the far plane is pushed further in the case of negative elevation.
+        const minElevationInPixels = tr.elevation ?
+            tr.elevation.getMinElevationBelowMSL() * pixelsPerMeter :
+            0;
+        const cameraToSeaLevelDistance = ((tr._camera.position[2] * tr.worldSize) - minElevationInPixels) / Math.cos(tr._pitch);
+        const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
+
+        // Calculate z distance of the farthest fragment that should be rendered.
+        const furthestDistance = Math.cos(Math.PI / 2 - tr._pitch) * topHalfSurfaceDistance + cameraToSeaLevelDistance;
+        const horizonDistance = cameraToSeaLevelDistance * (1 / tr._horizonShift);
+
+        // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
+        return Math.min(furthestDistance * 1.01, horizonDistance);
+    },
+
+    createTileTransform(tr: Transform, worldSize: number): Object {
+        return new FlatTileTransform(tr, worldSize);
     }
 };

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -1,26 +1,19 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, wrap, degToRad, radToDeg} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import {mercatorZfromAltitude, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 import {vec2} from 'gl-matrix';
-import {
-    mercatorXfromLng,
-    mercatorYfromLat,
-    mercatorZfromAltitude,
-    lngFromMercatorX,
-    latFromMercatorY
-} from '../mercator_coordinate.js';
 import type Transform from '../../geo/transform.js';
 import Point from '@mapbox/point-geometry';
 import FlatTileTransform from './flat_tile_transform.js';
+import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 export default {
     name: 'albers',
     range: [4, 7],
-
     center: [-96, 37.5],
     parallels: [29.5, 45.5],
-
+    zAxisUnit: "meters",
     conic: true,
 
     // based on https://github.com/d3/d3-geo-projection, MIT-licensed
@@ -84,28 +77,7 @@ export default {
 
     farthestPixelDistance(tr: Transform): number {
         const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
-
-        // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
-        // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
-        // 1 Z unit is equivalent to 1 horizontal px at the center of the map
-        // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
-        const groundAngle = Math.PI / 2 + tr._pitch;
-        const fovAboveCenter = tr.fovAboveCenter;
-
-        // Adjust distance to MSL by the minimum possible elevation visible on screen,
-        // this way the far plane is pushed further in the case of negative elevation.
-        const minElevationInPixels = tr.elevation ?
-            tr.elevation.getMinElevationBelowMSL() * pixelsPerMeter :
-            0;
-        const cameraToSeaLevelDistance = ((tr._camera.position[2] * tr.worldSize) - minElevationInPixels) / Math.cos(tr._pitch);
-        const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
-
-        // Calculate z distance of the farthest fragment that should be rendered.
-        const furthestDistance = Math.cos(Math.PI / 2 - tr._pitch) * topHalfSurfaceDistance + cameraToSeaLevelDistance;
-        const horizonDistance = cameraToSeaLevelDistance * (1 / tr._horizonShift);
-
-        // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
-        return Math.min(furthestDistance * 1.01, horizonDistance);
+        return farthestPixelDistanceOnPlane(tr, pixelsPerMeter);
     },
 
     createTileTransform(tr: Transform, worldSize: number): Object {

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -15,6 +15,7 @@ export default {
     parallels: [29.5, 45.5],
     zAxisUnit: "meters",
     conic: true,
+    isReprojectedInTileSpace: true,
 
     // based on https://github.com/d3/d3-geo-projection, MIT-licensed
 

--- a/src/geo/projection/cylindrical_equal_area.js
+++ b/src/geo/projection/cylindrical_equal_area.js
@@ -9,7 +9,7 @@ export default function(phi: number) {
     const scale = 1 / (2 * Math.max(Math.PI * cosPhi, 1 / cosPhi));
 
     return {
-        wrap: true,
+        supportsWorldCopies: true,
         project(lng: number, lat: number) {
             const x = degToRad(lng) * cosPhi;
             const y = Math.sin(degToRad(lat)) / cosPhi;

--- a/src/geo/projection/cylindrical_equal_area.js
+++ b/src/geo/projection/cylindrical_equal_area.js
@@ -17,6 +17,7 @@ export default function(phi: number) {
             return {
                 x: (x * scale) + 0.5,
                 y: (-y * scale) + 0.5,
+                z: 0
             };
         },
         unproject(x: number, y: number) {

--- a/src/geo/projection/equal_earth.js
+++ b/src/geo/projection/equal_earth.js
@@ -32,7 +32,8 @@ export default {
 
         return {
             x: (x / Math.PI + 0.5) * 0.5,
-            y: 1 - (y / Math.PI + 1) * 0.5
+            y: 1 - (y / Math.PI + 1) * 0.5,
+            z: 0
         };
     },
 

--- a/src/geo/projection/equal_earth.js
+++ b/src/geo/projection/equal_earth.js
@@ -18,6 +18,7 @@ export default {
     center: [0, 0],
     range: [3.5, 7],
     zAxisUnit: "meters",
+    isReprojectedInTileSpace: true,
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed

--- a/src/geo/projection/equal_earth.js
+++ b/src/geo/projection/equal_earth.js
@@ -1,7 +1,11 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import {mercatorZfromAltitude, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type Transform from '../../geo/transform.js';
+import Point from '@mapbox/point-geometry';
+import FlatTileTransform from './flat_tile_transform.js';
+import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 const a1 = 1.340264;
 const a2 = -0.081106;
@@ -13,6 +17,7 @@ export default {
     name: 'equalEarth',
     center: [0, 0],
     range: [3.5, 7],
+    zAxisUnit: "meters",
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed
@@ -54,5 +59,26 @@ export default {
         const lat = clamp(phi * 180 / Math.PI, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 
         return new LngLat(lng, lat);
+    },
+
+    projectTilePoint(x: number, y: number): {x: number, y: number, z: number} {
+        return {x, y, z: 0};
+    },
+
+    locationPoint(tr: Transform, lngLat: LngLat): Point {
+        return tr._coordinatePoint(tr.locationCoordinate(lngLat), false);
+    },
+
+    pixelsPerMeter(lat: number, worldSize: number) {
+        return mercatorZfromAltitude(1, lat) * worldSize;
+    },
+
+    farthestPixelDistance(tr: Transform): number {
+        const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
+        return farthestPixelDistanceOnPlane(tr, pixelsPerMeter);
+    },
+
+    createTileTransform(tr: Transform, worldSize: number): Object {
+        return new FlatTileTransform(tr, worldSize);
     }
 };

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -1,21 +1,49 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import {mercatorZfromAltitude, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type Transform from '../../geo/transform.js';
+import Point from '@mapbox/point-geometry';
+import FlatTileTransform from './flat_tile_transform.js';
+import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 export default {
     name: 'equirectangular',
     wrap: true,
     center: [0, 0],
     range: [3.5, 7],
+    zAxisUnit: "meters",
+
     project(lng: number, lat: number) {
         const x = 0.5 + lng / 360;
         const y = 0.5 - lat / 360;
         return {x, y};
     },
+
     unproject(x: number, y: number) {
         const lng = (x - 0.5) * 360;
         const lat = clamp((0.5 - y) * 360, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
         return new LngLat(lng, lat);
+    },
+
+    projectTilePoint(x: number, y: number): {x: number, y: number, z: number} {
+        return {x, y, z: 0};
+    },
+
+    locationPoint(tr: Transform, lngLat: LngLat): Point {
+        return tr._coordinatePoint(tr.locationCoordinate(lngLat), false);
+    },
+
+    pixelsPerMeter(lat: number, worldSize: number) {
+        return mercatorZfromAltitude(1, lat) * worldSize;
+    },
+
+    farthestPixelDistance(tr: Transform): number {
+        const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
+        return farthestPixelDistanceOnPlane(tr, pixelsPerMeter);
+    },
+
+    createTileTransform(tr: Transform, worldSize: number): Object {
+        return new FlatTileTransform(tr, worldSize);
     }
 };

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -13,6 +13,7 @@ export default {
     center: [0, 0],
     range: [3.5, 7],
     zAxisUnit: "meters",
+    isReprojectedInTileSpace: true,
 
     project(lng: number, lat: number) {
         const x = 0.5 + lng / 360;

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -18,7 +18,7 @@ export default {
     project(lng: number, lat: number) {
         const x = 0.5 + lng / 360;
         const y = 0.5 - lat / 360;
-        return {x, y};
+        return {x, y, z: 0};
     },
 
     unproject(x: number, y: number) {

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -9,7 +9,7 @@ import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 export default {
     name: 'equirectangular',
-    wrap: true,
+    supportsWorldCopies: true,
     center: [0, 0],
     range: [3.5, 7],
     zAxisUnit: "meters",

--- a/src/geo/projection/far_z.js
+++ b/src/geo/projection/far_z.js
@@ -1,0 +1,78 @@
+// @flow
+import {mat4, vec3} from 'gl-matrix';
+import {Ray} from '../../util/primitives.js';
+import type Transform from '../transform.js';
+import {clamp} from '../../util/util.js';
+
+export function farthestPixelDistanceOnPlane(tr: Transform, pixelsPerMeter: number): number {
+    // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
+    // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
+    // 1 Z unit is equivalent to 1 horizontal px at the center of the map
+    // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
+    const groundAngle = Math.PI / 2 + tr._pitch;
+    const fovAboveCenter = tr.fovAboveCenter;
+
+    // Adjust distance to MSL by the minimum possible elevation visible on screen,
+    // this way the far plane is pushed further in the case of negative elevation.
+    const minElevationInPixels = tr.elevation ?
+        tr.elevation.getMinElevationBelowMSL() * pixelsPerMeter :
+        0;
+    const cameraToSeaLevelDistance = ((tr._camera.position[2] * tr.worldSize) - minElevationInPixels) / Math.cos(tr._pitch);
+    const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
+
+    // Calculate z distance of the farthest fragment that should be rendered.
+    const furthestDistance = Math.cos(Math.PI / 2 - tr._pitch) * topHalfSurfaceDistance + cameraToSeaLevelDistance;
+    const horizonDistance = cameraToSeaLevelDistance * (1 / tr._horizonShift);
+
+    // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
+    return Math.min(furthestDistance * 1.01, horizonDistance);
+}
+
+export function furthestPixelDistanceOnSphere(tr: Transform, pixelsPerMeter: number): number {
+    // Find farthest distance of the globe that is potentially visible to the camera.
+    // First check if the view frustum is fully covered by the map by casting a ray
+    // from the top left/right corner and see if it intersects with the globe. In case
+    // of no intersection we need to find distance to the horizon point where the
+    // surface normal is perpendicular to the camera forward direction.
+    const cameraDistance = tr.cameraToCenterDistance;
+    const centerPixelAltitude = tr._centerAltitude * pixelsPerMeter;
+
+    const camera = tr._camera;
+    const forward = tr._camera.forward();
+    const cameraPosition = vec3.add([], vec3.scale([], forward, -cameraDistance), [0, 0, centerPixelAltitude]);
+
+    const globeRadius = tr.worldSize / (2.0 * Math.PI);
+    const globeCenter = [0, 0, -globeRadius];
+
+    const aspectRatio = tr.width / tr.height;
+    const tanFovAboveCenter = Math.tan(tr.fovAboveCenter);
+
+    const up = vec3.scale([], camera.up(), tanFovAboveCenter);
+    const right = vec3.scale([], camera.right(), tanFovAboveCenter * aspectRatio);
+    const dir = vec3.normalize([], vec3.add([], vec3.add([], forward, up), right));
+
+    const pointOnGlobe = [];
+    const ray = new Ray(cameraPosition, dir);
+
+    let pixelDistance;
+    if (ray.closestPointOnSphere(globeCenter, globeRadius, pointOnGlobe)) {
+        const p0 = vec3.add([], pointOnGlobe, globeCenter);
+        const p1 = vec3.sub([], p0, cameraPosition);
+        // Globe is fully covering the view frustum. Project the intersection
+        // point to the camera view vector in order to find the pixel distance
+        pixelDistance = Math.cos(tr.fovAboveCenter) * vec3.length(p1);
+    } else {
+        // Background space is visible. Find distance to the point of the
+        // globe where surface normal is parallel to the view vector
+        const p0 = vec3.sub([], cameraPosition, globeCenter);
+        const p1 = vec3.sub([], globeCenter, cameraPosition);
+        vec3.normalize(p1, p1);
+
+        const cameraHeight = vec3.length(p0) - globeRadius;
+        pixelDistance = Math.sqrt(cameraHeight * cameraHeight + 2 * globeRadius * cameraHeight);
+        const angle = Math.acos(pixelDistance / (globeRadius + cameraHeight)) - Math.acos(vec3.dot(forward, p1));
+        pixelDistance *= Math.cos(angle);
+    }
+
+    return pixelDistance * 1.01;
+}

--- a/src/geo/projection/far_z.js
+++ b/src/geo/projection/far_z.js
@@ -1,5 +1,5 @@
 // @flow
-import {mat4, vec3} from 'gl-matrix';
+import {vec3} from 'gl-matrix';
 import {Ray} from '../../util/primitives.js';
 import type Transform from '../transform.js';
 import {clamp} from '../../util/util.js';

--- a/src/geo/projection/flat_tile_transform.js
+++ b/src/geo/projection/flat_tile_transform.js
@@ -20,32 +20,6 @@ export default class FlatTileTransform {
         this._identity = mat4.identity(new Float64Array(16));
     }
 
-    createLabelPlaneMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
-        const m = mat4.create();
-        if (pitchWithMap) {
-            mat4.scale(m, m, [1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1]);
-            if (!rotateWithMap) {
-                mat4.rotateZ(m, m, this._tr.angle);
-            }
-        } else {
-            mat4.multiply(m, this._tr.labelPlaneMatrix, posMatrix);
-        }
-        return m;
-    }
-
-    createGlCoordMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
-        if (pitchWithMap) {
-            const m = mat4.clone(posMatrix);
-            mat4.scale(m, m, [pixelsToTileUnits, pixelsToTileUnits, 1]);
-            if (!rotateWithMap) {
-                mat4.rotateZ(m, m, -this._tr.angle);
-            }
-            return m;
-        } else {
-            return this._tr.glCoordMatrix;
-        }
-    }
-
     createInversionMatrix(): mat4 {
         return this._identity;
     }
@@ -68,10 +42,10 @@ export default class FlatTileTransform {
            scaledY = cs.y;
            mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, this._tr.pixelsPerMeter / this._worldSize]);
         }
-        
+
         mat4.translate(posMatrix, posMatrix, [scaledX, scaledY, 0]);
         mat4.scale(posMatrix, posMatrix, [scale / EXTENT, scale / EXTENT, 1]);
-        
+
         return posMatrix;
     }
 

--- a/src/geo/projection/flat_tile_transform.js
+++ b/src/geo/projection/flat_tile_transform.js
@@ -1,0 +1,78 @@
+// @flow
+import type Transform from '../transform.js';
+import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
+import {mat4, vec3} from 'gl-matrix';
+import MercatorCoordinate from '../mercator_coordinate.js';
+import Point from '@mapbox/point-geometry';
+import EXTENT from '../../data/extent.js';
+
+export default class FlatTileTransform {
+    _tr: Transform;
+    _worldSize: number;
+    _identity: Float64Array;
+
+    constructor(tr: Transform, worldSize: number) {
+        this._tr = tr;
+        this._worldSize = worldSize;
+        // eslint-disable-next-line no-warning-comments
+        // TODO: Cache this elsewhere?
+        this._identity = mat4.identity(new Float64Array(16));
+    }
+
+    createLabelPlaneMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
+        const m = mat4.create();
+        if (pitchWithMap) {
+            mat4.scale(m, m, [1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1]);
+            if (!rotateWithMap) {
+                mat4.rotateZ(m, m, this._tr.angle);
+            }
+        } else {
+            mat4.multiply(m, this._tr.labelPlaneMatrix, posMatrix);
+        }
+        return m;
+    }
+
+    createGlCoordMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
+        if (pitchWithMap) {
+            const m = mat4.clone(posMatrix);
+            mat4.scale(m, m, [pixelsToTileUnits, pixelsToTileUnits, 1]);
+            if (!rotateWithMap) {
+                mat4.rotateZ(m, m, -this._tr.angle);
+            }
+            return m;
+        } else {
+            return this._tr.glCoordMatrix;
+        }
+    }
+
+    createInversionMatrix(): mat4 {
+        return this._identity;
+    }
+
+    createTileMatrix(id: UnwrappedTileID): mat4 {
+        const canonical = id.canonical;
+        const zoomScale = Math.pow(2, canonical.z);
+        const scale = this._worldSize / zoomScale;
+        const unwrappedX = canonical.x + zoomScale * id.wrap;
+
+        const posMatrix = mat4.identity(new Float64Array(16));
+        mat4.translate(posMatrix, posMatrix, [unwrappedX * scale, canonical.y * scale, 0]);
+        mat4.scale(posMatrix, posMatrix, [scale / EXTENT, scale / EXTENT, 1]);
+
+        return posMatrix;
+    }
+
+    pointCoordinate(x: number, y: number, z?: number): MercatorCoordinate {
+        const horizonOffset = this._tr.horizonLineFromTop(false);
+        const clamped = new Point(x, Math.max(horizonOffset, y));
+        return this._tr.rayIntersectionCoordinate(this._tr.pointRayIntersection(clamped, z));
+    }
+
+    upVector(): vec3 {
+        return [0, 0, 1];
+    }
+
+    upVectorScale(): number {
+        return 1;
+    }
+}

--- a/src/geo/projection/flat_tile_transform.js
+++ b/src/geo/projection/flat_tile_transform.js
@@ -1,6 +1,6 @@
 // @flow
 import type Transform from '../transform.js';
-import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
+import {UnwrappedTileID} from '../../source/tile_id.js';
 import {mat4, vec3} from 'gl-matrix';
 import MercatorCoordinate from '../mercator_coordinate.js';
 import Point from '@mapbox/point-geometry';
@@ -31,16 +31,16 @@ export default class FlatTileTransform {
         const projection = this._tr.projection;
 
         if (projection.isReprojectedInTileSpace) {
-           const cs = tileTransform(canonical, projection);
-           scale = 1;
-           scaledX = cs.x + id.wrap * cs.scale;
-           scaledY = cs.y;
-           mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, this._tr.pixelsPerMeter / this._worldSize]);
+            const cs = tileTransform(canonical, projection);
+            scale = 1;
+            scaledX = cs.x + id.wrap * cs.scale;
+            scaledY = cs.y;
+            mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, this._tr.pixelsPerMeter / this._worldSize]);
         } else {
-           scale = this._worldSize / this._tr.zoomScale(canonical.z);
-           const unwrappedX = canonical.x + Math.pow(2, canonical.z) * id.wrap;
-           scaledX = unwrappedX * scale;
-           scaledY = canonical.y * scale;
+            scale = this._worldSize / this._tr.zoomScale(canonical.z);
+            const unwrappedX = canonical.x + Math.pow(2, canonical.z) * id.wrap;
+            scaledX = unwrappedX * scale;
+            scaledY = canonical.y * scale;
         }
 
         mat4.translate(posMatrix, posMatrix, [scaledX, scaledY, 0]);

--- a/src/geo/projection/flat_tile_transform.js
+++ b/src/geo/projection/flat_tile_transform.js
@@ -30,17 +30,17 @@ export default class FlatTileTransform {
         const posMatrix = mat4.identity(new Float64Array(16));
         const projection = this._tr.projection;
 
-        if (projection.name === 'mercator') {
-           scale = this._worldSize / this._tr.zoomScale(canonical.z);
-           const unwrappedX = canonical.x + Math.pow(2, canonical.z) * id.wrap;
-           scaledX = unwrappedX * scale;
-           scaledY = canonical.y * scale;
-        } else {
+        if (projection.isReprojectedInTileSpace) {
            const cs = tileTransform(canonical, projection);
            scale = 1;
            scaledX = cs.x + id.wrap * cs.scale;
            scaledY = cs.y;
            mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, this._tr.pixelsPerMeter / this._worldSize]);
+        } else {
+           scale = this._worldSize / this._tr.zoomScale(canonical.z);
+           const unwrappedX = canonical.x + Math.pow(2, canonical.z) * id.wrap;
+           scaledX = unwrappedX * scale;
+           scaledY = canonical.y * scale;
         }
 
         mat4.translate(posMatrix, posMatrix, [scaledX, scaledY, 0]);

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -34,6 +34,7 @@ export default {
     name: 'globe',
     requiresDraping: true,
     supportsWorldCopies: false,
+    supportsTerrain: true,
     zAxisUnit: "pixels",
 
     project(lng: number, lat: number) {

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -36,8 +36,10 @@ export default {
     supportsWorldCopies: false,
     zAxisUnit: "pixels",
 
-    project() {
-        return {x: 0, y: 0, z: 0};
+    project(lng: number, lat: number) {
+        const x = mercatorXfromLng(lng);
+        const y = mercatorYfromLat(lat);
+        return {x, y, z: 0};
     },
 
     unproject(x: number, y: number) {

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -40,6 +40,12 @@ export default {
         return {x: 0, y: 0, z: 0};
     },
 
+    unproject(x: number, y: number) {
+        const lng = lngFromMercatorX(x);
+        const lat = latFromMercatorY(y);
+        return new LngLat(lng, lat);
+    },
+
     projectTilePoint(x: number, y: number, id: CanonicalTileID): {x: number, y: number, z: number} {
         const tiles = Math.pow(2.0, id.z);
         const mx = (x / EXTENT + id.x) / tiles;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -37,6 +37,7 @@ export default {
     supportsTerrain: true,
     supportsFreeCamera: true,
     zAxisUnit: "pixels",
+    center: [0, 0],
 
     project(lng: number, lat: number) {
         const x = mercatorXfromLng(lng);
@@ -201,7 +202,7 @@ export function denormalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export function calculateGlobeMatrix(tr: Transform, worldSize: number, offset: [number, number]): mat4 {
+export function calculateGlobeMatrix(tr: Transform, worldSize: number, offset?: [number, number]): mat4 {
     const localRadius = EXTENT / (2.0 * Math.PI);
     const wsRadius = worldSize / (2.0 * Math.PI);
     const s = wsRadius / localRadius;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -199,19 +199,24 @@ export function denormalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export function calculateGlobeMatrix(tr: Transform, worldSize: number): mat4 {
+export function calculateGlobeMatrix(tr: Transform, worldSize: number, offset: [number, number]): mat4 {
     const localRadius = EXTENT / (2.0 * Math.PI);
     const wsRadius = worldSize / (2.0 * Math.PI);
     const s = wsRadius / localRadius;
 
-    const lat = clamp(tr.center.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
-    const point = new Point(
-        mercatorXfromLng(tr.center.lng) * worldSize,
-        mercatorYfromLat(lat) * worldSize);
+    if (!offset) {
+        const lat = clamp(tr.center.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        const lng = tr.center.lng;
+
+        offset = [
+            mercatorXfromLng(lng) * worldSize,
+            mercatorYfromLat(lat) * worldSize
+        ];
+    }
 
     // transform the globe from reference coordinate space to world space
     const posMatrix = mat4.identity(new Float64Array(16));
-    mat4.translate(posMatrix, posMatrix, [point.x, point.y, -wsRadius]);
+    mat4.translate(posMatrix, posMatrix, [offset[0], offset[1], -wsRadius]);
     mat4.scale(posMatrix, posMatrix, [s, s, s]);
     mat4.rotateX(posMatrix, posMatrix, degToRad(-tr._center.lat));
     mat4.rotateY(posMatrix, posMatrix, degToRad(-tr._center.lng));

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -88,25 +88,6 @@ class GlobeTileTransform {
         return mat4.multiply(matrix, matrix, scaling);
     }
 
-    tileAabb(id: UnwrappedTileID) {
-        const aabb = tileBoundsOnGlobe(id.canonical);
-
-        // Transform corners of the aabb to the correct space
-        const corners = aabb.getCorners();
-
-        const mx = Number.MAX_VALUE;
-        const max = [-mx, -mx, -mx];
-        const min = [mx, mx, mx];
-
-        for (let i = 0; i < corners.length; i++) {
-            vec3.transformMat4(corners[i], corners[i], this._globeMatrix);
-            vec3.min(min, min, corners[i]);
-            vec3.max(max, max, corners[i]);
-        }
-
-        return new Aabb(min, max);
-    }
-
     upVector(id: CanonicalTileID, x: number, y: number): vec3 {
         const corners = tileLatLngCorners(id);
         const tl = corners[0];
@@ -315,7 +296,7 @@ export default {
 
 export const globeRefRadius = EXTENT / Math.PI / 2.0;
 
-function tileBoundsOnGlobe(id: CanonicalTileID): Aabb {
+export function tileBoundsOnGlobe(id: CanonicalTileID): Aabb {
     const z = id.z;
 
     const mn = -globeRefRadius;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -35,6 +35,7 @@ export default {
     requiresDraping: true,
     supportsWorldCopies: false,
     supportsTerrain: true,
+    supportsFreeCamera: true,
     zAxisUnit: "pixels",
 
     project(lng: number, lat: number) {

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -4,7 +4,14 @@ import {Aabb, Ray} from '../../util/primitives.js';
 import EXTENT from '../../data/extent.js';
 import LngLat from '../lng_lat.js';
 import {degToRad, smoothstep, clamp} from '../../util/util.js';
-import {lngFromMercatorX, latFromMercatorY, mercatorZfromAltitude, mercatorXfromLng, mercatorYfromLat} from '../mercator_coordinate.js';
+import {
+    MAX_MERCATOR_LATITUDE,
+    lngFromMercatorX,
+    latFromMercatorY,
+    mercatorZfromAltitude,
+    mercatorXfromLng,
+    mercatorYfromLat
+} from '../mercator_coordinate.js';
 import {CanonicalTileID, OverscaledTileID} from '../../source/tile_id.js';
 import Context from '../../gl/context.js';
 import Tile from '../../source/tile.js';
@@ -189,7 +196,7 @@ export function calculateGlobeMatrix(tr: Transform, worldSize: number): mat4 {
     const wsRadius = worldSize / (2.0 * Math.PI);
     const s = wsRadius / localRadius;
 
-    const lat = clamp(tr.center.lat, -tr.maxValidLatitude, tr.maxValidLatitude);
+    const lat = clamp(tr.center.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
     const point = new Point(
         mercatorXfromLng(tr.center.lng) * worldSize,
         mercatorYfromLat(lat) * worldSize);
@@ -206,7 +213,7 @@ export function calculateGlobeMatrix(tr: Transform, worldSize: number): mat4 {
 
 export function calculateGlobeMercatorMatrix(tr: Transform): mat4 {
     const worldSize = tr.worldSize;
-    const lat = clamp(tr.center.lat, -tr.maxValidLatitude, tr.maxValidLatitude);
+    const lat = clamp(tr.center.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
     const point = new Point(
         mercatorXfromLng(tr.center.lng) * worldSize,
         mercatorYfromLat(lat) * worldSize);

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -1,12 +1,11 @@
 // @flow
-
-import {mat4, vec4, vec3} from 'gl-matrix';
+import {mat4, vec3} from 'gl-matrix';
 import {Aabb, Ray} from '../../util/primitives.js';
 import EXTENT from '../../data/extent.js';
 import LngLat from '../lng_lat.js';
 import {degToRad, smoothstep, clamp} from '../../util/util.js';
-import MercatorCoordinate, {lngFromMercatorX, latFromMercatorY, mercatorZfromAltitude, mercatorXfromLng, mercatorYfromLat} from '../mercator_coordinate.js';
-import {CanonicalTileID, UnwrappedTileID, OverscaledTileID} from '../../source/tile_id.js';
+import {lngFromMercatorX, latFromMercatorY, mercatorZfromAltitude, mercatorXfromLng, mercatorYfromLat} from '../mercator_coordinate.js';
+import {CanonicalTileID, OverscaledTileID} from '../../source/tile_id.js';
 import Context from '../../gl/context.js';
 import Tile from '../../source/tile.js';
 import IndexBuffer from '../../gl/index_buffer.js';
@@ -17,179 +16,11 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import {TriangleIndexArray, GlobeVertexArray, LineIndexArray} from '../../data/array_types.js';
 import type Transform from '../transform.js';
 import {members as globeLayoutAttributes, atmosphereLayout} from '../../terrain/globe_attributes.js';
+import GlobeTileTransform from './globe_tile_transform.js';
 
-class GlobeTileTransform {
-    _tr: Transform;
-    _worldSize: number;
-    _globeMatrix: Float64Array;
-
-    constructor(tr: Transform, worldSize: number) {
-        this._tr = tr;
-        this._worldSize = worldSize;
-
-        this._globeMatrix = calculateGlobeMatrix(tr, worldSize);
-    }
-
-    createLabelPlaneMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean): mat4 {
-        let m = mat4.create();
-        if (pitchWithMap) {
-            m = this._calculateGlobeLabelMatrix(tileID, this._tr.worldSize / this._tr._projectionScaler, this._tr.center.lat, this._tr.center.lng);
-
-            if (!rotateWithMap) {
-                mat4.rotateZ(m, m, this._tr.angle);
-            }
-        } else {
-            mat4.multiply(m, this._tr.labelPlaneMatrix, posMatrix);
-        }
-        return m;
-    }
-
-    createGlCoordMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean): mat4 {
-        if (pitchWithMap) {
-            const m = this.createLabelPlaneMatrix(posMatrix, tileID, pitchWithMap, rotateWithMap);
-            mat4.invert(m, m);
-            mat4.multiply(m, posMatrix, m);
-            return m;
-        } else {
-            return this._tr.glCoordMatrix;
-        }
-    }
-
-    createTileMatrix(id: UnwrappedTileID): mat4 {
-        const decode = denormalizeECEF(tileBoundsOnGlobe(id.canonical));
-        return mat4.multiply([], this._globeMatrix, decode);
-    }
-
-    createInversionMatrix(id: UnwrappedTileID): mat4 {
-        const center = this._tr.center;
-        const localRadius = EXTENT / (2.0 * Math.PI);
-        const wsRadiusGlobe = this._worldSize / (2.0 * Math.PI);
-        const sGlobe = wsRadiusGlobe / localRadius;
-
-        const matrix = mat4.identity(new Float64Array(16));
-        mat4.scale(matrix, matrix, [sGlobe, sGlobe, 1.0]);
-        mat4.rotateX(matrix, matrix, degToRad(-center.lat));
-        mat4.rotateY(matrix, matrix, degToRad(-center.lng));
-
-        const decode = denormalizeECEF(tileBoundsOnGlobe(id.canonical));
-        mat4.multiply(matrix, matrix, decode);
-        mat4.invert(matrix, matrix);
-
-        const z = mercatorZfromAltitude(1, center.lat) * this._worldSize;
-        const projectionScaler = z / this._tr.pixelsPerMeter;
-
-        const ws = this._worldSize / projectionScaler;
-        const wsRadiusScaled = ws / (2.0 * Math.PI);
-        const sMercator = wsRadiusScaled / localRadius;
-
-        const scaling = mat4.identity(new Float64Array(16));
-        mat4.scale(scaling, scaling, [sMercator, sMercator, 1.0]);
-
-        return mat4.multiply(matrix, matrix, scaling);
-    }
-
-    upVector(id: CanonicalTileID, x: number, y: number): vec3 {
-        const corners = tileLatLngCorners(id);
-        const tl = corners[0];
-        const br = corners[1];
-
-        const tlUp = latLngToECEF(tl[0], tl[1]);
-        const trUp = latLngToECEF(tl[0], br[1]);
-        const brUp = latLngToECEF(br[0], br[1]);
-        const blUp = latLngToECEF(br[0], tl[1]);
-
-        vec3.normalize(tlUp, tlUp);
-        vec3.normalize(trUp, trUp);
-        vec3.normalize(brUp, brUp);
-        vec3.normalize(blUp, blUp);
-
-        const u = x / EXTENT;
-        const v = y / EXTENT;
-
-        const tltr = vec3.lerp([], tlUp, trUp, u);
-        const blbr = vec3.lerp([], blUp, brUp, u);
-
-        return vec3.lerp([], tltr, blbr, v);
-    }
-
-    upVectorScale(id: CanonicalTileID): number {
-        const pixelsPerMeterECEF = mercatorZfromAltitude(1, 0.0) * 2.0 * globeRefRadius * Math.PI;
-        const maxTileScale = tileNormalizationScale(id);
-        return pixelsPerMeterECEF * maxTileScale;
-    }
-
-    _calculateGlobeLabelMatrix(tileID: CanonicalTileID, worldSize: number, lat: number, lng: number) {
-
-        // Camera is moved closer towards the ground near poles as part of compesanting the reprojection.
-        // This has to be compensated for the map aligned label space.
-        // Whithout this logic map aligned symbols would appear larger than intended
-        const ws = worldSize;
-
-        const localRadius = EXTENT / (2.0 * Math.PI);
-        const wsRadius = ws / (2.0 * Math.PI);
-        const s = wsRadius / localRadius;
-
-        // transform the globe from reference coordinate space to world space
-        const posMatrix = mat4.identity(new Float64Array(16));
-
-        mat4.translate(posMatrix, posMatrix, [0, 0, -wsRadius]);
-        mat4.scale(posMatrix, posMatrix, [s, s, s]);
-        mat4.rotateX(posMatrix, posMatrix, degToRad(-lat));
-        mat4.rotateY(posMatrix, posMatrix, degToRad(-lng));
-
-        return mat4.multiply([], posMatrix, denormalizeECEF(tileBoundsOnGlobe(tileID)));
-    }
-
-    pointCoordinate(x: number, y: number): MercatorCoordinate {
-        const p0 = [x, y, 0, 1];
-        const p1 = [x, y, 1, 1];
-
-        vec4.transformMat4(p0, p0, this._tr.pixelMatrixInverse);
-        vec4.transformMat4(p1, p1, this._tr.pixelMatrixInverse);
-
-        vec4.scale(p0, p0, 1 / p0[3]);
-        vec4.scale(p1, p1, 1 / p1[3]);
-
-        const p0p1 = vec3.sub([], p1, p0);
-        const dir = vec3.normalize([], p0p1);
-
-        // Compute globe origo in world space
-        const matrix = calculateGlobeMatrix(this._tr, this._worldSize);
-        const center = vec3.transformMat4([], [0, 0, 0], matrix);
-        const radius = this._worldSize / (2.0 * Math.PI);
-
-        const oc = vec3.sub([], p0, center);
-        const a = vec3.dot(dir, dir);
-        const b = 2.0 * vec3.dot(oc, dir);
-        const c = vec3.dot(oc, oc) - radius * radius;
-        const d = b * b - 4 * a * c;
-        let pOnGlobe;
-
-        if (d < 0) {
-            // Not intersecting with the globe. Find shortest distance between the ray and the globe
-            const t = clamp(vec3.dot(vec3.negate([], oc), p0p1) / vec3.dot(p0p1, p0p1), 0, 1);
-            const pointOnRay = vec3.lerp([], p0, p1, t);
-            const pointToGlobe = vec3.sub([], center, pointOnRay);
-
-            pOnGlobe = vec3.sub([], vec3.add([], pointOnRay, vec3.scale([], pointToGlobe, (1.0 - radius / vec3.length(pointToGlobe)))), center);
-        } else {
-            const t = (-b - Math.sqrt(d)) / (2.0 * a);
-            pOnGlobe = vec3.sub([], vec3.scaleAndAdd([], p0, dir, t), center);
-        }
-
-        // Transform coordinate axes to find lat & lng of the position
-        const xa = vec3.normalize([], vec4.transformMat4([], [1, 0, 0, 0], matrix));
-        const ya = vec3.normalize([], vec4.transformMat4([], [0, -1, 0, 0], matrix));
-        const za = vec3.normalize([], vec4.transformMat4([], [0, 0, 1, 0], matrix));
-
-        const lat = Math.asin(vec3.dot(ya, pOnGlobe) / radius) * 180 / Math.PI;
-        const xp = vec3.dot(xa, pOnGlobe);
-        const zp = vec3.dot(za, pOnGlobe);
-        const lng = Math.atan2(xp, zp) * 180 / Math.PI;
-
-        return new MercatorCoordinate(mercatorXfromLng(lng), mercatorYfromLat(lat));
-    }
-}
+export const NORMALIZATION_BIT_RANGE = 15;
+export const GLOBE_RADIUS = EXTENT / Math.PI / 2.0;
+const GLOBE_VERTEX_GRID_SIZE = 64;
 
 export default {
     name: 'globe',
@@ -211,7 +42,7 @@ export default {
 
         // eslint-disable-next-line no-warning-comments
         // TODO: cached matrices!
-        const bounds = tileBoundsOnGlobe(id);
+        const bounds = globeTileBounds(id);
         const normalizationMatrix = normalizeECEF(bounds);
         vec3.transformMat4(pos, pos, normalizationMatrix);
 
@@ -294,13 +125,11 @@ export default {
     }
 };
 
-export const globeRefRadius = EXTENT / Math.PI / 2.0;
-
-export function tileBoundsOnGlobe(id: CanonicalTileID): Aabb {
+export function globeTileBounds(id: CanonicalTileID): Aabb {
     const z = id.z;
 
-    const mn = -globeRefRadius;
-    const mx = globeRefRadius;
+    const mn = -GLOBE_RADIUS;
+    const mx = GLOBE_RADIUS;
 
     if (z === 0) {
         return new Aabb([mn, mn, mn], [mx, mx, mx]);
@@ -318,13 +147,13 @@ export function tileBoundsOnGlobe(id: CanonicalTileID): Aabb {
 
     // After zoom 1 surface function is monotonic for all tile patches
     // => it is enough to project corner points
-    const [min, max] = tileLatLngCorners(id);
+    const [min, max] = globeTileLatLngCorners(id);
 
     const corners = [
-        latLngToECEF(min[0], min[1], globeRefRadius),
-        latLngToECEF(min[0], max[1], globeRefRadius),
-        latLngToECEF(max[0], min[1], globeRefRadius),
-        latLngToECEF(max[0], max[1], globeRefRadius)
+        latLngToECEF(min[0], min[1], GLOBE_RADIUS),
+        latLngToECEF(min[0], max[1], GLOBE_RADIUS),
+        latLngToECEF(max[0], min[1], GLOBE_RADIUS),
+        latLngToECEF(max[0], max[1], GLOBE_RADIUS)
     ];
 
     const bMin = [mx, mx, mx];
@@ -343,14 +172,7 @@ export function tileBoundsOnGlobe(id: CanonicalTileID): Aabb {
     return new Aabb(bMin, bMax);
 }
 
-function tileNormalizationScale(id: CanonicalTileID) {
-    const bounds = tileBoundsOnGlobe(id);
-    const maxExtInv = 1.0 / Math.max(...vec3.sub([], bounds.max, bounds.min));
-    const st = (1 << (normBitRange - 1)) - 1;
-    return st * maxExtInv;
-}
-
-function tileLatLngCorners(id: CanonicalTileID) {
+export function globeTileLatLngCorners(id: CanonicalTileID) {
     const tileScale = Math.pow(2, id.z);
     const left = id.x / tileScale;
     const right = (id.x + 1) / tileScale;
@@ -368,7 +190,7 @@ export function latLngToECEF(lat: number, lng: number, radius: ?number): Array<n
     lng = degToRad(lng);
 
     if (!radius) {
-        radius = globeRefRadius;
+        radius = GLOBE_RADIUS;
     }
 
     // Convert lat & lng to spherical representation. Use zoom=0 as a reference
@@ -379,13 +201,11 @@ export function latLngToECEF(lat: number, lng: number, radius: ?number): Array<n
     return [sx, sy, sz];
 }
 
-const normBitRange = 15;
-
 function normalizeECEF(bounds: Aabb): Float64Array {
     const m = mat4.identity(new Float64Array(16));
 
     const maxExtInv = 1.0 / Math.max(...vec3.sub([], bounds.max, bounds.min));
-    const st = (1 << (normBitRange - 1)) - 1;
+    const st = (1 << (NORMALIZATION_BIT_RANGE - 1)) - 1;
 
     mat4.scale(m, m, [st, st, st]);
     mat4.scale(m, m, [maxExtInv, maxExtInv, maxExtInv]);
@@ -394,13 +214,13 @@ function normalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-function denormalizeECEF(bounds: Aabb): Float64Array {
+export function denormalizeECEF(bounds: Aabb): Float64Array {
     const m = mat4.identity(new Float64Array(16));
 
     const maxExt = Math.max(...vec3.sub([], bounds.max, bounds.min));
 
     // Denormalize points to the correct range
-    const st = 1.0 / ((1 << (normBitRange - 1)) - 1);
+    const st = 1.0 / ((1 << (NORMALIZATION_BIT_RANGE - 1)) - 1);
     mat4.translate(m, m, bounds.min);
     mat4.scale(m, m, [maxExt, maxExt, maxExt]);
     mat4.scale(m, m, [st, st, st]);
@@ -476,7 +296,7 @@ export function globeBuffersForTileMesh(painter: Painter, tile: Tile, coord: Ove
 
 export function globeMatrixForTile(id: CanonicalTileID, globeMatrix: mat4) {
     const gridTileId = new CanonicalTileID(id.z, Math.pow(2, id.z) / 2, id.y);
-    const bounds = tileBoundsOnGlobe(gridTileId);
+    const bounds = globeTileBounds(gridTileId);
     const decode = denormalizeECEF(bounds);
     const posMatrix = mat4.clone(globeMatrix);
     mat4.mul(posMatrix, posMatrix, decode);
@@ -516,8 +336,6 @@ export function globePoleMatrixForTile(id: CanonicalTileID, south: boolean, tr: 
 
     return poleMatrix;
 }
-
-const GLOBE_VERTEX_GRID_SIZE = 64;
 
 export class GlobeSharedBuffers {
     poleIndexBuffer: IndexBuffer;
@@ -612,10 +430,10 @@ export class GlobeSharedBuffers {
         const lerp = (a, b, t) => a * (1 - t) + b * t;
         const tiles = Math.pow(2, sz);
         const gridTileId = new CanonicalTileID(sz, sx, sy);
-        const [latLngTL, latLngBR] = tileLatLngCorners(gridTileId);
+        const [latLngTL, latLngBR] = globeTileLatLngCorners(gridTileId);
         const boundsArray = new GlobeVertexArray();
 
-        const bounds = tileBoundsOnGlobe(new CanonicalTileID(sz, tiles / 2, sy));
+        const bounds = globeTileBounds(new CanonicalTileID(sz, tiles / 2, sy));
         const norm = normalizeECEF(bounds);
 
         const vertexExt = GLOBE_VERTEX_GRID_SIZE + 1;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -1,6 +1,6 @@
 // @flow
 import {mat4, vec3} from 'gl-matrix';
-import {Aabb, Ray} from '../../util/primitives.js';
+import {Aabb} from '../../util/primitives.js';
 import EXTENT from '../../data/extent.js';
 import LngLat from '../lng_lat.js';
 import {degToRad, smoothstep, clamp} from '../../util/util.js';

--- a/src/geo/projection/globe_tile_transform.js
+++ b/src/geo/projection/globe_tile_transform.js
@@ -1,0 +1,196 @@
+// @flow
+import type Transform from '../transform.js';
+import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
+import {mat4, vec4, vec3} from 'gl-matrix';
+import MercatorCoordinate, {mercatorZfromAltitude, mercatorXfromLng, mercatorYfromLat} from '../mercator_coordinate.js';
+import EXTENT from '../../data/extent.js';
+import {degToRad, clamp} from '../../util/util.js';
+import {
+    latLngToECEF,
+    globeTileLatLngCorners,
+    globeTileBounds,
+    calculateGlobeMatrix,
+    denormalizeECEF,
+    NORMALIZATION_BIT_RANGE,
+    GLOBE_RADIUS
+} from './globe.js';
+
+function tileNormalizationScale(id: CanonicalTileID) {
+    const bounds = globeTileBounds(id);
+    const maxExtInv = 1.0 / Math.max(...vec3.sub([], bounds.max, bounds.min));
+    const st = (1 << (NORMALIZATION_BIT_RANGE - 1)) - 1;
+    return st * maxExtInv;
+}
+
+export default class GlobeTileTransform {
+    _tr: Transform;
+    _worldSize: number;
+    _globeMatrix: Float64Array;
+
+    constructor(tr: Transform, worldSize: number) {
+        this._tr = tr;
+        this._worldSize = worldSize;
+
+        this._globeMatrix = calculateGlobeMatrix(tr, worldSize);
+    }
+
+    createLabelPlaneMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean): mat4 {
+        let m = mat4.create();
+        if (pitchWithMap) {
+            m = this._calculateGlobeLabelMatrix(tileID, this._tr.worldSize / this._tr._projectionScaler, this._tr.center.lat, this._tr.center.lng);
+
+            if (!rotateWithMap) {
+                mat4.rotateZ(m, m, this._tr.angle);
+            }
+        } else {
+            mat4.multiply(m, this._tr.labelPlaneMatrix, posMatrix);
+        }
+        return m;
+    }
+
+    createGlCoordMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean): mat4 {
+        if (pitchWithMap) {
+            const m = this.createLabelPlaneMatrix(posMatrix, tileID, pitchWithMap, rotateWithMap);
+            mat4.invert(m, m);
+            mat4.multiply(m, posMatrix, m);
+            return m;
+        } else {
+            return this._tr.glCoordMatrix;
+        }
+    }
+
+    createTileMatrix(id: UnwrappedTileID): mat4 {
+        const decode = denormalizeECEF(globeTileBounds(id.canonical));
+        return mat4.multiply([], this._globeMatrix, decode);
+    }
+
+    createInversionMatrix(id: UnwrappedTileID): mat4 {
+        const center = this._tr.center;
+        const localRadius = EXTENT / (2.0 * Math.PI);
+        const wsRadiusGlobe = this._worldSize / (2.0 * Math.PI);
+        const sGlobe = wsRadiusGlobe / localRadius;
+
+        const matrix = mat4.identity(new Float64Array(16));
+        mat4.scale(matrix, matrix, [sGlobe, sGlobe, 1.0]);
+        mat4.rotateX(matrix, matrix, degToRad(-center.lat));
+        mat4.rotateY(matrix, matrix, degToRad(-center.lng));
+
+        const decode = denormalizeECEF(globeTileBounds(id.canonical));
+        mat4.multiply(matrix, matrix, decode);
+        mat4.invert(matrix, matrix);
+
+        const z = mercatorZfromAltitude(1, center.lat) * this._worldSize;
+        const projectionScaler = z / this._tr.pixelsPerMeter;
+
+        const ws = this._worldSize / projectionScaler;
+        const wsRadiusScaled = ws / (2.0 * Math.PI);
+        const sMercator = wsRadiusScaled / localRadius;
+
+        const scaling = mat4.identity(new Float64Array(16));
+        mat4.scale(scaling, scaling, [sMercator, sMercator, 1.0]);
+
+        return mat4.multiply(matrix, matrix, scaling);
+    }
+
+    upVector(id: CanonicalTileID, x: number, y: number): vec3 {
+        const corners = globeTileLatLngCorners(id);
+        const tl = corners[0];
+        const br = corners[1];
+
+        const tlUp = latLngToECEF(tl[0], tl[1]);
+        const trUp = latLngToECEF(tl[0], br[1]);
+        const brUp = latLngToECEF(br[0], br[1]);
+        const blUp = latLngToECEF(br[0], tl[1]);
+
+        vec3.normalize(tlUp, tlUp);
+        vec3.normalize(trUp, trUp);
+        vec3.normalize(brUp, brUp);
+        vec3.normalize(blUp, blUp);
+
+        const u = x / EXTENT;
+        const v = y / EXTENT;
+
+        const tltr = vec3.lerp([], tlUp, trUp, u);
+        const blbr = vec3.lerp([], blUp, brUp, u);
+
+        return vec3.lerp([], tltr, blbr, v);
+    }
+
+    upVectorScale(id: CanonicalTileID): number {
+        const pixelsPerMeterECEF = mercatorZfromAltitude(1, 0.0) * 2.0 * GLOBE_RADIUS * Math.PI;
+        const maxTileScale = tileNormalizationScale(id);
+        return pixelsPerMeterECEF * maxTileScale;
+    }
+
+    _calculateGlobeLabelMatrix(tileID: CanonicalTileID, worldSize: number, lat: number, lng: number) {
+
+        // Camera is moved closer towards the ground near poles as part of compesanting the reprojection.
+        // This has to be compensated for the map aligned label space.
+        // Whithout this logic map aligned symbols would appear larger than intended
+        const ws = worldSize;
+
+        const localRadius = EXTENT / (2.0 * Math.PI);
+        const wsRadius = ws / (2.0 * Math.PI);
+        const s = wsRadius / localRadius;
+
+        // transform the globe from reference coordinate space to world space
+        const posMatrix = mat4.identity(new Float64Array(16));
+
+        mat4.translate(posMatrix, posMatrix, [0, 0, -wsRadius]);
+        mat4.scale(posMatrix, posMatrix, [s, s, s]);
+        mat4.rotateX(posMatrix, posMatrix, degToRad(-lat));
+        mat4.rotateY(posMatrix, posMatrix, degToRad(-lng));
+
+        return mat4.multiply([], posMatrix, denormalizeECEF(globeTileBounds(tileID)));
+    }
+
+    pointCoordinate(x: number, y: number): MercatorCoordinate {
+        const p0 = [x, y, 0, 1];
+        const p1 = [x, y, 1, 1];
+
+        vec4.transformMat4(p0, p0, this._tr.pixelMatrixInverse);
+        vec4.transformMat4(p1, p1, this._tr.pixelMatrixInverse);
+
+        vec4.scale(p0, p0, 1 / p0[3]);
+        vec4.scale(p1, p1, 1 / p1[3]);
+
+        const p0p1 = vec3.sub([], p1, p0);
+        const dir = vec3.normalize([], p0p1);
+
+        // Compute globe origo in world space
+        const matrix = calculateGlobeMatrix(this._tr, this._worldSize);
+        const center = vec3.transformMat4([], [0, 0, 0], matrix);
+        const radius = this._worldSize / (2.0 * Math.PI);
+
+        const oc = vec3.sub([], p0, center);
+        const a = vec3.dot(dir, dir);
+        const b = 2.0 * vec3.dot(oc, dir);
+        const c = vec3.dot(oc, oc) - radius * radius;
+        const d = b * b - 4 * a * c;
+        let pOnGlobe;
+
+        if (d < 0) {
+            // Not intersecting with the globe. Find shortest distance between the ray and the globe
+            const t = clamp(vec3.dot(vec3.negate([], oc), p0p1) / vec3.dot(p0p1, p0p1), 0, 1);
+            const pointOnRay = vec3.lerp([], p0, p1, t);
+            const pointToGlobe = vec3.sub([], center, pointOnRay);
+
+            pOnGlobe = vec3.sub([], vec3.add([], pointOnRay, vec3.scale([], pointToGlobe, (1.0 - radius / vec3.length(pointToGlobe)))), center);
+        } else {
+            const t = (-b - Math.sqrt(d)) / (2.0 * a);
+            pOnGlobe = vec3.sub([], vec3.scaleAndAdd([], p0, dir, t), center);
+        }
+
+        // Transform coordinate axes to find lat & lng of the position
+        const xa = vec3.normalize([], vec4.transformMat4([], [1, 0, 0, 0], matrix));
+        const ya = vec3.normalize([], vec4.transformMat4([], [0, -1, 0, 0], matrix));
+        const za = vec3.normalize([], vec4.transformMat4([], [0, 0, 1, 0], matrix));
+
+        const lat = Math.asin(vec3.dot(ya, pOnGlobe) / radius) * 180 / Math.PI;
+        const xp = vec3.dot(xa, pOnGlobe);
+        const zp = vec3.dot(za, pOnGlobe);
+        const lng = Math.atan2(xp, zp) * 180 / Math.PI;
+
+        return new MercatorCoordinate(mercatorXfromLng(lng), mercatorYfromLat(lat));
+    }
+}

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -29,6 +29,8 @@ export type Projection = {
     supportsTerrain?: boolean;
     supportsFog?: boolean;
     supportsWorldCopies: boolean,
+    // Whether the projection reprojects data in tile space
+    isReprojectedInTileSpace?: boolean;
     zAxisUnit: "meters" | "pixels",
     project: (lng: number, lat: number) => {x: number, y: number, z: number},
     unproject: (x: number, y: number) => LngLat,

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -64,7 +64,7 @@ function getConicProjection(projection: Projection, config: ProjectionSpecificat
 
             if (config.name === 'lambertConformalConic') {
                 const {project, unproject} = projections['mercator'];
-                cylindricalFunctions = {wrap: true, project, unproject};
+                cylindricalFunctions = {supportsWorldCopies: true, project, unproject};
             }
 
             return extend({}, projection, config, cylindricalFunctions);

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -25,12 +25,12 @@ export type Projection = {
     conic?: boolean,
     wrap?: boolean,
     name: string,
-    requiresDraping: boolean,
+    requiresDraping?: boolean,
     supportsTerrain?: boolean;
     supportsFog?: boolean;
     supportsCustomLayers?: boolean,
     supportsFreeCamera?: boolean,
-    supportsWorldCopies: boolean,
+    supportsWorldCopies?: boolean,
     // Whether the projection reprojects data in tile space
     isReprojectedInTileSpace?: boolean;
     zAxisUnit: "meters" | "pixels",

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -7,11 +7,9 @@ import mercator from './mercator.js';
 import naturalEarth from './natural_earth.js';
 import winkelTripel from './winkel_tripel.js';
 import cylindricalEqualArea from './cylindrical_equal_area.js';
-import LngLat from '../lng_lat.js';
 import {extend} from '../../util/util.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import globe from './globe.js';
-import mercator from './mercator.js';
 import {mat4, vec3} from 'gl-matrix';
 import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
 import {Aabb} from '../../util/primitives.js';
@@ -27,11 +25,21 @@ export type Projection = {
     range?: [number, number],
     conic?: boolean,
     wrap?: boolean,
-    project: (lng: number, lat: number) => {x: number, y: number},
-    unproject: (x: number, y: number) => LngLat
+    name: string,
+    requiresDraping: boolean,
+    supportsWorldCopies: boolean,
+    zAxisUnit: "meters" | "pixels",
+    project: (lng: number, lat: number) => {x: number, y: number, z: number},
+    unproject: (x: number, y: number) => LngLat,
+    locationPoint: (tr: Transform, lngLat: LngLat) => Point,
+    projectTilePoint: (x: number, y: number, id: CanonicalTileID) => {x: number, y: number, z: number},
+    pixelsPerMeter: (lat: number, worldSize: number) => number,
+    farthestPixelDistance: (tr: Transform) => number,
+    createTileTransform: (tr: Transform, worldSize: number) => TileTransform,
 };
 
 const projections = {
+    globe,
     albers,
     equalEarth,
     equirectangular,
@@ -84,33 +92,3 @@ export type TileTransform = {
 
     pointCoordinate: (x: number, y: number, z?: number) => MercatorCoordinate
 };
-
-export type Projection = {
-    name: string,
-    requiresDraping: boolean,
-    supportsWorldCopies: boolean,
-    zAxisUnit: "meters" | "pixels",
-
-    project: (lng: number, lat: number) => {x: number, y: number, z: number},
-
-    locationPoint: (tr: Transform, lngLat: LngLat) => Point,
-
-    projectTilePoint: (x: number, y: number, id: CanonicalTileID) => {x: number, y: number, z: number},
-
-    pixelsPerMeter: (lat: number, worldSize: number) => number,
-
-    farthestPixelDistance: (tr: Transform) => number,
-
-    createTileTransform: (tr: Transform, worldSize: number) => TileTransform,
-};
-
-const projections = {
-    globe,
-    mercator
-};
-
-export default function getProjection(name: ?string): Projection {
-    if (!name || !(name in projections))
-        return projections.mercator;
-    return projections[name];
-}

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -26,6 +26,8 @@ export type Projection = {
     wrap?: boolean,
     name: string,
     requiresDraping: boolean,
+    supportsTerrain?: boolean;
+    supportsFog?: boolean;
     supportsWorldCopies: boolean,
     zAxisUnit: "meters" | "pixels",
     project: (lng: number, lat: number) => {x: number, y: number, z: number},

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -28,6 +28,8 @@ export type Projection = {
     requiresDraping: boolean,
     supportsTerrain?: boolean;
     supportsFog?: boolean;
+    supportsCustomLayers?: boolean,
+    supportsFreeCamera?: boolean,
     supportsWorldCopies: boolean,
     // Whether the projection reprojects data in tile space
     isReprojectedInTileSpace?: boolean;

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -12,7 +12,6 @@ import type {ProjectionSpecification} from '../../style-spec/types.js';
 import globe from './globe.js';
 import {mat4, vec3} from 'gl-matrix';
 import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
-import {Aabb} from '../../util/primitives.js';
 import Transform from '../transform.js';
 import LngLat from '../lng_lat.js';
 import Point from '@mapbox/point-geometry';
@@ -83,8 +82,6 @@ export type TileTransform = {
     createTileMatrix: (id: UnwrappedTileID) => mat4,
 
     createInversionMatrix: (id: UnwrappedTileID) => mat4,
-
-    tileAabb: (id: UnwrappedTileID, z: number, min: number, max: number) => Aabb,
 
     upVector: (id: CanonicalTileID, x: number, y: number) => vec3,
 

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -75,17 +75,9 @@ export function getProjection(config: ProjectionSpecification) {
 }
 
 export type TileTransform = {
-    createLabelPlaneMatrix: (posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits: number) => mat4,
-
-    createGlCoordMatrix: (posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits: number) => mat4,
-
     createTileMatrix: (id: UnwrappedTileID) => mat4,
-
     createInversionMatrix: (id: UnwrappedTileID) => mat4,
-
     upVector: (id: CanonicalTileID, x: number, y: number) => vec3,
-
     upVectorScale: (id: CanonicalTileID) => number,
-
     pointCoordinate: (x: number, y: number, z?: number) => MercatorCoordinate
 };

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -1,8 +1,12 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import {mercatorZfromAltitude, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 import {vec2} from 'gl-matrix';
+import type Transform from '../../geo/transform.js';
+import Point from '@mapbox/point-geometry';
+import FlatTileTransform from './flat_tile_transform.js';
+import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 const halfPi = Math.PI / 2;
 
@@ -14,6 +18,7 @@ export default {
     name: 'lambertConformalConic',
     range: [3.5, 7],
 
+    zAxisUnit: "meters",
     center: [0, 30],
     parallels: [30, 30],
 
@@ -78,5 +83,26 @@ export default {
         const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 
         return new LngLat(lng, lat);
+    },
+
+    projectTilePoint(x: number, y: number): {x: number, y: number, z: number} {
+        return {x, y, z: 0};
+    },
+
+    locationPoint(tr: Transform, lngLat: LngLat): Point {
+        return tr._coordinatePoint(tr.locationCoordinate(lngLat), false);
+    },
+
+    pixelsPerMeter(lat: number, worldSize: number) {
+        return mercatorZfromAltitude(1, lat) * worldSize;
+    },
+
+    farthestPixelDistance(tr: Transform): number {
+        const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
+        return farthestPixelDistanceOnPlane(tr, pixelsPerMeter);
+    },
+
+    createTileTransform(tr: Transform, worldSize: number): Object {
+        return new FlatTileTransform(tr, worldSize);
     }
 };

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -23,6 +23,7 @@ export default {
     parallels: [30, 30],
 
     conic: true,
+    isReprojectedInTileSpace: true,
 
     initializeConstants() {
         if (this.constants && vec2.exactEquals(this.parallels, this.constants.parallels)) {

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -61,7 +61,8 @@ export default {
 
         return {
             x: (x / Math.PI + 0.5) * 0.5,
-            y: 1 - (y / Math.PI + 0.5) * 0.5
+            y: 1 - (y / Math.PI + 0.5) * 0.5,
+            z: 0
         };
     },
 

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,6 +1,5 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import assert from 'assert';
 import {mat4, vec3} from 'gl-matrix';
 import {clamp} from '../../util/util.js';
 import MercatorCoordinate, {
@@ -12,7 +11,6 @@ import MercatorCoordinate, {
 } from '../mercator_coordinate.js';
 import EXTENT from '../../data/extent.js';
 import type Transform from '../../geo/transform.js';
-import {Aabb} from '../../util/primitives.js';
 import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
 import Point from '@mapbox/point-geometry';
 
@@ -70,22 +68,6 @@ class MercatorTileTransform {
         mat4.scale(posMatrix, posMatrix, [scale / EXTENT, scale / EXTENT, 1]);
 
         return posMatrix;
-    }
-
-    tileAabb(id: UnwrappedTileID, z: number, min: number, max: number) {
-        assert(z >= id.canonical.z);
-        const numTiles = 1 << z;
-        const zScale = 1 << (z - id.canonical.z);
-        const wrap = id.wrap;
-
-        const xMin = wrap * numTiles + id.canonical.x * zScale;
-        const xMax = wrap * numTiles + (id.canonical.x + 1) * zScale;
-        const yMin = id.canonical.y * zScale;
-        const yMax = (id.canonical.y + 1) * zScale;
-
-        return new Aabb(
-            [xMin, yMin, min],
-            [xMax, yMax, max]);
     }
 
     pointCoordinate(x: number, y: number, z?: number): MercatorCoordinate {

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -3,7 +3,13 @@ import LngLat from '../lng_lat.js';
 import assert from 'assert';
 import {mat4, vec3} from 'gl-matrix';
 import {clamp} from '../../util/util.js';
-import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate.js';
+import MercatorCoordinate, {
+    mercatorXfromLng,
+    mercatorYfromLat,
+    mercatorZfromAltitude,
+    lngFromMercatorX,
+    latFromMercatorY
+} from '../mercator_coordinate.js';
 import EXTENT from '../../data/extent.js';
 import type Transform from '../../geo/transform.js';
 import {Aabb} from '../../util/primitives.js';

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -19,6 +19,8 @@ export default {
     supportsWorldCopies: true,
     supportsTerrain: true,
     supportsFog: true,
+    supportsCustomLayers: true,
+    supportsFreeCamera: true,
     zAxisUnit: "meters",
     wrap: true,
     center: [0, 0],

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,32 +1,14 @@
 // @flow
-import {mercatorXfromLng, mercatorYfromLat, lngFromMercatorX, latFromMercatorY} from '../mercator_coordinate.js';
 import LngLat from '../lng_lat.js';
 import assert from 'assert';
 import {mat4, vec3} from 'gl-matrix';
 import {clamp} from '../../util/util.js';
-import LngLat from '../lng_lat.js';
 import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate.js';
 import EXTENT from '../../data/extent.js';
 import type Transform from '../../geo/transform.js';
 import {Aabb} from '../../util/primitives.js';
 import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
 import Point from '@mapbox/point-geometry';
-
-export default {
-    name: 'mercator',
-    wrap: true,
-    center: [0, 0],
-    project(lng: number, lat: number) {
-        const x = mercatorXfromLng(lng);
-        const y = mercatorYfromLat(lat);
-        return {x, y};
-    },
-    unproject(x: number, y: number) {
-        const lng = lngFromMercatorX(x);
-        const lat = latFromMercatorY(y);
-        return new LngLat(lng, lat);
-    }
-};
 
 class MercatorTileTransform {
     _tr: Transform;
@@ -120,11 +102,19 @@ export default {
     requiresDraping: false,
     supportsWorldCopies: true,
     zAxisUnit: "meters",
+    wrap: true,
+    center: [0, 0],
 
     project(lng: number, lat: number) {
         const x = mercatorXfromLng(lng);
         const y = mercatorYfromLat(lat);
         return {x, y, z: 0};
+    },
+
+    unproject(x: number, y: number) {
+        const lng = lngFromMercatorX(x);
+        const lat = latFromMercatorY(y);
+        return new LngLat(lng, lat);
     },
 
     projectTilePoint(x: number, y: number): {x: number, y: number, z: number} {

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -21,7 +21,6 @@ export default {
     supportsCustomLayers: true,
     supportsFreeCamera: true,
     zAxisUnit: "meters",
-    wrap: true,
     center: [0, 0],
 
     project(lng: number, lat: number) {

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -17,6 +17,8 @@ export default {
     name: 'mercator',
     requiresDraping: false,
     supportsWorldCopies: true,
+    supportsTerrain: true,
+    supportsFog: true,
     zAxisUnit: "meters",
     wrap: true,
     center: [0, 0],

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,89 +1,16 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import {mat4, vec3} from 'gl-matrix';
 import {clamp} from '../../util/util.js';
-import MercatorCoordinate, {
+import {
     mercatorXfromLng,
     mercatorYfromLat,
     mercatorZfromAltitude,
     lngFromMercatorX,
     latFromMercatorY
 } from '../mercator_coordinate.js';
-import EXTENT from '../../data/extent.js';
 import type Transform from '../../geo/transform.js';
-import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
 import Point from '@mapbox/point-geometry';
-
-class MercatorTileTransform {
-    _tr: Transform;
-    _worldSize: number;
-    _identity: Float64Array;
-
-    constructor(tr: Transform, worldSize: number) {
-        this._tr = tr;
-        this._worldSize = worldSize;
-        // eslint-disable-next-line no-warning-comments
-        // TODO: Cache this elsewhere?
-        this._identity = mat4.identity(new Float64Array(16));
-    }
-
-    createLabelPlaneMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
-        const m = mat4.create();
-        if (pitchWithMap) {
-            mat4.scale(m, m, [1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1]);
-            if (!rotateWithMap) {
-                mat4.rotateZ(m, m, this._tr.angle);
-            }
-        } else {
-            mat4.multiply(m, this._tr.labelPlaneMatrix, posMatrix);
-        }
-        return m;
-    }
-
-    createGlCoordMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
-        if (pitchWithMap) {
-            const m = mat4.clone(posMatrix);
-            mat4.scale(m, m, [pixelsToTileUnits, pixelsToTileUnits, 1]);
-            if (!rotateWithMap) {
-                mat4.rotateZ(m, m, -this._tr.angle);
-            }
-            return m;
-        } else {
-            return this._tr.glCoordMatrix;
-        }
-    }
-
-    createInversionMatrix(): mat4 {
-        return this._identity;
-    }
-
-    createTileMatrix(id: UnwrappedTileID): mat4 {
-        const canonical = id.canonical;
-        const zoomScale = Math.pow(2, canonical.z);
-        const scale = this._worldSize / zoomScale;
-        const unwrappedX = canonical.x + zoomScale * id.wrap;
-
-        const posMatrix = mat4.identity(new Float64Array(16));
-        mat4.translate(posMatrix, posMatrix, [unwrappedX * scale, canonical.y * scale, 0]);
-        mat4.scale(posMatrix, posMatrix, [scale / EXTENT, scale / EXTENT, 1]);
-
-        return posMatrix;
-    }
-
-    pointCoordinate(x: number, y: number, z?: number): MercatorCoordinate {
-        const horizonOffset = this._tr.horizonLineFromTop(false);
-        const clamped = new Point(x, Math.max(horizonOffset, y));
-        return this._tr.rayIntersectionCoordinate(this._tr.pointRayIntersection(clamped, z));
-    }
-
-    upVector(): vec3 {
-        return [0, 0, 1];
-    }
-
-    upVectorScale(): number {
-        return 1;
-    }
-}
+import FlatTileTransform from './flat_tile_transform.js';
 
 export default {
     name: 'mercator',
@@ -144,6 +71,6 @@ export default {
     },
 
     createTileTransform(tr: Transform, worldSize: number): Object {
-        return new MercatorTileTransform(tr, worldSize);
-    },
+        return new FlatTileTransform(tr, worldSize);
+    }
 };

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,6 +1,5 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import {clamp} from '../../util/util.js';
 import {
     mercatorXfromLng,
     mercatorYfromLat,

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -11,6 +11,7 @@ import {
 import type Transform from '../../geo/transform.js';
 import Point from '@mapbox/point-geometry';
 import FlatTileTransform from './flat_tile_transform.js';
+import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 export default {
     name: 'mercator',
@@ -46,28 +47,7 @@ export default {
 
     farthestPixelDistance(tr: Transform): number {
         const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
-
-        // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
-        // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
-        // 1 Z unit is equivalent to 1 horizontal px at the center of the map
-        // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
-        const groundAngle = Math.PI / 2 + tr._pitch;
-        const fovAboveCenter = tr.fovAboveCenter;
-
-        // Adjust distance to MSL by the minimum possible elevation visible on screen,
-        // this way the far plane is pushed further in the case of negative elevation.
-        const minElevationInPixels = tr.elevation ?
-            tr.elevation.getMinElevationBelowMSL() * pixelsPerMeter :
-            0;
-        const cameraToSeaLevelDistance = ((tr._camera.position[2] * tr.worldSize) - minElevationInPixels) / Math.cos(tr._pitch);
-        const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
-
-        // Calculate z distance of the farthest fragment that should be rendered.
-        const furthestDistance = Math.cos(Math.PI / 2 - tr._pitch) * topHalfSurfaceDistance + cameraToSeaLevelDistance;
-        const horizonDistance = cameraToSeaLevelDistance * (1 / tr._horizonShift);
-
-        // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
-        return Math.min(furthestDistance * 1.01, horizonDistance);
+        return farthestPixelDistanceOnPlane(tr, pixelsPerMeter);
     },
 
     createTileTransform(tr: Transform, worldSize: number): Object {

--- a/src/geo/projection/natural_earth.js
+++ b/src/geo/projection/natural_earth.js
@@ -14,6 +14,7 @@ export default {
     center: [0, 0],
     range: [3.5, 7],
     isReprojectedInTileSpace: true,
+    zAxisUnit: "meters",
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed
@@ -27,7 +28,8 @@ export default {
 
         return {
             x: (x / Math.PI + 0.5) * 0.5,
-            y: 1 - (y / Math.PI + 1) * 0.5
+            y: 1 - (y / Math.PI + 1) * 0.5,
+            z: 0
         };
     },
 

--- a/src/geo/projection/natural_earth.js
+++ b/src/geo/projection/natural_earth.js
@@ -1,7 +1,11 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import {mercatorZfromAltitude, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type Transform from '../../geo/transform.js';
+import Point from '@mapbox/point-geometry';
+import FlatTileTransform from './flat_tile_transform.js';
+import {farthestPixelDistanceOnPlane} from './far_z.js';
 
 const maxPhi = degToRad(MAX_MERCATOR_LATITUDE);
 
@@ -51,5 +55,26 @@ export default {
         const lat = radToDeg(phi);
 
         return new LngLat(lng, lat);
+    },
+
+    projectTilePoint(x: number, y: number): {x: number, y: number, z: number} {
+        return {x, y, z: 0};
+    },
+
+    locationPoint(tr: Transform, lngLat: LngLat): Point {
+        return tr._coordinatePoint(tr.locationCoordinate(lngLat), false);
+    },
+
+    pixelsPerMeter(lat: number, worldSize: number) {
+        return mercatorZfromAltitude(1, lat) * worldSize;
+    },
+
+    farthestPixelDistance(tr: Transform): number {
+        const pixelsPerMeter = this.pixelsPerMeter(tr.center.lat, tr.worldSize);
+        return farthestPixelDistanceOnPlane(tr, pixelsPerMeter);
+    },
+
+    createTileTransform(tr: Transform, worldSize: number): Object {
+        return new FlatTileTransform(tr, worldSize);
     }
 };

--- a/src/geo/projection/natural_earth.js
+++ b/src/geo/projection/natural_earth.js
@@ -13,6 +13,7 @@ export default {
     name: 'naturalEarth',
     center: [0, 0],
     range: [3.5, 7],
+    isReprojectedInTileSpace: true,
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -5,7 +5,7 @@ import EXTENT from '../../data/extent.js';
 import {vec3} from 'gl-matrix';
 import type {Projection} from './index.js';
 import {Aabb} from '../../util/primitives.js';
-import {tileBoundsOnGlobe, calculateGlobeMatrix} from './globe.js';
+import {globeTileBounds, calculateGlobeMatrix} from './globe.js';
 import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
 import assert from 'assert';
 

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -19,16 +19,16 @@ export type TileTransform = {
 };
 
 export default function tileTransform(id: Object, projection: Projection) {
+    if (projection.name === 'mercator' || projection.name !== 'globe') {
+        return {scale: 1 << id.z, x: id.x, y: id.y, x2: id.x + 1, y2: id.y + 1, projection};
+    }
+
     const s = Math.pow(2, -id.z);
 
     const x1 = (id.x) * s;
     const x2 = (id.x + 1) * s;
     const y1 = (id.y) * s;
     const y2 = (id.y + 1) * s;
-
-    if (projection.name === 'mercator') {
-        return {scale: 1 << id.z, x: id.x, y: id.y, x2: id.x + 1, y2: id.y + 1, projection};
-    }
 
     const lng1 = lngFromMercatorX(x1);
     const lng2 = lngFromMercatorX(x2);

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -4,6 +4,10 @@ import MercatorCoordinate, {altitudeFromMercatorZ, lngFromMercatorX, latFromMerc
 import EXTENT from '../../data/extent.js';
 import {vec3} from 'gl-matrix';
 import type {Projection} from './index.js';
+import {Aabb} from '../../util/primitives.js';
+import {tileBoundsOnGlobe, calculateGlobeMatrix} from './globe.js';
+import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
+import assert from 'assert';
 
 export type TileTransform = {
     scale: number,
@@ -84,6 +88,43 @@ export default function tileTransform(id: Object, projection: Projection) {
         y2: maxY * scale,
         projection
     };
+}
+
+export function tileAABB(tr: Transform, numTiles, z, x, y, wrap, min, max, projection: Projection) {
+    if (projection.name === 'globe') {
+        const tileId = new UnwrappedTileID(wrap, new CanonicalTileID(z, x, y));
+        const aabb = tileBoundsOnGlobe(tileId.canonical);
+
+        // Transform corners of the aabb to the correct space
+        const corners = aabb.getCorners();
+
+        const mx = Number.MAX_VALUE;
+        const cornerMax = [-mx, -mx, -mx];
+        const cornerMin = [mx, mx, mx];
+        const globeMatrix = calculateGlobeMatrix(tr, numTiles);
+
+        for (let i = 0; i < corners.length; i++) {
+            vec3.transformMat4(corners[i], corners[i], globeMatrix);
+            vec3.min(cornerMin, cornerMin, corners[i]);
+            vec3.max(cornerMax, cornerMax, corners[i]);
+        }
+
+        return new Aabb(cornerMin, cornerMax);
+    }
+
+    const tt = tileTransform({z, x, y}, projection);
+    const tx = tt.x / tt.scale;
+    const ty = tt.y / tt.scale;
+    const tx2 = tt.x2 / tt.scale;
+    const ty2 = tt.y2 / tt.scale;
+
+    if (isNaN(tx) || isNaN(tx2) || isNaN(ty) || isNaN(ty2)) {
+        assert(false);
+    }
+
+    return new Aabb(
+        [(wrap + tx) * numTiles, numTiles * ty, min],
+        [(wrap  + tx2) * numTiles, numTiles * ty2, max]);
 }
 
 export function getTilePoint(tileTransform: TileTransform, {x, y}: {x: number, y: number}, wrap: number = 0) {

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -6,6 +6,7 @@ import {vec3} from 'gl-matrix';
 import type {Projection} from './index.js';
 import {Aabb} from '../../util/primitives.js';
 import {globeTileBounds, calculateGlobeMatrix} from './globe.js';
+import type Transform from '../transform.js';
 import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
 import assert from 'assert';
 
@@ -90,7 +91,7 @@ export default function tileTransform(id: Object, projection: Projection) {
     };
 }
 
-export function tileAABB(tr: Transform, numTiles, z, x, y, wrap, min, max, projection: Projection) {
+export function tileAABB(tr: Transform, numTiles: number, z: number, x: number, y: number, wrap: number, min: number, max: number, projection: Projection) {
     if (projection.name === 'globe') {
         const tileId = new UnwrappedTileID(wrap, new CanonicalTileID(z, x, y));
         const aabb = globeTileBounds(tileId.canonical);

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -93,7 +93,7 @@ export default function tileTransform(id: Object, projection: Projection) {
 export function tileAABB(tr: Transform, numTiles, z, x, y, wrap, min, max, projection: Projection) {
     if (projection.name === 'globe') {
         const tileId = new UnwrappedTileID(wrap, new CanonicalTileID(z, x, y));
-        const aabb = tileBoundsOnGlobe(tileId.canonical);
+        const aabb = globeTileBounds(tileId.canonical);
 
         // Transform corners of the aabb to the correct space
         const corners = aabb.getCorners();

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -19,7 +19,7 @@ export type TileTransform = {
 };
 
 export default function tileTransform(id: Object, projection: Projection) {
-    if (projection.name === 'mercator' || projection.name !== 'globe') {
+    if (projection.name === 'mercator' || projection.name === 'globe') {
         return {scale: 1 << id.z, x: id.x, y: id.y, x2: id.x + 1, y2: id.y + 1, projection};
     }
 

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -19,7 +19,7 @@ export type TileTransform = {
 };
 
 export default function tileTransform(id: Object, projection: Projection) {
-    if (projection.name === 'mercator' || projection.name === 'globe') {
+    if (!projection.isReprojectedInTileSpace) {
         return {scale: 1 << id.z, x: id.x, y: id.y, x2: id.x + 1, y2: id.y + 1, projection};
     }
 

--- a/src/geo/projection/winkel_tripel.js
+++ b/src/geo/projection/winkel_tripel.js
@@ -27,7 +27,8 @@ export default {
         const y = 0.5 * (lat + Math.sin(lat) / sinAlphaOverAlpha) || 0;
         return {
             x: (x / Math.PI + 0.5) * 0.5,
-            y: 1 - (y / Math.PI + 1) * 0.5
+            y: 1 - (y / Math.PI + 1) * 0.5,
+            z: 0
         };
     },
 

--- a/src/geo/projection/winkel_tripel.js
+++ b/src/geo/projection/winkel_tripel.js
@@ -14,6 +14,7 @@ export default {
     center: [0, 0],
     range: [3.5, 7],
     zAxisUnit: "meters",
+    isReprojectedInTileSpace: true,
 
     project(lng: number, lat: number) {
         lat = degToRad(lat);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -708,6 +708,7 @@ class Transform {
 
         const useElevationData = this.elevation && !options.isTerrainDEM;
         const isMercator = this.projection.name === 'mercator';
+        const isGlobe = this.projection.name === 'globe';
 
         if (options.minzoom !== undefined && z < options.minzoom) return [];
         if (options.maxzoom !== undefined && z > options.maxzoom) z = options.maxzoom;
@@ -728,7 +729,7 @@ class Transform {
         const zoomSplitDistance = this.cameraToCenterDistance / options.tileSize * (options.roundZoom ? 1 : 0.502);
 
         // No change of LOD behavior for pitch lower than 60 and when there is no top padding: return only tile ids from the requested zoom level
-        const minZoom = this.pitch <= 60.0 && this._edgeInsets.top <= this._edgeInsets.bottom && !this._elevation && isMercator ? z : 0;
+        const minZoom = this.pitch <= 60.0 && this._edgeInsets.top <= this._edgeInsets.bottom && !this._elevation && (isMercator || isGlobe) ? z : 0;
 
         // When calculating tile cover for terrain, create deep AABB for nodes, to ensure they intersect frustum: for sources,
         // other than DEM, use minimum of visible DEM tiles and center altitude as upper bound (pitch is always less than 90°).
@@ -832,7 +833,7 @@ class Transform {
             }
 
             let tileScaleAdjustment = 1;
-            if (!isMercator && actualZ <= 5) {
+            if (!(isMercator || isGlobe) && actualZ <= 5) {
                 // In other projections, not all tiles are the same size.
                 // Account for the tile size difference by adjusting the distToSplit.
                 // Adjust by the ratio of the area at the tile center to the area at the map center.

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -270,7 +270,7 @@ class Transform {
     }
 
     get renderWorldCopies(): boolean {
-        return this._renderWorldCopies && this.projection.wrap === true;
+        return this._renderWorldCopies && this.projection.supportsWorldCopies === true;
     }
     set renderWorldCopies(renderWorldCopies?: ?boolean) {
         if (renderWorldCopies === undefined) {
@@ -846,7 +846,7 @@ class Transform {
             return distanceSqr < distToSplitSqr;
         };
 
-        if (this.projection.supportsWorldCopies && this._renderWorldCopies) {
+        if (this.renderWorldCopies) {
             // Render copy of the globe thrice on both sides
             for (let i = 1; i <= NUM_WORLD_COPIES; i++) {
                 stack.push(newRootTile(-i));

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1524,7 +1524,7 @@ class Transform {
         this._constraining = true;
 
         // alternate constraining for non-Mercator projections
-        if (!this.project.isReprojectedInTileSpace) {
+        if (this.projection.isReprojectedInTileSpace) {
             const center = this.center;
             center.lat = clamp(center.lat, this.minLat, this.maxLat);
             if (this.maxBounds || !this.renderWorldCopies) center.lng = clamp(center.lng, this.minLng, this.maxLng);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -763,7 +763,6 @@ class Transform {
         const newRootTile = (wrap: number): any => {
             const max = maxRange;
             const min = minRange;
-            // FIXME(globe-view-rebase): Use aabb
             return {
                 // With elevation, this._elevation provides z coordinate values. For 2D:
                 // All tiles are on zero elevation plane => z difference is zero
@@ -1347,28 +1346,6 @@ class Transform {
 
     calculatePosMatrix(unwrappedTileID: UnwrappedTileID, worldSize: number): Float32Array {
         return this.projection.createTileTransform(this, worldSize).createTileMatrix(unwrappedTileID);
-        // FIXME(globe-view-rebase)
-        //let scale, scaledX, scaledY;
-        //const canonical = unwrappedTileID.canonical;
-        //const posMatrix = mat4.identity(new Float64Array(16));
-        //
-        //if (this.projection.name === 'mercator') {
-        //    scale = worldSize / this.zoomScale(canonical.z);
-        //    const unwrappedX = canonical.x + Math.pow(2, canonical.z) * unwrappedTileID.wrap;
-        //    scaledX = unwrappedX * scale;
-        //    scaledY = canonical.y * scale;
-        //} else {
-        //    const cs = tileTransform(canonical, this.projection);
-        //    scale = 1;
-        //    scaledX = cs.x + unwrappedTileID.wrap * cs.scale;
-        //    scaledY = cs.y;
-        //    mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, this.pixelsPerMeter / this.worldSize]);
-        //}
-        //
-        //mat4.translate(posMatrix, posMatrix, [scaledX, scaledY, 0]);
-        //mat4.scale(posMatrix, posMatrix, [scale / EXTENT, scale / EXTENT, 1]);
-        //
-        //return posMatrix;
     }
 
     calculateDistanceTileData(unwrappedTileID: UnwrappedTileID): FeatureDistanceData {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -846,7 +846,6 @@ class Transform {
             return distanceSqr < distToSplitSqr;
         };
 
-        // FIXME(globe-view-rebase): Add supportsWorldCopies to projection
         if (this.projection.supportsWorldCopies && this._renderWorldCopies) {
             // Render copy of the globe thrice on both sides
             for (let i = 1; i <= NUM_WORLD_COPIES; i++) {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1498,8 +1498,7 @@ class Transform {
         const cameraHeight = this._camera.position[2] - terrainElevation;
 
         if (cameraHeight < minHeight) {
-            // FIXME(globe-view-rebase): MercatorCoordinate -> this.locationCoordinate
-            const center = MercatorCoordinate.fromLngLat(this._center, this._centerAltitude);
+            const center = this.locationCoordinate(this._center, this._centerAltitude);
             const cameraToCenter = [center.x - pos[0], center.y - pos[1], center.z - pos[2]];
             const prevDistToCamera = vec3.length(cameraToCenter);
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1525,7 +1525,7 @@ class Transform {
         this._constraining = true;
 
         // alternate constraining for non-Mercator projections
-        if (this.project.isReprojectedInTileSpace) {
+        if (!this.project.isReprojectedInTileSpace) {
             const center = this.center;
             center.lat = clamp(center.lat, this.minLat, this.maxLat);
             if (this.maxBounds || !this.renderWorldCopies) center.lng = clamp(center.lng, this.minLng, this.maxLng);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1422,7 +1422,9 @@ class Transform {
         }
 
         const posMatrix = this.calculatePosMatrix(unwrappedTileID, this.worldSize);
-        const projMatrix = this.projection.name === 'mercator' ? (aligned ? this.alignedProjMatrix : this.projMatrix) : this.mercatorMatrix;
+        const projMatrix = this.projection.name === 'mercator' || this.projection.name === 'globe' ?
+            (aligned ? this.alignedProjMatrix : this.projMatrix) :
+            this.mercatorMatrix;
         mat4.multiply(posMatrix, projMatrix, posMatrix);
 
         cache[projMatrixKey] = new Float32Array(posMatrix);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -10,7 +10,7 @@ import {wrap, clamp, pick, radToDeg, degToRad, getAABBPointSquareDist, furthestT
 import {number as interpolate} from '../style-spec/util/interpolate.js';
 import EXTENT from '../data/extent.js';
 import {vec4, mat4, mat2, vec3, quat} from 'gl-matrix';
-import {Frustum, Ray} from '../util/primitives.js';
+import {Aabb, Frustum, Ray} from '../util/primitives.js';
 import EdgeInsets from './edge_insets.js';
 import {FreeCamera, FreeCameraOptions, orientationFromFrame} from '../ui/free_camera.js';
 import assert from 'assert';

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -20,7 +20,6 @@ import type {Projection} from '../geo/projection/index.js';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import type {Elevation} from '../terrain/elevation.js';
 import type {PaddingOptions} from './edge_insets.js';
-import type {Projection} from './projection/index.js';
 import type Tile from '../source/tile.js';
 import type {ProjectionSpecification} from '../style-spec/types.js';
 import type {FeatureDistanceData} from '../style-spec/feature_filter/index.js';

--- a/src/render/draw_custom.js
+++ b/src/render/draw_custom.js
@@ -15,7 +15,7 @@ function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomSty
     const context = painter.context;
     const implementation = layer.implementation;
 
-    if (painter.transform.projection.name !== 'mercator') {
+    if (!painter.transform.projection.supportsCustomLayers) {
         warnOnce('Custom layers are not yet supported with non-mercator projections. Use mercator to enable custom layers.');
         return;
     }

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -134,7 +134,7 @@ function updateVariableAnchors(coords, painter, layer, sourceCache, rotationAlig
         const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
 
         const pixelsToTileUnits = painter.transform.calculatePixelsToTileUnitsMatrix(tile);
-        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, tile.tileID.canonical, pitchWithMap, rotateWithMap, painter.transform, pixelToTileScale);
+        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, tile.tileID.canonical, pitchWithMap, rotateWithMap, painter.transform, pixelsToTileUnits);
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&  bucket.hasIconData();
 
         if (size) {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -173,7 +173,11 @@ class Painter {
     }
 
     updateTerrain(style: Style, cameraChanging: boolean) {
-        const enabled = !!style && !!style.terrain && this.transform.projection.name === 'mercator';
+        // FIXME: Move this check as part of the projection interface
+        const globeOrMercator =
+            this.transform.projection.name === 'mercator' ||
+            this.transform.projection.name === 'globe' ;
+        const enabled = !!style && !!style.terrain && globeOrMercator;
         if (!enabled && (!this._terrain || !this._terrain.enabled)) return;
         if (!this._terrain) {
             this._terrain = new Terrain(this, style);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -173,11 +173,7 @@ class Painter {
     }
 
     updateTerrain(style: Style, cameraChanging: boolean) {
-        // FIXME: Move this check as part of the projection interface
-        const globeOrMercator =
-            this.transform.projection.name === 'mercator' ||
-            this.transform.projection.name === 'globe' ;
-        const enabled = !!style && !!style.terrain && globeOrMercator;
+        const enabled = !!style && !!style.terrain && this.transform.projection.supportsTerrain;
         if (!enabled && (!this._terrain || !this._terrain.enabled)) return;
         if (!this._terrain) {
             this._terrain = new Terrain(this, style);

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -10,7 +10,6 @@ import {CollisionBoxArray, TileBoundsArray, PosArray, TriangleIndexArray, LineSt
 import Texture from '../render/texture.js';
 import browser from '../util/browser.js';
 import {Debug} from '../util/debug.js';
-import type VertexBuffer from '../gl/vertex_buffer.js';
 import toEvaluationFeature from '../data/evaluation_feature.js';
 import EvaluationParameters from '../style/evaluation_parameters.js';
 import SourceFeatureState from '../source/source_state.js';

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -134,13 +134,9 @@ export default class Worker {
         callback();
     }
 
-    setProjection(mapId: string, config: ProjectionSpecification) {
-        //setProjection(mapId: string, projection: string, callback: WorkerTileCallback) {
-        // FIXME(rebase): Make sure that setProjection is called with a callback
-        // FIXME(rebase): Remove duplicate
+    setProjection(mapId: string, config: ProjectionSpecification, callback: WorkerTileCallback) {
         this.projections[mapId] = getProjection(config);
-        // this.projection = projection;
-        // callback();
+        callback();
     }
 
     setLayers(mapId: string, layers: Array<LayerSpecification>, callback: WorkerTileCallback) {
@@ -158,9 +154,6 @@ export default class Worker {
         const p = this.enableTerrain ? extend({enableTerrain: this.terrain}, params) : params;
         p.projection = this.projections[mapId] || this.defaultProjection;
         this.getWorkerSource(mapId, params.type, params.source).loadTile(p, callback);
-        // FIXME(rebase):
-        // extend(params, {enableTerrain: this.terrain, projection: this.projection});
-        // this.getWorkerSource(mapId, params.type, params.source).loadTile(params, callback);
     }
 
     loadDEMTile(mapId: string, params: WorkerDEMTileParameters, callback: WorkerDEMTileCallback) {
@@ -173,9 +166,6 @@ export default class Worker {
         const p = this.enableTerrain ? extend({enableTerrain: this.terrain}, params) : params;
         p.projection = this.projections[mapId] || this.defaultProjection;
         this.getWorkerSource(mapId, params.type, params.source).reloadTile(p, callback);
-        // FIXME(rebase):
-        // extend(params, {enableTerrain: this.terrain, projection: this.projection});
-        // this.getWorkerSource(mapId, params.type, params.source).reloadTile(params, callback);
     }
 
     abortTile(mapId: string, params: TileParameters & {type: string}, callback: WorkerTileCallback) {

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -134,12 +134,13 @@ export default class Worker {
         callback();
     }
 
-    setProjection(mapId: string, projection: string, callback: WorkerTileCallback) {
+    setProjection(mapId: string, config: ProjectionSpecification) {
+        //setProjection(mapId: string, projection: string, callback: WorkerTileCallback) {
         // FIXME(rebase): Make sure that setProjection is called with a callback
         // FIXME(rebase): Remove duplicate
         this.projections[mapId] = getProjection(config);
-        this.projection = projection;
-        callback();
+        // this.projection = projection;
+        // callback();
     }
 
     setLayers(mapId: string, layers: Array<LayerSpecification>, callback: WorkerTileCallback) {

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -45,7 +45,6 @@ export default class Worker {
     isSpriteLoaded: {[_: string]: boolean };
     referrer: ?string;
     terrain: ?boolean;
-    projection: string;
 
     constructor(self: WorkerGlobalScopeInterface) {
         PerformanceUtils.measure('workerEvaluateScript');
@@ -57,9 +56,7 @@ export default class Worker {
         this.isSpriteLoaded = {};
 
         this.projections = {};
-        // FIXME(rebase): Duplicate
         this.defaultProjection = getProjection({name: 'mercator'});
-        this.projection = 'mercator';
 
         this.workerSourceTypes = {
             vector: VectorTileWorkerSource,

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -131,9 +131,8 @@ export default class Worker {
         callback();
     }
 
-    setProjection(mapId: string, config: ProjectionSpecification, callback: WorkerTileCallback) {
+    setProjection(mapId: string, config: ProjectionSpecification) {
         this.projections[mapId] = getProjection(config);
-        callback();
     }
 
     setLayers(mapId: string, layers: Array<LayerSpecification>, callback: WorkerTileCallback) {

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -40,7 +40,7 @@ export type WorkerTileParameters = RequestedTileParameters & {
     collectResourceTiming?: boolean,
     returnDependencies?: boolean,
     enableTerrain?: boolean,
-    projection?: Projection
+    projection: Projection
 };
 
 export type WorkerDEMTileParameters = TileParameters & {

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -20,7 +20,6 @@ import {PerformanceUtils} from '../util/performance.js';
 import tileTransform from '../geo/projection/tile_transform.js';
 
 import type {Projection} from '../geo/projection/index.js';
-import {getProjection} from '../geo/projection/index.js';
 import type {Bucket} from '../data/bucket.js';
 import type Actor from '../util/actor.js';
 import type StyleLayer from '../style/style_layer.js';

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -239,7 +239,6 @@ class WorkerTile {
                 for (const key in buckets) {
                     const bucket = buckets[key];
                     if (bucket instanceof SymbolBucket) {
-                        const projection: Projection = getProjection(this.projection);
                         recalculateLayers(bucket.layers, this.zoom, availableImages);
                         performSymbolLayout(bucket,
                             glyphMap,
@@ -250,8 +249,8 @@ class WorkerTile {
                             availableImages,
                             this.tileID.canonical,
                             this.tileZoom,
-                            projection);
-                        bucket.projection = this.projection;
+                            this.projection);
+                        bucket.projection = this.projection.name;
                     } else if (bucket.hasPattern &&
                         (bucket instanceof LineBucket ||
                          bucket instanceof FillBucket ||

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -18,7 +18,7 @@ import EvaluationParameters from '../style/evaluation_parameters.js';
 import {CanonicalTileID, OverscaledTileID} from './tile_id.js';
 import {PerformanceUtils} from '../util/performance.js';
 import tileTransform from '../geo/projection/tile_transform.js';
-
+import type {Projection} from '../geo/projection/index.js';
 import type {Bucket} from '../data/bucket.js';
 import type Actor from '../util/actor.js';
 import type StyleLayer from '../style/style_layer.js';
@@ -48,7 +48,7 @@ class WorkerTile {
     returnDependencies: boolean;
     enableTerrain: boolean;
     isSymbolTile: ?boolean;
-    projection: ?string;
+    projection: Projection;
     tileTransform: TileTransform;
 
     status: 'parsing' | 'done';
@@ -75,12 +75,7 @@ class WorkerTile {
         this.promoteId = params.promoteId;
         this.enableTerrain = !!params.enableTerrain;
         this.isSymbolTile = params.isSymbolTile;
-        if (params.projection) {
-            this.tileTransform = tileTransform(params.tileID.canonical, params.projection);
-        } else {
-            // silence flow
-            assert(params.projection);
-        }
+        this.tileTransform = tileTransform(params.tileID.canonical, params.projection);
         this.projection = params.projection;
     }
 

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -20,7 +20,7 @@ import {PerformanceUtils} from '../util/performance.js';
 import tileTransform from '../geo/projection/tile_transform.js';
 
 import type {Projection} from '../geo/projection/index.js';
-import getProjection from '../geo/projection/index.js';
+import {getProjection} from '../geo/projection/index.js';
 import type {Bucket} from '../data/bucket.js';
 import type Actor from '../util/actor.js';
 import type StyleLayer from '../style/style_layer.js';

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -19,7 +19,6 @@ import {CanonicalTileID, OverscaledTileID} from './tile_id.js';
 import {PerformanceUtils} from '../util/performance.js';
 import tileTransform from '../geo/projection/tile_transform.js';
 
-import type {Projection} from '../geo/projection/index.js';
 import type {Bucket} from '../data/bucket.js';
 import type Actor from '../util/actor.js';
 import type StyleLayer from '../style/style_layer.js';

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -96,7 +96,7 @@
     },
     "projection": {
       "type": "projection",
-      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain, fog, sky and CustomLayerInterface are not supported for projections other than mercator.",
+      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, Globe, and Winkel Tripel. Terrain, fog, sky and CustomLayerInterface are not supported for projections other than mercator.",
       "example": {
         "name": "albers",
         "center": [-154, 50],
@@ -3991,6 +3991,9 @@
         },
         "winkelTripel": {
           "doc": "A Winkel Tripel projection."
+        },
+        "globe": {
+          "doc": "A globe projection."
         }
       },
       "default": "mercator",

--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -95,7 +95,7 @@ export type FogSpecification = {|
 |}
 
 export type ProjectionSpecification = {|
-    "name": "albers" | "equalEarth" | "equirectangular" | "lambertConformalConic" | "mercator" | "naturalEarth" | "winkelTripel",
+    "name": "albers" | "equalEarth" | "equirectangular" | "lambertConformalConic" | "mercator" | "naturalEarth" | "winkelTripel" | "globe",
     "center"?: [number, number],
     "parallels"?: [number, number]
 |}

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -46,11 +46,6 @@ class Fog extends Evented {
         this._transform = transform;
     }
 
-    isSoftDisabled(): boolean {
-        // FIXME: Move this as part of the projection interface
-        return this._transform.projection.name !== 'mercator';
-    }
-
     get state(): FogState {
         return {
             range: this.properties.get('range'),
@@ -79,7 +74,7 @@ class Fog extends Evented {
     }
 
     getOpacity(pitch: number): number {
-        if (this.isSoftDisabled()) return 0;
+        if (this._transform.projection.supportsFog) return 0;
 
         const fogColor = (this.properties && this.properties.get('color')) || 1.0;
         const pitchFactor = smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
@@ -87,14 +82,14 @@ class Fog extends Evented {
     }
 
     getOpacityAtLatLng(lngLat: LngLat, transform: Transform): number {
-        if (this.isSoftDisabled()) return 0;
+        if (this._transform.projection.supportsFog) return 0;
 
         return getFogOpacityAtLngLat(this.state, lngLat, transform);
     }
 
     getFovAdjustedRange(fov: number): [number, number] {
         // We can return any arbitrary range because we expect opacity=0 to clean it up
-        if (this.isSoftDisabled()) return [0, 1];
+        if (this._transform.projection.supportsFog) return [0, 1];
 
         return getFovAdjustedFogRange(this.state, fov);
     }

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -47,6 +47,7 @@ class Fog extends Evented {
     }
 
     isSoftDisabled(): boolean {
+        // FIXME: Move this as part of the projection interface
         return this._transform.projection.name !== 'mercator';
     }
 

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -74,7 +74,7 @@ class Fog extends Evented {
     }
 
     getOpacity(pitch: number): number {
-        if (this._transform.projection.supportsFog) return 0;
+        if (!this._transform.projection.supportsFog) return 0;
 
         const fogColor = (this.properties && this.properties.get('color')) || 1.0;
         const pitchFactor = smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
@@ -82,14 +82,14 @@ class Fog extends Evented {
     }
 
     getOpacityAtLatLng(lngLat: LngLat, transform: Transform): number {
-        if (this._transform.projection.supportsFog) return 0;
+        if (!this._transform.projection.supportsFog) return 0;
 
         return getFogOpacityAtLngLat(this.state, lngLat, transform);
     }
 
     getFovAdjustedRange(fov: number): [number, number] {
         // We can return any arbitrary range because we expect opacity=0 to clean it up
-        if (this._transform.projection.supportsFog) return [0, 1];
+        if (!this._transform.projection.supportsFog) return [0, 1];
 
         return getFovAdjustedFogRange(this.state, fov);
     }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -369,10 +369,13 @@ class Style extends Evented {
 
         if (!projectionChanged) return;
 
+        // TODO: Only do that for runtime reprojection, otherwise
+        // reduce to only _forceSymbolLayerUpdate for faster switch
         this.map.painter.clearBackgroundTiles();
         for (const id in this._sourceCaches) {
             this._sourceCaches[id].clearTiles();
         }
+        // this._forceSymbolLayerUpdate();
 
         this.map._update(true);
     }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -355,9 +355,11 @@ class Style extends Evented {
         const projectionChanged = this.map.transform.setProjection(this.map._runtimeProjection || (this.stylesheet ? this.stylesheet.projection : undefined));
         const projection = this.map.transform.projection;
 
+        // eslint-disable-next-line no-warning-comments
         // TODO: Allow globe to be set without style loaded at map creation
         if (this._loaded) {
             if (projection.requiresDraping) {
+                // eslint-disable-next-line no-warning-comments
                 // TODO: Allow draping to work without an explicit DEM source (dummy source)
                 this.map._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
             } else {
@@ -369,6 +371,7 @@ class Style extends Evented {
 
         if (!projectionChanged) return;
 
+        // eslint-disable-next-line no-warning-comments
         // TODO: Only do that for runtime reprojection, otherwise
         // reduce to only _forceSymbolLayerUpdate for faster switch
         this.map.painter.clearBackgroundTiles();

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -360,10 +360,18 @@ class Style extends Evented {
         if (this._loaded) {
             if (projection.requiresDraping) {
                 // eslint-disable-next-line no-warning-comments
-                // TODO: Allow draping to work without an explicit DEM source (dummy source)
+                // TODO:
+                // - Allow draping to work without an explicit DEM source (dummy source)
+                // - Prevent override of exaggeration when terrain is already enabled
                 this.map._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
             } else {
-                this.map._setTerrain(null, "projection");
+                // eslint-disable-next-line no-warning-comments
+                // TODO:
+                // - Revert terrain if terrain use is only for globe draping
+                // - Make sure that terrain set as part of stylesheet is set with 'explicit' mode
+                // if (!this.map._terrainRefCount['explicit']) {
+                //   this.map._setTerrain(null, "projection");
+                // }
             }
         }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1710,7 +1710,8 @@ class Style extends Evented {
         }
 
         if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now(), transform.zoom))) {
-            this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement, this.fog && !this.fog.isSoftDisabled() ? this.fog.state : null);
+            const fogState = this.fog && transform.projection.supportsFog ? this.fog.state : null;
+            this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement, fogState);
             this._layerOrderChanged = false;
         }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -353,6 +353,17 @@ class Style extends Evented {
 
     updateProjection() {
         const projectionChanged = this.map.transform.setProjection(this.map._runtimeProjection || (this.stylesheet ? this.stylesheet.projection : undefined));
+        const projection = this.map.transform.projection;
+
+        // TODO: Allow globe to be set without style loaded at map creation
+        if (this._loaded) {
+            if (projection.requiresDraping) {
+                // TODO: Allow draping to work without an explicit DEM source (dummy source)
+                this.map._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
+            } else {
+                this.map._setTerrain(null, "projection");
+            }
+        }
 
         this.dispatcher.broadcast('setProjection', this.map.transform.projectionOptions);
 

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -16,7 +16,7 @@ import type {
 } from '../data/array_types.js';
 import {WritingMode} from '../symbol/shaping.js';
 import {CanonicalTileID, OverscaledTileID} from '../source/tile_id.js';
-
+import {calculateGlobeMatrix, denormalizeECEF, globeTileBounds} from '../geo/projection/globe.js';
 export {updateLineLabels, hideGlyphs, getLabelPlaneMatrix, getGlCoordMatrix, project, getPerspectiveRatio, placeFirstAndLastGlyph, placeGlyphAlongLine, xyTransformMat4};
 
 const FlipState = {
@@ -83,11 +83,22 @@ function getLabelPlaneMatrix(posMatrix: mat4,
                              pixelsToTileUnits: Float32Array) {
     const m = mat4.create();
     if (pitchWithMap) {
-        const s = mat2.invert([], pixelsToTileUnits);
-        m[0] = s[0];
-        m[1] = s[1];
-        m[4] = s[2];
-        m[5] = s[3];
+        if (transform.projection.name === 'globe') {
+            // Camera is moved closer towards the ground near poles as part of
+            // compesanting the reprojection. This has to be compensated for the
+            // map aligned label space. Whithout this logic map aligned symbols
+            // would appear larger than intended.
+            const labelWorldSize = this._tr.worldSize / this._tr._projectionScaler;
+            m = calculateGlobeMatrix(tr, labelWorldSize, [0, 0]);
+
+            mat4.multiply(m, m, denormalizeECEF(globeTileBounds(tileID)))
+        } else {
+            const s = mat2.invert([], pixelsToTileUnits);
+            m[0] = s[0];
+            m[1] = s[1];
+            m[4] = s[2];
+            m[5] = s[3];
+        }
         if (!rotateWithMap) {
             mat4.rotateZ(m, m, transform.angle);
         }
@@ -95,10 +106,6 @@ function getLabelPlaneMatrix(posMatrix: mat4,
         mat4.multiply(m, transform.labelPlaneMatrix, posMatrix);
     }
     return m;
-
-    // FIXME(globe-view-rebase): pixelsToTileUnits number -> Float32Array
-    //return transform.projection.createTileTransform(transform, transform.worldSize).createLabelPlaneMatrix(
-    //    posMatrix, tileID, pitchWithMap, rotateWithMap, pixelsToTileUnits);
 }
 
 /*
@@ -111,22 +118,27 @@ function getGlCoordMatrix(posMatrix: mat4,
                           transform: Transform,
                           pixelsToTileUnits: Float32Array) {
     if (pitchWithMap) {
-        const m = mat4.clone(posMatrix);
-        const s = mat4.identity([]);
-        s[0] = pixelsToTileUnits[0];
-        s[1] = pixelsToTileUnits[1];
-        s[4] = pixelsToTileUnits[2];
-        s[5] = pixelsToTileUnits[3];
-        mat4.multiply(m, m, s);
-        if (!rotateWithMap) {
-            mat4.rotateZ(m, m, -transform.angle);
+        if (transform.projection.name === 'globe') {
+            const m = getLabelPlaneMatrix(posMatrix, tileID, pitchWithMap, rotateWithMap, transform, pixelsToTileUnits);
+            mat4.invert(m, m);
+            mat4.multiply(m, posMatrix, m);
+            return m;
+        } else {
+            const m = mat4.clone(posMatrix);
+            const s = mat4.identity([]);
+            s[0] = pixelsToTileUnits[0];
+            s[1] = pixelsToTileUnits[1];
+            s[4] = pixelsToTileUnits[2];
+            s[5] = pixelsToTileUnits[3];
+            mat4.multiply(m, m, s);
+            if (!rotateWithMap) {
+                mat4.rotateZ(m, m, -transform.angle);
+            }
         }
         return m;
     } else {
         return transform.glCoordMatrix;
     }
-    // FIXME(globe-view-rebase): pixelsToTileUnits number -> Float32Array
-    //return transform.projection.createTileTransform(transform, transform.worldSize).createGlCoordMatrix(posMatrix, tileID, pitchWithMap, rotateWithMap, pixelsToTileUnits);
 }
 
 function project(point: Point, matrix: mat4, elevation: ?number = 0) {

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -81,17 +81,17 @@ function getLabelPlaneMatrix(posMatrix: mat4,
                              rotateWithMap: boolean,
                              transform: Transform,
                              pixelsToTileUnits: Float32Array) {
-    const m = mat4.create();
+    let m = mat4.create();
     if (pitchWithMap) {
         if (transform.projection.name === 'globe') {
             // Camera is moved closer towards the ground near poles as part of
             // compesanting the reprojection. This has to be compensated for the
             // map aligned label space. Whithout this logic map aligned symbols
             // would appear larger than intended.
-            const labelWorldSize = this._tr.worldSize / this._tr._projectionScaler;
-            m = calculateGlobeMatrix(tr, labelWorldSize, [0, 0]);
+            const labelWorldSize = transform.worldSize / transform._projectionScaler;
+            m = calculateGlobeMatrix(transform, labelWorldSize, [0, 0]);
 
-            mat4.multiply(m, m, denormalizeECEF(globeTileBounds(tileID)))
+            mat4.multiply(m, m, denormalizeECEF(globeTileBounds(tileID)));
         } else {
             const s = mat2.invert([], pixelsToTileUnits);
             m[0] = s[0];
@@ -134,8 +134,8 @@ function getGlCoordMatrix(posMatrix: mat4,
             if (!rotateWithMap) {
                 mat4.rotateZ(m, m, -transform.angle);
             }
+            return m;
         }
-        return m;
     } else {
         return transform.glCoordMatrix;
     }

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1006,6 +1006,7 @@ class Camera extends Evented {
      * map.setFreeCameraOptions(camera);
      */
     getFreeCameraOptions(): FreeCameraOptions {
+        // FIXME: Move this as part of the projection interface
         if (this.transform.projection.name !== 'mercator') {
             warnOnce(freeCameraNotSupportedWarning);
         }

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1006,8 +1006,7 @@ class Camera extends Evented {
      * map.setFreeCameraOptions(camera);
      */
     getFreeCameraOptions(): FreeCameraOptions {
-        // FIXME: Move this as part of the projection interface
-        if (this.transform.projection.name !== 'mercator') {
+        if (!this.transform.projection.supportsFreeCamera) {
             warnOnce(freeCameraNotSupportedWarning);
         }
         return this.transform.getFreeCameraOptions();
@@ -1051,7 +1050,7 @@ class Camera extends Evented {
     setFreeCameraOptions(options: FreeCameraOptions, eventData?: Object) {
         const tr = this.transform;
 
-        if (tr.projection.name !== 'mercator') {
+        if (!tr.projection.supportsFreeCamera) {
             warnOnce(freeCameraNotSupportedWarning);
             return;
         }

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1157,7 +1157,9 @@ class Camera extends Evented {
 
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
-        const locationAtOffset = tr.pointCoordinate(pointAtOffset).toLngLat();
+        const locationAtOffset = tr.projection.name === 'globe' ?
+            tr.pointCoordinate(pointAtOffset).toLngLat() :
+            tr.pointLocation(pointAtOffset);
         const center = LngLat.convert(options.center || locationAtOffset);
         this._normalizeCenter(center);
 

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -526,14 +526,6 @@ class HandlerManager {
                 panVec[0] = endPoint.x - startPoint.x;
                 panVec[1] = endPoint.y - startPoint.y;
             }
-
-            // const startRay = tr.screenPointToMercatorRay(around);
-            // const endRay = tr.screenPointToMercatorRay(around.sub(panDelta));
-
-            // const startPoint = this._trackingEllipsoid.projectRay(startRay.dir);
-            // const endPoint = this._trackingEllipsoid.projectRay(endRay.dir);
-            //panVec[0] = endPoint[0] - startPoint[0];
-            //panVec[1] = endPoint[1] - startPoint[1];
         }
 
         const originalZoom = tr.zoom;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2443,26 +2443,26 @@ class Map extends Camera {
         }
     }
 
-    setProjection(options?: { name: string }) {
-        const prevName = this.transform.projection.name;
-        const name = options ? options.name : null;
-        const projection = getProjection(name || 'mercator');
-        this.transform.projection = projection;
-        this._transitionFromGlobe = false;
+    // setProjection(options?: { name: string }) {
+    //     const prevName = this.transform.projection.name;
+    //     const name = options ? options.name : null;
+    //     const projection = getProjection(name || 'mercator');
+    //     this.transform.projection = projection;
+    //     this._transitionFromGlobe = false;
 
-        if (projection.requiresDraping) {
-            this._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
-        } else {
-            this._setTerrain(null, "projection");
-        }
+    //     if (projection.requiresDraping) {
+    //         this._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
+    //     } else {
+    //         this._setTerrain(null, "projection");
+    //     }
 
-        if (projection.name !== prevName) {
-            this.style._forceSymbolLayerUpdate();
-            this.style.dispatcher.broadcast('setProjection', projection.name);
-        }
+    //     if (projection.name !== prevName) {
+    //         this.style._forceSymbolLayerUpdate();
+    //         this.style.dispatcher.broadcast('setProjection', projection.name);
+    //     }
 
-        return this._update(true);
-    }
+    //     return this._update(true);
+    // }
 
     _setTerrain(options: ?TerrainSpecification, user: string) {
         // There are multiple different consumers for the terrain.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -12,7 +12,6 @@ import Style from '../style/style.js';
 import EvaluationParameters from '../style/evaluation_parameters.js';
 import Painter from '../render/painter.js';
 import Transform from '../geo/transform.js';
-import {getProjection} from '../geo/projection/index.js';
 import Hash from './hash.js';
 import HandlerManager from './handler_manager.js';
 import Camera from './camera.js';

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -12,7 +12,7 @@ import Style from '../style/style.js';
 import EvaluationParameters from '../style/evaluation_parameters.js';
 import Painter from '../render/painter.js';
 import Transform from '../geo/transform.js';
-import getProjection from '../geo/projection/index.js';
+import {getProjection} from '../geo/projection/index.js';
 import Hash from './hash.js';
 import HandlerManager from './handler_manager.js';
 import Camera from './camera.js';

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1040,6 +1040,7 @@ class Map extends Camera {
         }
         this._runtimeProjection = projection;
         this.style.updateProjection();
+        this._transitionFromGlobe = false;
         return this;
     }
 
@@ -2442,27 +2443,6 @@ class Map extends Camera {
             this.setProjection({name: 'globe'});
         }
     }
-
-    // setProjection(options?: { name: string }) {
-    //     const prevName = this.transform.projection.name;
-    //     const name = options ? options.name : null;
-    //     const projection = getProjection(name || 'mercator');
-    //     this.transform.projection = projection;
-    //     this._transitionFromGlobe = false;
-
-    //     if (projection.requiresDraping) {
-    //         this._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
-    //     } else {
-    //         this._setTerrain(null, "projection");
-    //     }
-
-    //     if (projection.name !== prevName) {
-    //         this.style._forceSymbolLayerUpdate();
-    //         this.style.dispatcher.broadcast('setProjection', projection.name);
-    //     }
-
-    //     return this._update(true);
-    // }
 
     _setTerrain(options: ?TerrainSpecification, user: string) {
         // There are multiple different consumers for the terrain.

--- a/src/util/primitives.js
+++ b/src/util/primitives.js
@@ -132,6 +132,19 @@ class Aabb {
         this.center = vec3.scale([], vec3.add([], this.min, this.max), 0.5);
     }
 
+    quadrant(index: number): Aabb {
+        const split = [(index % 2) === 0, index < 2];
+        const qMin = vec3.clone(this.min);
+        const qMax = vec3.clone(this.max);
+        for (let axis = 0; axis < split.length; axis++) {
+            qMin[axis] = split[axis] ? this.min[axis] : this.center[axis];
+            qMax[axis] = split[axis] ? this.center[axis] : this.max[axis];
+        }
+        // Temporarily, elevation is constant, hence quadrant.max.z = this.max.z
+        qMax[2] = this.max[2];
+        return new Aabb(qMin, qMax);
+    }
+
     distanceX(point: Array<number>): number {
         const pointOnAabb = Math.max(Math.min(this.max[0], point[0]), this.min[0]);
         return pointOnAabb - point[0];

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -6,7 +6,6 @@ import {VectorTile} from '@mapbox/vector-tile';
 import SymbolBucket from '../../../src/data/bucket/symbol_bucket.js';
 import {CollisionBoxArray} from '../../../src/data/array_types.js';
 import {performSymbolLayout} from '../../../src/symbol/symbol_layout.js';
-import getProjection from '../../../src/geo/projection/index.js';
 import {Placement} from '../../../src/symbol/placement.js';
 import Transform from '../../../src/geo/transform.js';
 import {OverscaledTileID} from '../../../src/source/tile_id.js';

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -44,16 +44,16 @@ function bucketSetup(text = 'abcde') {
 test('SymbolBucket', (t) => {
     const bucketA = bucketSetup();
     const bucketB = bucketSetup();
-    const projection = getProjection('mercator');
+    const projection = getProjection({name: 'mercator'});
     const options = {iconDependencies: {}, glyphDependencies: {}};
     const placement = new Placement(transform, 0, true);
     const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
     const crossTileSymbolIndex = new CrossTileSymbolIndex();
-    const painter = {transform: {projection: getProjection({name: 'mercator'})}};
+    const painter = {transform: {projection}};
 
     // add feature from bucket A
     bucketA.populate([{feature}], options);
-    performSymbolLayout(bucketA, stacks, glyphPositions, null, null, null, null, null, projection);
+    performSymbolLayout(bucketA, stacks, glyphPositions, null, null, null, null, null, null, projection);
     const tileA = new Tile(tileID, 512, 0, painter);
     tileA.latestFeatureIndex = new FeatureIndex(tileID);
     tileA.buckets = {test: bucketA};
@@ -61,7 +61,7 @@ test('SymbolBucket', (t) => {
 
     // add same feature from bucket B
     bucketB.populate([{feature}], options);
-    performSymbolLayout(bucketB, stacks, glyphPositions, null, null, null, null, null, projection);
+    performSymbolLayout(bucketB, stacks, glyphPositions, null, null, null, null, null, null, projection);
     const tileB = new Tile(tileID, 512, 0, painter);
     tileB.buckets = {test: bucketB};
     tileB.collisionBoxArray = collisionBoxArray;
@@ -92,12 +92,12 @@ test('SymbolBucket integer overflow', (t) => {
     t.stub(SymbolBucket, 'MAX_GLYPHS').value(5);
 
     const bucket = bucketSetup();
-    const projection = getProjection('mercator');
+    const projection = getProjection({name: 'mercator'});
     const options = {iconDependencies: {}, glyphDependencies: {}};
 
     bucket.populate([{feature}], options);
     const fakeRect = {w: 10, h: 10};
-    performSymbolLayout(bucket, stacks, {'Test':  {97: fakeRect, 98: fakeRect, 99: fakeRect, 100: fakeRect, 101: fakeRect, 102: fakeRect}}, null, null, null, null, null, projection);
+    performSymbolLayout(bucket, stacks, {'Test':  {97: fakeRect, 98: fakeRect, 99: fakeRect, 100: fakeRect, 101: fakeRect, 102: fakeRect}}, null, null, null, null, null, null, projection);
 
     t.ok(console.warn.calledOnce);
     t.ok(console.warn.getCall(0).calledWithMatch(/Too many glyphs being rendered in a tile./));


### PR DESCRIPTION
To be able to review the changes as part of the rebase of `globe-view` against `main`, I created a rough rebase in the branch `globe-view-rebase` and left FIXMEs and TODOs that are to be addressed against the newly introduced projection feature. This PR makes these changes reviewable and allows the globe view to be added on top of existing projection work, while globe view and non-mercator projections are now able to coexist.

The list of rearchitecture changes that were required:
- Extract `MercatorTileTransform` as `FlatTileTransform` to be shared across 2d projections.
- Split frustum far z plane calculation in its own file to share flat plane z distance calculation and use max visible sphere distance with globe.
- Adjust abstract projection interface to work with both mercator/globe and non-mercator projections:
  - Add `projectTilePoint`, `locationPoint`, `pixelsPerMeter` and `farthestPixelDistance` and `createTileTransform` as part of the abstraction.
  - Share common code for `tileAABB` calculation used as part of tile cover.
  - Merge `wrap and `supportsWorldCopies` concepts.
  - Reduce checks against explicit projection name, replace with `supportsFeature` in the interface and `isReprojectedInTileSpace` checks.
  
Addresses leftover FIXMEs identified during the rebase:
  - [x] `src/geo/projection/index`
  - [x] `src/geo/projection/mercator`
  - [x] `src/symbol/projection:getGlCoordMatrix`
  - [x] `src/symbol/projection:getLabelPlaneMatrix`
  - [x] `src/geo/transform`: merge `aabbForTile` from `TileTransform` interface
  - [x] `src/geo/transform`: merge `calculatePosMatrix` changes
  - [x] `src/source/worker`: merge `setProjection`, `setTerrain` changes
  
Other TODOs:
 - [x] Fix constraining logic under `globe` projection
 - [x] Fix gestures under non-mercator

After this change, we should aim at merging the rebased branch in main to prevent further rebasing and conflicting work. We also need to allow the draping pipeline to be leveraged without using any DEM data sources (we need to introduce a mock DEM data source as we do not have support for 2d render cache in gl-js compared to native).

cc @endanke @mpulkki-mapbox 