### PR TITLE
Preload source tiles

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -6,7 +6,7 @@ import {extend} from '../util/util.js';
 import EXTENT from '../data/extent.js';
 import {ResourceType} from '../util/ajax.js';
 import browser from '../util/browser.js';
-import {preloadTiles} from './source.js';
+import {preloadTiles} from './preload_tiles.js';
 
 import type {Source} from './source.js';
 import type Map from '../ui/map.js';

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -6,6 +6,7 @@ import {extend} from '../util/util.js';
 import EXTENT from '../data/extent.js';
 import {ResourceType} from '../util/ajax.js';
 import browser from '../util/browser.js';
+import {preloadTiles} from './source.js';
 
 import type {Source} from './source.js';
 import type Map from '../ui/map.js';
@@ -16,6 +17,9 @@ import type {Callback} from '../types/callback.js';
 import type {GeoJSON, GeoJSONFeature} from '@mapbox/geojson-types';
 import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-spec/types.js';
 import type {Cancelable} from '../types/cancelable.js';
+import type {CameraOptions} from '../ui/camera.js';
+import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
+import type {TilesPreloadProgress} from './source_cache.js';
 
 /**
  * A source containing GeoJSON.
@@ -395,6 +399,30 @@ class GeoJSONSource extends Evented implements Source {
             type: this.type,
             data: this._data
         });
+    }
+
+    /**
+     * Preloads tiles in the requested viewport.
+     *
+     * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
+     *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
+     * @param {Object} [options] Options supports all properties from {@link CameraOptions}.
+     * @param {Function} [callback] Called when each of the requested tiles is ready or errored.
+     * @returns {number} Number of tiles to load.
+     * @example
+     * map.addSource('some id', {
+     *     type: 'vector',
+     *     url: 'mapbox://mapbox.mapbox-streets-v8'
+     * });
+     *
+     * map.getSource('some id').preloadTiles(bbox, {padding: 20}, ({pending}) => {
+     *     if (pending === 0) {
+     *         map.fitBounds(bbox, {duration:0});
+     *     }
+     * });
+     */
+    preloadTiles(bounds: LngLatBoundsLike, options?: CameraOptions, callback?: (progress: TilesPreloadProgress) => void): number {
+        return preloadTiles.call(this, bounds, options, callback);
     }
 
     hasTransition() {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -19,7 +19,7 @@ import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-
 import type {Cancelable} from '../types/cancelable.js';
 import type {CameraOptions} from '../ui/camera.js';
 import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
-import type {TilesPreloadProgress} from './source_cache.js';
+import type {TilesPreloadProgress} from './preload_tiles.js';
 
 /**
  * A source containing GeoJSON.
@@ -410,12 +410,12 @@ class GeoJSONSource extends Evented implements Source {
      * @param {Function} [callback] Called when each of the requested tiles is ready or errored.
      * @returns {number} Number of tiles to load.
      * @example
-     * map.addSource('some id', {
+     * map.addSource('id', {
      *     type: 'vector',
      *     url: 'mapbox://mapbox.mapbox-streets-v8'
      * });
      *
-     * map.getSource('some id').preloadTiles(bbox, {padding: 20}, ({pending}) => {
+     * map.getSource('id').preloadTiles(bbox, {padding: 20}, ({requested, pending, completed, errored}) => {
      *     if (pending === 0) {
      *         map.fitBounds(bbox, {duration:0});
      *     }

--- a/src/source/preload_tiles.js
+++ b/src/source/preload_tiles.js
@@ -1,0 +1,31 @@
+// @flow
+
+import type Tile from './tile.js';
+import type {CameraOptions} from '../ui/camera.js';
+import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
+import type {TilesPreloadProgress} from './source_cache.js';
+
+export const preloadTiles = function(bounds: LngLatBoundsLike, options?: CameraOptions, callback?: (progress: TilesPreloadProgress) => void): number {
+    const progress = {
+        errored: 0,
+        completed: 0,
+        pending: 0,
+        requested: 0,
+    };
+
+    function tileLoaded(err: ?Error, _: ?Tile) {
+        if (err) progress.errored++;
+        else progress.completed++;
+        progress.pending = progress.requested - (progress.errored + progress.completed);
+
+        // $FlowFixMe
+        callback(progress);
+    }
+
+    const sourceCaches = this.map.style._getSourceCaches(this.id);
+    for (const sourceCache of sourceCaches) {
+        progress.requested += sourceCache.preloadTiles(bounds, options, callback ? tileLoaded : undefined);
+    }
+
+    return progress.requested;
+};

--- a/src/source/preload_tiles.js
+++ b/src/source/preload_tiles.js
@@ -3,8 +3,43 @@
 import type Tile from './tile.js';
 import type {CameraOptions} from '../ui/camera.js';
 import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
-import type {TilesPreloadProgress} from './source_cache.js';
 
+/**
+ * Tiles preloading progress state.
+ *
+ * @typedef {Object} TilesPreloadProgress
+ * @property {number} completed Number of completed tiles.
+ * @property {number} errored Number of errored tiles.
+ * @property {number} requested Number of requested tiles.
+ * @property {number} pending Number of pending tiles.
+ */
+export type TilesPreloadProgress = {
+  completed: number,
+  errored: number,
+  requested: number,
+  pending: number,
+};
+
+/**
+ * Preloads tiles in the requested viewport.
+ *
+ * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
+ *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
+ * @param {Object} [options] Options supports all properties from {@link CameraOptions}.
+ * @param {Function} [callback] Called when each of the requested tiles is ready or errored.
+ * @returns {number} Number of tiles to load.
+ * @example
+ * map.addSource('id', {
+ *     type: 'vector',
+ *     url: 'mapbox://mapbox.mapbox-streets-v8'
+ * });
+ *
+ * map.getSource('id').preloadTiles(bbox, {padding: 20}, ({requested, pending, completed, errored}) => {
+ *     if (pending === 0) {
+ *         map.fitBounds(bbox, {duration:0});
+ *     }
+ * });
+ */
 export const preloadTiles = function(bounds: LngLatBoundsLike, options?: CameraOptions, callback?: (progress: TilesPreloadProgress) => void): number {
     const progress = {
         errored: 0,

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -9,6 +9,7 @@ import {postTurnstileEvent} from '../util/mapbox.js';
 import TileBounds from './tile_bounds.js';
 import Texture from '../render/texture.js';
 import browser from '../util/browser.js';
+import {preloadTiles} from './preload_tiles.js';
 
 import {cacheEntryPossiblyAdded} from '../util/tile_request_cache.js';
 
@@ -23,6 +24,9 @@ import type {
     RasterSourceSpecification,
     RasterDEMSourceSpecification
 } from '../style-spec/types.js';
+import type {CameraOptions} from '../ui/camera.js';
+import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
+import type {TilesPreloadProgress} from './preload_tiles.js';
 
 class RasterTileSource extends Evented implements Source {
     type: 'raster' | 'raster-dem';
@@ -158,6 +162,30 @@ class RasterTileSource extends Evented implements Source {
     unloadTile(tile: Tile, callback: Callback<void>) {
         if (tile.texture) this.map.painter.saveTileTexture(tile.texture);
         callback();
+    }
+
+    /**
+     * Preloads tiles in the requested viewport.
+     *
+     * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
+     *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
+     * @param {Object} [options] Options supports all properties from {@link CameraOptions}.
+     * @param {Function} [callback] Called when each of the requested tiles is ready or errored.
+     * @returns {number} Number of tiles to load.
+     * @example
+     * map.addSource('mapbox-dem', {
+     *     'type': 'raster-dem',
+     *     'url': 'mapbox://mapbox.mapbox-terrain-dem-v1'
+     * });
+     *
+     * map.getSource('id').preloadTiles(bbox, {padding: 20}, ({requested, pending, completed, errored}) => {
+     *     if (pending === 0) {
+     *         map.fitBounds(bbox, {duration:0});
+     *     }
+     * });
+     */
+    preloadTiles(bounds: LngLatBoundsLike, options?: CameraOptions, callback?: (progress: TilesPreloadProgress) => void): number {
+        return preloadTiles.call(this, bounds, options, callback);
     }
 
     hasTransition() {

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -8,9 +8,6 @@ import type Map from '../ui/map.js';
 import type Tile from './tile.js';
 import type {OverscaledTileID} from './tile_id.js';
 import type {Callback} from '../types/callback.js';
-import type {CameraOptions} from '../ui/camera.js';
-import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
-import type {TilesPreloadProgress} from './source_cache.js';
 import {CanonicalTileID} from './tile_id.js';
 
 /**

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -140,31 +140,6 @@ export const setType = function (name: string, type: Class<Source>) {
     sourceTypes[name] = type;
 };
 
-export const preloadTiles = function(bounds: LngLatBoundsLike, options?: CameraOptions, callback?: (progress: TilesPreloadProgress) => void): number {
-    const progress = {
-        errored: 0,
-        completed: 0,
-        pending: 0,
-        requested: 0,
-    };
-
-    function tileLoaded(err: ?Error, _: ?Tile) {
-        if (err) progress.errored++;
-        else progress.completed++;
-        progress.pending = progress.requested - (progress.errored + progress.completed);
-
-        // $FlowFixMe
-        callback(progress);
-    }
-
-    const sourceCaches = this.map.style._getSourceCaches(this.id);
-    for (const sourceCache of sourceCaches) {
-        progress.requested += sourceCache.preloadTiles(bounds, options, callback ? tileLoaded : undefined);
-    }
-
-    return progress.requested;
-};
-
 export interface Actor {
     send(type: string, data: Object, callback: Callback<any>): void;
 }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -921,6 +921,28 @@ class SourceCache extends Evented {
         }
         this._cache.filter(tile => !tile.hasDependency(namespaces, keys));
     }
+
+    preloadTiles(bounds: LngLatBoundsLike, options?: CameraOptions) {
+        const calculatedOptions = this.map.cameraForBounds(bounds, options);
+        if (!calculatedOptions) return this;
+
+        const transform = this.transform.clone();
+        transform.zoom = calculatedOptions.zoom;
+        transform.center = calculatedOptions.center;
+
+        const tileIDs = transform.coveringTiles({
+            tileSize: this._source.tileSize,
+            minzoom: this._source.minzoom,
+            maxzoom: this._source.maxzoom,
+            roundZoom: this._source.roundZoom,
+            reparseOverscaled: this._source.reparseOverscaled,
+            isTerrainDEM: this.usedForTerrain
+        });
+
+        for (const tileID of tileIDs) {
+            this._addTile(tileID);
+        }
+    }
 }
 
 SourceCache.maxOverzooming = 10;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -21,13 +21,6 @@ import type {QueryGeometry, TilespaceQueryGeometry} from '../style/query_geometr
 import type {CameraOptions} from '../ui/camera.js';
 import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
 
-export type TilesPreloadProgress = {
-  completed: number,
-  errored: number,
-  requested: number,
-  pending: number,
-};
-
 /**
  * `SourceCache` is responsible for
  *

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -938,6 +938,7 @@ class SourceCache extends Evented {
      *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
      * @param {Object} [options] Options supports all properties from {@link CameraOptions}.
      * @param {Function} callback Called when the requested tile is ready or errored.
+     * @returns {number} Number of tiles to load.
      */
     preloadTiles(bounds: LngLatBoundsLike, options?: CameraOptions, callback?: Callback<Tile>): number {
         const transform = this.transform.clone();
@@ -964,7 +965,8 @@ class SourceCache extends Evented {
 
         const painter = this.map ? this.map.painter : null;
         for (const tileID of tileIDs) {
-            const tile = new Tile(tileID, this._source.tileSize * tileID.overscaleFactor(), this.transform.tileZoom, painter, this._source.type === 'raster' || this._source.type === 'raster-dem');
+            const isRaster = this._source.type === 'raster' || this._source.type === 'raster-dem';
+            const tile = new Tile(tileID, this._source.tileSize * tileID.overscaleFactor(), this.transform.tileZoom, painter, isRaster);
             this._loadTile(tile, tileLoaded.bind(this, tile, tileID.key, tile.state));
         }
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -310,6 +310,13 @@ class VectorTileSource extends Evented implements Source {
         }
     }
 
+    preloadTiles(bounds: LngLatBoundsLike, options?: CameraOptions) {
+        const sourceCaches = this.map.style._getSourceCaches(this.id);
+        for (const sourceCache of sourceCaches) {
+            sourceCache.preloadTiles(bounds, options);
+        }
+    }
+
     hasTransition() {
         return false;
     }

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -315,6 +315,7 @@ class VectorTileSource extends Evented implements Source {
 
     /**
      * Preloads tiles in the requested viewport.
+     *
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
      *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
      * @param {Object} [options] Options supports all properties from {@link CameraOptions}.
@@ -337,7 +338,7 @@ class VectorTileSource extends Evented implements Source {
         let pending = 0;
         let requested = 0;
 
-        function tileLoaded(err: ?Error, tile: ?Tile) {
+        function tileLoaded(err: ?Error, _: ?Tile) {
             if (err) errored++;
             else completed++;
             pending = requested - (errored + completed);

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -10,7 +10,7 @@ import {ResourceType} from '../util/ajax.js';
 import browser from '../util/browser.js';
 import {cacheEntryPossiblyAdded} from '../util/tile_request_cache.js';
 import {DedupedRequest, loadVectorTile} from './vector_tile_worker_source.js';
-import {preloadTiles} from './source.js';
+import {preloadTiles} from './preload_tiles.js';
 
 import type {Source} from './source.js';
 import type {OverscaledTileID} from './tile_id.js';

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -24,7 +24,7 @@ import type Actor from '../util/actor.js';
 import type {LoadVectorTileResult} from './vector_tile_worker_source.js';
 import type {CameraOptions} from '../ui/camera.js';
 import type {LngLatBoundsLike} from '../geo/lng_lat_bounds.js';
-import type {TilesPreloadProgress} from './source_cache.js';
+import type {TilesPreloadProgress} from './preload_tiles.js';
 
 /**
  * A source containing vector tiles in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/reference/).
@@ -323,12 +323,12 @@ class VectorTileSource extends Evented implements Source {
      * @param {Function} [callback] Called when each of the requested tiles is ready or errored.
      * @returns {number} Number of tiles to load.
      * @example
-     * map.addSource('some id', {
+     * map.addSource('id', {
      *     type: 'vector',
      *     url: 'mapbox://mapbox.mapbox-streets-v8'
      * });
      *
-     * map.getSource('some id').preloadTiles(bbox, {padding: 20}, ({pending}) => {
+     * map.getSource('id').preloadTiles(bbox, {padding: 20}, ({requested, pending, completed, errored}) => {
      *     if (pending === 0) {
      *         map.fitBounds(bbox, {duration:0});
      *     }


### PR DESCRIPTION
## Launch Checklist

This PR allows loading tiles for regions ahead of time before traveling to that location

The API is similar to that of [Map#fitBounds](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#fitbounds):

```js
map.addSource('id', {
    type: 'vector',
    url: 'mapbox://mapbox.mapbox-streets-v8'
});

const bbox = [[-79, 43], [-73, 45]];

map.getSource('id').preloadTiles(bbox, {padding: 20}, ({requested, pending, completed, errored}) => {
    if (pending === 0) {
        map.fitBounds(bbox, {duration:0});
    }
});
```

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>feature: add source preload tiles method</changelog>`
