### PR TITLE
Add height lift uniform to fill extrusion shaders when globe is enabled

### DIFF
--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -64,7 +64,8 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    float top_offset = float(t > 0.0) * u_height_lift;
+    // If t > 0 (top) we always add the lift, otherwise (group) we only add it if z > 0
+    float top_offset = float((t + pos.z) > 0.0) * u_height_lift;
     vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
     vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (pos.z + top_offset));
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, pos.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * pos.z;

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -17,6 +17,7 @@ uniform vec2 u_merc_center;
 uniform vec3 u_tile_id;
 uniform float u_zoom_transition;
 uniform vec3 u_up_dir;
+uniform float u_height_lift;
 #endif
 
 varying vec4 v_color;
@@ -63,11 +64,12 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    vec3 globeNormal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
-    vec3 globePos = a_pos_3 + globeNormal * u_tile_up_scale * pos.z;
-    vec3 mercPos = mercator_tile_position(u_inv_rot_matrix, pos.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * pos.z;
+    float top_offset = float(t > 0.0) * u_height_lift;
+    vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
+    vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (pos.z + top_offset));
+    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, pos.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * pos.z;
 
-    pos = mix_globe_mercator(globePos, mercPos, u_zoom_transition);
+    pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #endif
 
     float hidden = float(centroid_pos.x == 0.0 && centroid_pos.y == 1.0);

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -22,6 +22,7 @@ uniform vec2 u_merc_center;
 uniform vec3 u_tile_id;
 uniform float u_zoom_transition;
 uniform vec3 u_up_dir;
+uniform float u_height_lift;
 #endif
 
 varying vec2 v_pos_a;
@@ -89,11 +90,12 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    vec3 globeNormal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
-    vec3 globePos = a_pos_3 + globeNormal * u_tile_up_scale * p.z;
-    vec3 mercPos = mercator_tile_position(u_inv_rot_matrix, p.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * p.z;
+    float top_offset = float(t > 0.0) * u_height_lift;
+    vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
+    vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (p.z + top_offset));
+    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, p.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * p.z;
 
-    p = mix_globe_mercator(globePos, mercPos, u_zoom_transition);
+    p = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #endif
 
     float hidden = float(centroid_pos.x == 0.0 && centroid_pos.y == 1.0);

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -90,7 +90,8 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    float top_offset = float(t > 0.0) * u_height_lift;
+    // If t > 0 (top) we always add the lift, otherwise (group) we only add it if z > 0
+    float top_offset = float((t + p.z) > 0.0) * u_height_lift;
     vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
     vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (p.z + top_offset));
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, p.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * p.z;


### PR DESCRIPTION
This PR:
- Adds `u_height_lift` uniform to fill extrusion vertex shaders. This value is only used when the globe is enabled, to apply a minimum height to all fill extrusions depending on the zoom level. (Which is needed to prevent collision with the curvature of the globe with large but low height surfaces.)
- Rename variables in the same shaders to use snake case format.

### Why is this needed?

The problem: the curvature of the globe collides with  the top surface of large fill extrusions. Even if we add more vertices to follow the globe's shape, it would still peak through those shapes which have zero height. (Illustrated below.)

![Screenshot 2021-11-30 at 11 27 58](https://user-images.githubusercontent.com/2576246/144020997-86c53599-c4a3-4538-bac6-1d0fef735275.png)

This PR adds a uniform lift to those surfaces. This way even zero height fill extrusions will have a slight elevation when the globe projection is enabled, but proportionally they will be still correct as all other fill extrusions will get the same lift.

![Screenshot 2021-11-30 at 11 27 34](https://user-images.githubusercontent.com/2576246/144020986-881b9ab4-664e-4f61-b117-77798162deda.png)

Note: this is a temporary workaround and later we could try to resample the fill extrusions with the same resolution that we use for the surface of the globe.