### PR TITLE
Simplify projection types

### DIFF
--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -1,62 +1,61 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import {clamp, wrap, degToRad, radToDeg} from '../../util/util.js';
+import {clamp, wrap, degToRad, radToDeg, extend} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
-import {vec2} from 'gl-matrix';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
 
-export default {
-    name: 'albers',
-    range: [4, 7],
+import cylindricalEqualArea from './cylindrical_equal_area.js';
 
-    center: [-96, 37.5],
-    parallels: [29.5, 45.5],
+export default function({
+    center = [-96, 37.5],
+    parallels = [29.5, 45.5]
+}: ProjectionSpecification) {
 
-    conic: true,
+    const name = 'albers';
+    const range: [number, number] = [4, 7];
 
-    // based on https://github.com/d3/d3-geo-projection, MIT-licensed
-
-    initializeConstants() {
-        if (this.constants && vec2.exactEquals(this.parallels, this.constants.parallels)) {
-            return;
-        }
-
-        const sy0 = Math.sin(degToRad(this.parallels[0]));
-        const n = (sy0 + Math.sin(degToRad(this.parallels[1]))) / 2;
-        const c = 1 + sy0 * (2 * n - sy0);
-        const r0 = Math.sqrt(c) / n;
-
-        this.constants = {n, c, r0, parallels: this.parallels};
-    },
-
-    project(lng: number, lat: number) {
-        this.initializeConstants();
-
-        const lambda = degToRad(lng - this.center[0]);
-        const phi = degToRad(lat);
-
-        const {n, c, r0} = this.constants;
-        const r = Math.sqrt(c - 2 * n * Math.sin(phi)) / n;
-        const x = r * Math.sin(lambda * n);
-        const y = r * Math.cos(lambda * n) - r0;
-        return {x, y};
-    },
-
-    unproject(x: number, y: number) {
-        this.initializeConstants();
-        const {n, c, r0} = this.constants;
-
-        const r0y = r0 + y;
-        let l = Math.atan2(x, Math.abs(r0y)) * Math.sign(r0y);
-        if (r0y * n < 0) {
-            l -= Math.PI * Math.sign(x) * Math.sign(r0y);
-        }
-        const dt = degToRad(this.center[0]) * n;
-        l = wrap(l, -Math.PI - dt, Math.PI - dt);
-
-        const lng = radToDeg(l / n) + this.center[0];
-        const phi = Math.asin(clamp((c - (x * x + r0y * r0y) * n * n) / (2 * n), -1, 1));
-        const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
-
-        return new LngLat(lng, lat);
+    // parallels that are equal but with opposite signs (e.g. [10, -10])
+    // create a cylindrical projection so we replace the
+    // project and unproject functions with equivalent cylindrical version
+    if (Math.abs(parallels[0] + parallels[1]) < 0.01) {
+        return extend({name, range, center, parallels}, cylindricalEqualArea(parallels[0]));
     }
-};
+
+    const sy0 = Math.sin(degToRad(parallels[0]));
+    const n = (sy0 + Math.sin(degToRad(parallels[1]))) / 2;
+    const c = 1 + sy0 * (2 * n - sy0);
+    const r0 = Math.sqrt(c) / n;
+
+    return {
+        name,
+        range,
+        center,
+        parallels,
+
+        // based on https://github.com/d3/d3-geo-projection, MIT-licensed
+        project(lng: number, lat: number) {
+            const lambda = degToRad(lng - center[0]);
+            const phi = degToRad(lat);
+            const r = Math.sqrt(c - 2 * n * Math.sin(phi)) / n;
+            const x = r * Math.sin(lambda * n);
+            const y = r * Math.cos(lambda * n) - r0;
+            return {x, y};
+        },
+
+        unproject(x: number, y: number) {
+            const r0y = r0 + y;
+            let l = Math.atan2(x, Math.abs(r0y)) * Math.sign(r0y);
+            if (r0y * n < 0) {
+                l -= Math.PI * Math.sign(x) * Math.sign(r0y);
+            }
+            const dt = degToRad(center[0]) * n;
+            l = wrap(l, -Math.PI - dt, Math.PI - dt);
+
+            const lng = radToDeg(l / n) + center[0];
+            const phi = Math.asin(clamp((c - (x * x + r0y * r0y) * n * n) / (2 * n), -1, 1));
+            const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+
+            return new LngLat(lng, lat);
+        }
+    };
+}

--- a/src/geo/projection/equal_earth.js
+++ b/src/geo/projection/equal_earth.js
@@ -2,6 +2,7 @@
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
 
 const a1 = 1.340264;
 const a2 = -0.081106;
@@ -9,10 +10,10 @@ const a3 = 0.000893;
 const a4 = 0.003796;
 const M = Math.sqrt(3) / 2;
 
-export default {
+export default (_: ProjectionSpecification) => ({
     name: 'equalEarth',
-    center: [0, 0],
-    range: [3.5, 7],
+    center: ([0, 0]: [number, number]),
+    range: ([3.5, 7]: [number, number]),
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed
@@ -55,4 +56,4 @@ export default {
 
         return new LngLat(lng, lat);
     }
-};
+});

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -2,12 +2,13 @@
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
 
-export default {
+export default (_: ProjectionSpecification) => ({
     name: 'equirectangular',
     wrap: true,
-    center: [0, 0],
-    range: [3.5, 7],
+    center: ([0, 0]: [number, number]),
+    range: ([3.5, 7]: [number, number]),
     project(lng: number, lat: number) {
         const x = 0.5 + lng / 360;
         const y = 0.5 - lat / 360;
@@ -18,4 +19,4 @@ export default {
         const lat = clamp((0.5 - y) * 360, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
         return new LngLat(lng, lat);
     }
-};
+});

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -6,21 +6,18 @@ import lambertConformalConic from './lambert.js';
 import mercator from './mercator.js';
 import naturalEarth from './natural_earth.js';
 import winkelTripel from './winkel_tripel.js';
-import cylindricalEqualArea from './cylindrical_equal_area.js';
 import LngLat from '../lng_lat.js';
-import {extend} from '../../util/util.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 
-export type Projection = {
+export interface Projection {
     name: string,
     center: [number, number],
     parallels?: [number, number],
     range?: [number, number],
-    conic?: boolean,
     wrap?: boolean,
     project: (lng: number, lat: number) => {x: number, y: number},
     unproject: (x: number, y: number) => LngLat
-};
+}
 
 const projections = {
     albers,
@@ -32,28 +29,8 @@ const projections = {
     winkelTripel
 };
 
-function getConicProjection(projection: Projection, config: ProjectionSpecification) {
-    if (config.parallels) {
-        // parallels that are equal but with opposite signs (e.g. [10, -10])
-        // create a cylindrical projection so we replace the
-        // project and unproject functions with equivalent cylindrical versions
-        if (Math.abs(config.parallels[0] + config.parallels[1]) < 0.01) {
-            let cylindricalFunctions = cylindricalEqualArea((config: any).parallels[0]);
-
-            if (config.name === 'lambertConformalConic') {
-                const {project, unproject} = projections['mercator'];
-                cylindricalFunctions = {wrap: true, project, unproject};
-            }
-
-            return extend({}, projection, config, cylindricalFunctions);
-        }
-    }
-
-    return extend({}, projection, config);
-}
-
-export function getProjection(config: ProjectionSpecification) {
-    const projection = projections[config.name];
-    if (!projection) throw new Error(`Invalid projection name: ${config.name}`);
-    return projection.conic ? getConicProjection(projection, config) : projection;
+export function getProjection(config: ProjectionSpecification): Projection {
+    const createProjection = projections[config.name];
+    if (!createProjection) throw new Error(`Invalid projection name: ${config.name}`);
+    return createProjection(config);
 }

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -1,8 +1,10 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import {clamp, degToRad, radToDeg} from '../../util/util.js';
+import {clamp, degToRad, radToDeg, extend} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
-import {vec2} from 'gl-matrix';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
+
+import mercator from './mercator.js';
 
 const halfPi = Math.PI / 2;
 
@@ -10,73 +12,70 @@ function tany(y) {
     return Math.tan((halfPi + y) / 2);
 }
 
-export default {
-    name: 'lambertConformalConic',
-    range: [3.5, 7],
+export default function ({
+    center = [0, 30],
+    parallels = [30, 30]
+}: ProjectionSpecification) {
+    const name = 'lambertConformalConic';
+    const range: [number, number] = [3.5, 7];
 
-    center: [0, 30],
-    parallels: [30, 30],
-
-    conic: true,
-
-    initializeConstants() {
-        if (this.constants && vec2.exactEquals(this.parallels, this.constants.parallels)) {
-            return;
-        }
-
-        const y0 = degToRad(this.parallels[0]);
-        const y1 = degToRad(this.parallels[1]);
-        const cy0 = Math.cos(y0);
-        const n = y0 === y1 ? Math.sin(y0) : Math.log(cy0 / Math.cos(y1)) / Math.log(tany(y1) / tany(y0));
-        const f = cy0 * Math.pow(tany(y0), n) / n;
-
-        this.constants = {n, f, parallels: this.parallels};
-    },
-
-    project(lng: number, lat: number) {
-        this.initializeConstants();
-
-        // based on https://github.com/d3/d3-geo, MIT-licensed
-        lat = degToRad(lat);
-        lng = degToRad(lng - this.center[0]);
-
-        const epsilon = 1e-6;
-        const {n, f} = this.constants;
-
-        if (f > 0) {
-            if (lat < -halfPi + epsilon) lat = -halfPi + epsilon;
-        } else {
-            if (lat > halfPi - epsilon) lat = halfPi - epsilon;
-        }
-
-        const r = f / Math.pow(tany(lat), n);
-        const x = r * Math.sin(n * lng);
-        const y = f - r * Math.cos(n * lng);
-
-        return {
-            x: (x / Math.PI + 0.5) * 0.5,
-            y: 1 - (y / Math.PI + 0.5) * 0.5
-        };
-    },
-
-    unproject(x: number, y: number) {
-        this.initializeConstants();
-
-        // based on https://github.com/d3/d3-geo, MIT-licensed
-        x = (2 * x - 0.5) * Math.PI;
-        y = (2 * (1 - y) - 0.5) * Math.PI;
-        const {n, f} = this.constants;
-        const fy = f - y;
-        const signFy = Math.sign(fy);
-        const r = Math.sign(n) * Math.sqrt(x * x + fy * fy);
-        let l = Math.atan2(x, Math.abs(fy)) * signFy;
-
-        if (fy * n < 0) l -= Math.PI * Math.sign(x) * signFy;
-
-        const lng = clamp(radToDeg(l / n) + this.center[0], -180, 180);
-        const phi = 2 * Math.atan(Math.pow(f / r, 1 / n)) - halfPi;
-        const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
-
-        return new LngLat(lng, lat);
+    // parallels that are equal but with opposite signs (e.g. [10, -10])
+    // create a cylindrical projection so we replace the
+    // project and unproject functions with equivalent cylindrical version
+    if (Math.abs(parallels[0] + parallels[1]) < 0.01) {
+        return extend(mercator(), {name, range, center, parallels});
     }
-};
+
+    const y0 = degToRad(parallels[0]);
+    const y1 = degToRad(parallels[1]);
+    const cy0 = Math.cos(y0);
+    const n = y0 === y1 ? Math.sin(y0) : Math.log(cy0 / Math.cos(y1)) / Math.log(tany(y1) / tany(y0));
+    const f = cy0 * Math.pow(tany(y0), n) / n;
+
+    return {
+        name,
+        range,
+        center,
+        parallels,
+
+        project(lng: number, lat: number) {
+            // based on https://github.com/d3/d3-geo, MIT-licensed
+            lat = degToRad(lat);
+            lng = degToRad(lng - center[0]);
+
+            const epsilon = 1e-6;
+            if (f > 0) {
+                if (lat < -halfPi + epsilon) lat = -halfPi + epsilon;
+            } else {
+                if (lat > halfPi - epsilon) lat = halfPi - epsilon;
+            }
+
+            const r = f / Math.pow(tany(lat), n);
+            const x = r * Math.sin(n * lng);
+            const y = f - r * Math.cos(n * lng);
+
+            return {
+                x: (x / Math.PI + 0.5) * 0.5,
+                y: 1 - (y / Math.PI + 0.5) * 0.5
+            };
+        },
+
+        unproject(x: number, y: number) {
+            // based on https://github.com/d3/d3-geo, MIT-licensed
+            x = (2 * x - 0.5) * Math.PI;
+            y = (2 * (1 - y) - 0.5) * Math.PI;
+            const fy = f - y;
+            const signFy = Math.sign(fy);
+            const r = Math.sign(n) * Math.sqrt(x * x + fy * fy);
+            let l = Math.atan2(x, Math.abs(fy)) * signFy;
+
+            if (fy * n < 0) l -= Math.PI * Math.sign(x) * signFy;
+
+            const lng = clamp(radToDeg(l / n) + center[0], -180, 180);
+            const phi = 2 * Math.atan(Math.pow(f / r, 1 / n)) - halfPi;
+            const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+
+            return new LngLat(lng, lat);
+        }
+    };
+}

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,11 +1,12 @@
 // @flow
 import {mercatorXfromLng, mercatorYfromLat, lngFromMercatorX, latFromMercatorY} from '../mercator_coordinate.js';
 import LngLat from '../lng_lat.js';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
 
-export default {
+export default (_: ?ProjectionSpecification) => ({
     name: 'mercator',
     wrap: true,
-    center: [0, 0],
+    center: ([0, 0]: [number, number]),
     project(lng: number, lat: number) {
         const x = mercatorXfromLng(lng);
         const y = mercatorYfromLat(lat);
@@ -16,4 +17,4 @@ export default {
         const lat = latFromMercatorY(y);
         return new LngLat(lng, lat);
     }
-};
+});

--- a/src/geo/projection/natural_earth.js
+++ b/src/geo/projection/natural_earth.js
@@ -2,13 +2,14 @@
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
 
 const maxPhi = degToRad(MAX_MERCATOR_LATITUDE);
 
-export default {
+export default (_: ProjectionSpecification) => ({
     name: 'naturalEarth',
-    center: [0, 0],
-    range: [3.5, 7],
+    center: ([0, 0]: [number, number]),
+    range: ([3.5, 7]: [number, number]),
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed
@@ -52,4 +53,4 @@ export default {
 
         return new LngLat(lng, lat);
     }
-};
+});

--- a/src/geo/projection/winkel_tripel.js
+++ b/src/geo/projection/winkel_tripel.js
@@ -2,13 +2,14 @@
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
 import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import type {ProjectionSpecification} from '../../style-spec/types.js';
 
 const maxPhi = degToRad(MAX_MERCATOR_LATITUDE);
 
-export default {
+export default (_: ProjectionSpecification) => ({
     name: 'winkelTripel',
-    center: [0, 0],
-    range: [3.5, 7],
+    center: ([0, 0]: [number, number]),
+    range: ([3.5, 7]: [number, number]),
 
     project(lng: number, lat: number) {
         lat = degToRad(lat);
@@ -64,4 +65,4 @@ export default {
 
         return new LngLat(radToDeg(lambda), radToDeg(phi));
     }
-};
+});


### PR DESCRIPTION
This PR refactors projection implementations to be factory functions instead of objects, allowing us to:

- Simplify caching logic in projections — instead of `initializeConstants` and equality checks, we can directly calculate any variables to use in the closure.
- Hide internal details of cylindrical edge cases of conic projections in corresponding files.
- Type projections more soundly (this will be more important when we upgrade to newer Flow).