### PR TITLE
Remove outdated DOM utilities and simplify marker SVG

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -84,7 +84,7 @@ class AttributionControl {
     }
 
     onRemove() {
-        DOM.remove(this._container);
+        this._container.remove();
 
         this._map.off('styledata', this._updateData);
         this._map.off('sourcedata', this._updateData);

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -66,7 +66,7 @@ class FullscreenControl {
     }
 
     onRemove() {
-        DOM.remove(this._controlContainer);
+        this._controlContainer.remove();
         this._map = (null: any);
         window.document.removeEventListener(this._fullscreenchange, this._changeIcon);
     }

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -170,7 +170,7 @@ class GeolocateControl extends Evented {
             this._accuracyCircleMarker.remove();
         }
 
-        DOM.remove(this._container);
+        this._container.remove();
         this._map.off('zoom', this._onZoom);
         this._map = (undefined: any);
         numberOfWatches = 0;

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -47,7 +47,7 @@ class LogoControl {
     }
 
     onRemove() {
-        DOM.remove(this._container);
+        this._container.remove();
         this._map.off('sourcedata', this._updateLogo);
         this._map.off('resize', this._updateCompact);
     }

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -124,7 +124,7 @@ class NavigationControl {
     }
 
     onRemove() {
-        DOM.remove(this._container);
+        this._container.remove();
         if (this.options.showZoom) {
             this._map.off('zoom', this._updateZoomButtons);
         }
@@ -172,11 +172,11 @@ class MouseRotateWrapper {
         if (pitch) this.mousePitch = new MousePitchHandler({clickTolerance: map.dragRotate._mousePitch._clickTolerance});
 
         bindAll(['mousedown', 'mousemove', 'mouseup', 'touchstart', 'touchmove', 'touchend', 'reset'], this);
-        DOM.addEventListener(element, 'mousedown', this.mousedown);
-        DOM.addEventListener(element, 'touchstart', this.touchstart, {passive: false});
-        DOM.addEventListener(element, 'touchmove', this.touchmove);
-        DOM.addEventListener(element, 'touchend', this.touchend);
-        DOM.addEventListener(element, 'touchcancel', this.reset);
+        element.addEventListener('mousedown', this.mousedown);
+        element.addEventListener('touchstart', this.touchstart, {passive: false});
+        element.addEventListener('touchmove', this.touchmove);
+        element.addEventListener('touchend', this.touchend);
+        element.addEventListener('touchcancel', this.reset);
     }
 
     down(e: MouseEvent, point: Point) {
@@ -197,24 +197,24 @@ class MouseRotateWrapper {
 
     off() {
         const element = this.element;
-        DOM.removeEventListener(element, 'mousedown', this.mousedown);
-        DOM.removeEventListener(element, 'touchstart', this.touchstart, {passive: false});
-        DOM.removeEventListener(element, 'touchmove', this.touchmove);
-        DOM.removeEventListener(element, 'touchend', this.touchend);
-        DOM.removeEventListener(element, 'touchcancel', this.reset);
+        element.removeEventListener('mousedown', this.mousedown);
+        element.removeEventListener('touchstart', this.touchstart, {passive: false});
+        element.removeEventListener('touchmove', this.touchmove);
+        element.removeEventListener('touchend', this.touchend);
+        element.removeEventListener('touchcancel', this.reset);
         this.offTemp();
     }
 
     offTemp() {
         DOM.enableDrag();
-        DOM.removeEventListener(window, 'mousemove', this.mousemove);
-        DOM.removeEventListener(window, 'mouseup', this.mouseup);
+        window.removeEventListener('mousemove', this.mousemove);
+        window.removeEventListener('mouseup', this.mouseup);
     }
 
     mousedown(e: MouseEvent) {
         this.down(extend({}, e, {ctrlKey: true, preventDefault: () => e.preventDefault()}), DOM.mousePos(this.element, e));
-        DOM.addEventListener(window, 'mousemove', this.mousemove);
-        DOM.addEventListener(window, 'mouseup', this.mouseup);
+        window.addEventListener('mousemove', this.mousemove);
+        window.addEventListener('mouseup', this.mouseup);
     }
 
     mousemove(e: MouseEvent) {

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -67,7 +67,7 @@ class ScaleControl {
     }
 
     onRemove() {
-        DOM.remove(this._container);
+        this._container.remove();
         this._map.off('move', this._onMove);
         this._map = (undefined: any);
     }

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -114,8 +114,7 @@ class BoxZoomHandler {
 
         this._map._requestDomTask(() => {
             if (this._box) {
-                DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
-
+                this._box.style.transform = `translate(${minX}px,${minY}px)`;
                 this._box.style.width = `${maxX - minX}px`;
                 this._box.style.height = `${maxY - minY}px`;
             }
@@ -163,7 +162,7 @@ class BoxZoomHandler {
         this._container.classList.remove('mapboxgl-crosshair');
 
         if (this._box) {
-            DOM.remove(this._box);
+            this._box.remove();
             this._box = (null: any);
         }
 

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -153,7 +153,7 @@ class HandlerManager {
     _updatingCamera: boolean;
     _changes: Array<[HandlerResult, Object, any]>;
     _previousActiveHandlers: { [string]: Handler };
-    _listeners: Array<[HTMLElement, string, void | {passive?: boolean, capture?: boolean}]>;
+    _listeners: Array<[HTMLElement, string, void | EventListenerOptionsOrUseCapture]>;
     _trackingEllipsoid: TrackingEllipsoid;
     _dragOrigin: ?vec3;
 
@@ -219,13 +219,15 @@ class HandlerManager {
         ];
 
         for (const [target, type, listenerOptions] of this._listeners) {
-            DOM.addEventListener(target, type, target === window.document ? this.handleWindowEvent : this.handleEvent, listenerOptions);
+            const listener = target === window.document ? this.handleWindowEvent : this.handleEvent;
+            target.addEventListener((type: any), (listener: any), listenerOptions);
         }
     }
 
     destroy() {
         for (const [target, type, listenerOptions] of this._listeners) {
-            DOM.removeEventListener(target, type, target === window.document ? this.handleWindowEvent : this.handleEvent, listenerOptions);
+            const listener = target === window.document ? this.handleWindowEvent : this.handleEvent;
+            target.removeEventListener((type: any), (listener: any), listenerOptions);
         }
     }
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -295,7 +295,7 @@ export default class Marker extends Evented {
             delete this._map;
         }
         this._clearFadeTimer();
-        DOM.remove(this._element);
+        this._element.remove();
         if (this._popup) this._popup.remove();
         return this;
     }
@@ -549,7 +549,7 @@ export default class Marker extends Evented {
             if (!this._map) return;
 
             if (this._element && this._pos && this._anchor) {
-                DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
+                this._element.style.transform = `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`;
             }
 
             if ((this._map.getTerrain() || this._map.getFog()) && !this._fadeTimer) {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -127,21 +127,17 @@ export default class Marker extends Evented {
                 viewBox: `0 0 ${defaultWidth} ${defaultHeight}`
             }, this._element);
 
-            const defs = DOM.createSVG('defs', {}, svg);
-            const gradient = DOM.createSVG('radialGradient', {id: 'shadowGradient'}, defs);
+            const gradient = DOM.createSVG('radialGradient', {id: 'shadowGradient'}, DOM.createSVG('defs', {}, svg));
             DOM.createSVG('stop', {offset: '10%', 'stop-opacity': 0.4}, gradient);
             DOM.createSVG('stop', {offset: '100%', 'stop-opacity': 0.05}, gradient);
-
             DOM.createSVG('ellipse', {cx: 13.5, cy: 34.8, rx: 10.5, ry: 5.25, fill: 'url(#shadowGradient)'}, svg); // shadow
 
             DOM.createSVG('path', { // marker shape
                 fill: this._color,
                 d: 'M27,13.5C27,19.07 20.25,27 14.75,34.5C14.02,35.5 12.98,35.5 12.25,34.5C6.75,27 0,19.22 0,13.5C0,6.04 6.04,0 13.5,0C20.96,0 27,6.04 27,13.5Z'
             }, svg);
-
             DOM.createSVG('path', { // border
                 opacity: 0.25,
-                fill: 'black',
                 d: 'M13.5,0C6.04,0 0,6.04 0,13.5C0,19.22 6.75,27 12.25,34.5C13,35.52 14.02,35.5 14.75,34.5C20.25,27 27,19.07 27,13.5C27,6.04 20.96,0 13.5,0ZM13.5,1C20.42,1 26,6.58 26,13.5C26,15.9 24.5,19.18 22.22,22.74C19.95,26.3 16.71,30.14 13.94,33.91C13.74,34.18 13.61,34.32 13.5,34.44C13.39,34.32 13.26,34.18 13.06,33.91C10.28,30.13 7.41,26.31 5.02,22.77C2.62,19.23 1,15.95 1,13.5C1,6.58 6.58,1 13.5,1Z'
             }, svg);
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -67,7 +67,7 @@ export default class Marker extends Evented {
     _popup: ?Popup;
     _lngLat: LngLat;
     _pos: ?Point;
-    _color: ?string;
+    _color: string;
     _scale: number;
     _defaultMarker: boolean;
     _draggable: boolean;
@@ -117,100 +117,43 @@ export default class Marker extends Evented {
             this._element.setAttribute('aria-label', 'Map marker');
 
             // create default map marker SVG
-            const svg = DOM.createNS('http://www.w3.org/2000/svg', 'svg');
             const defaultHeight = 41;
             const defaultWidth = 27;
-            svg.setAttributeNS(null, 'display', 'block');
-            svg.setAttributeNS(null, 'height', `${defaultHeight}px`);
-            svg.setAttributeNS(null, 'width', `${defaultWidth}px`);
-            svg.setAttributeNS(null, 'viewBox', `0 0 ${defaultWidth} ${defaultHeight}`);
 
-            const markerLarge = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            markerLarge.setAttributeNS(null, 'stroke', 'none');
-            markerLarge.setAttributeNS(null, 'stroke-width', '1');
-            markerLarge.setAttributeNS(null, 'fill', 'none');
-            markerLarge.setAttributeNS(null, 'fill-rule', 'evenodd');
+            const svg = DOM.createSVG('svg', {
+                display: 'block',
+                height: `${defaultHeight * this._scale}px`,
+                width: `${defaultWidth * this._scale}px`,
+                viewBox: `0 0 ${defaultWidth} ${defaultHeight}`
+            }, this._element);
 
-            const page1 = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            page1.setAttributeNS(null, 'fill-rule', 'nonzero');
-
-            const shadow = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            shadow.setAttributeNS(null, 'transform', 'translate(3.0, 29.0)');
-            shadow.setAttributeNS(null, 'fill', '#000000');
+            const page1 = DOM.createSVG('g', {'fill-rule': 'nonzero'}, svg);
+            const shadow = DOM.createSVG('g', {transform: 'translate(3.0, 29.0)', 'fill': '#000000'}, page1);
 
             const ellipses = [
-                {'rx': '10.5', 'ry': '5.25002273'},
-                {'rx': '10.5', 'ry': '5.25002273'},
-                {'rx': '9.5', 'ry': '4.77275007'},
-                {'rx': '8.5', 'ry': '4.29549936'},
-                {'rx': '7.5', 'ry': '3.81822308'},
-                {'rx': '6.5', 'ry': '3.34094679'},
-                {'rx': '5.5', 'ry': '2.86367051'},
-                {'rx': '4.5', 'ry': '2.38636864'}
+                ['10.5', '5.25002273'],
+                ['10.5', '5.25002273'],
+                ['9.5', '4.77275007'],
+                ['8.5', '4.29549936'],
+                ['7.5', '3.81822308'],
+                ['6.5', '3.34094679'],
+                ['5.5', '2.86367051'],
+                ['4.5', '2.38636864']
             ];
-
-            for (const data of ellipses) {
-                const ellipse = DOM.createNS('http://www.w3.org/2000/svg', 'ellipse');
-                ellipse.setAttributeNS(null, 'opacity', '0.04');
-                ellipse.setAttributeNS(null, 'cx', '10.5');
-                ellipse.setAttributeNS(null, 'cy', '5.80029008');
-                ellipse.setAttributeNS(null, 'rx', data['rx']);
-                ellipse.setAttributeNS(null, 'ry', data['ry']);
-                shadow.appendChild(ellipse);
+            for (const [rx, ry] of ellipses) {
+                DOM.createSVG('ellipse', {opacity: '0.04', cx: '10.5', cy: '5.80029008', rx, ry}, shadow);
             }
 
-            const background = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            background.setAttributeNS(null, 'fill', this._color);
+            const background = DOM.createSVG('g', {fill: this._color}, page1);
+            DOM.createSVG('path', {d: 'M27,13.5 C27,19.074644 20.250001,27.000002 14.75,34.500002 C14.016665,35.500004 12.983335,35.500004 12.25,34.500002 C6.7499993,27.000002 0,19.222562 0,13.5 C0,6.0441559 6.0441559,0 13.5,0 C20.955844,0 27,6.0441559 27,13.5 Z'}, background);
 
-            const bgPath = DOM.createNS('http://www.w3.org/2000/svg', 'path');
-            bgPath.setAttributeNS(null, 'd', 'M27,13.5 C27,19.074644 20.250001,27.000002 14.75,34.500002 C14.016665,35.500004 12.983335,35.500004 12.25,34.500002 C6.7499993,27.000002 0,19.222562 0,13.5 C0,6.0441559 6.0441559,0 13.5,0 C20.955844,0 27,6.0441559 27,13.5 Z');
+            const border = DOM.createSVG('g', {opacity: '0.25', fill: '#000000'}, page1);
+            DOM.createSVG('path', {d: 'M13.5,0 C6.0441559,0 0,6.0441559 0,13.5 C0,19.222562 6.7499993,27 12.25,34.5 C13,35.522727 14.016664,35.500004 14.75,34.5 C20.250001,27 27,19.074644 27,13.5 C27,6.0441559 20.955844,0 13.5,0 Z M13.5,1 C20.415404,1 26,6.584596 26,13.5 C26,15.898657 24.495584,19.181431 22.220703,22.738281 C19.945823,26.295132 16.705119,30.142167 13.943359,33.908203 C13.743445,34.180814 13.612715,34.322738 13.5,34.441406 C13.387285,34.322738 13.256555,34.180814 13.056641,33.908203 C10.284481,30.127985 7.4148684,26.314159 5.015625,22.773438 C2.6163816,19.232715 1,15.953538 1,13.5 C1,6.584596 6.584596,1 13.5,1 Z'}, border);
+            DOM.createSVG('g', {transform: 'translate(6.0, 7.0)', fill: '#FFFFFF'}, page1);
 
-            background.appendChild(bgPath);
-
-            const border = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            border.setAttributeNS(null, 'opacity', '0.25');
-            border.setAttributeNS(null, 'fill', '#000000');
-
-            const borderPath = DOM.createNS('http://www.w3.org/2000/svg', 'path');
-            borderPath.setAttributeNS(null, 'd', 'M13.5,0 C6.0441559,0 0,6.0441559 0,13.5 C0,19.222562 6.7499993,27 12.25,34.5 C13,35.522727 14.016664,35.500004 14.75,34.5 C20.250001,27 27,19.074644 27,13.5 C27,6.0441559 20.955844,0 13.5,0 Z M13.5,1 C20.415404,1 26,6.584596 26,13.5 C26,15.898657 24.495584,19.181431 22.220703,22.738281 C19.945823,26.295132 16.705119,30.142167 13.943359,33.908203 C13.743445,34.180814 13.612715,34.322738 13.5,34.441406 C13.387285,34.322738 13.256555,34.180814 13.056641,33.908203 C10.284481,30.127985 7.4148684,26.314159 5.015625,22.773438 C2.6163816,19.232715 1,15.953538 1,13.5 C1,6.584596 6.584596,1 13.5,1 Z');
-
-            border.appendChild(borderPath);
-
-            const maki = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            maki.setAttributeNS(null, 'transform', 'translate(6.0, 7.0)');
-            maki.setAttributeNS(null, 'fill', '#FFFFFF');
-
-            const circleContainer = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            circleContainer.setAttributeNS(null, 'transform', 'translate(8.0, 8.0)');
-
-            const circle1 = DOM.createNS('http://www.w3.org/2000/svg', 'circle');
-            circle1.setAttributeNS(null, 'fill', '#000000');
-            circle1.setAttributeNS(null, 'opacity', '0.25');
-            circle1.setAttributeNS(null, 'cx', '5.5');
-            circle1.setAttributeNS(null, 'cy', '5.5');
-            circle1.setAttributeNS(null, 'r', '5.4999962');
-
-            const circle2 = DOM.createNS('http://www.w3.org/2000/svg', 'circle');
-            circle2.setAttributeNS(null, 'fill', '#FFFFFF');
-            circle2.setAttributeNS(null, 'cx', '5.5');
-            circle2.setAttributeNS(null, 'cy', '5.5');
-            circle2.setAttributeNS(null, 'r', '5.4999962');
-
-            circleContainer.appendChild(circle1);
-            circleContainer.appendChild(circle2);
-
-            page1.appendChild(shadow);
-            page1.appendChild(background);
-            page1.appendChild(border);
-            page1.appendChild(maki);
-            page1.appendChild(circleContainer);
-
-            svg.appendChild(page1);
-
-            svg.setAttributeNS(null, 'height', `${defaultHeight * this._scale}px`);
-            svg.setAttributeNS(null, 'width', `${defaultWidth * this._scale}px`);
-
-            this._element.appendChild(svg);
+            const circles = DOM.createSVG('g', {transform: 'translate(8.0, 8.0)'}, page1);
+            DOM.createSVG('circle', {fill: '#000000', opacity: '0.25', cx: '5.5', cy: '5.5', r: '5.4999962'}, circles);
+            DOM.createSVG('circle', {fill: '#FFFFFF', cx: '5.5', cy: '5.5', r: '5.4999962'}, circles);
 
             // if no element and no offset option given apply an offset for the default marker
             // the -14 as the y value of the default marker offset was determined as follows

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -127,40 +127,32 @@ export default class Marker extends Evented {
                 viewBox: `0 0 ${defaultWidth} ${defaultHeight}`
             }, this._element);
 
-            const page1 = DOM.createSVG('g', {'fill-rule': 'nonzero'}, svg);
-            const shadow = DOM.createSVG('g', {transform: 'translate(3.0, 29.0)', 'fill': '#000000'}, page1);
+            const defs = DOM.createSVG('defs', {}, svg);
+            const gradient = DOM.createSVG('radialGradient', {id: 'shadowGradient'}, defs);
+            DOM.createSVG('stop', {offset: '10%', 'stop-opacity': 0.4}, gradient);
+            DOM.createSVG('stop', {offset: '100%', 'stop-opacity': 0.05}, gradient);
 
-            const ellipses = [
-                ['10.5', '5.25002273'],
-                ['10.5', '5.25002273'],
-                ['9.5', '4.77275007'],
-                ['8.5', '4.29549936'],
-                ['7.5', '3.81822308'],
-                ['6.5', '3.34094679'],
-                ['5.5', '2.86367051'],
-                ['4.5', '2.38636864']
-            ];
-            for (const [rx, ry] of ellipses) {
-                DOM.createSVG('ellipse', {opacity: '0.04', cx: '10.5', cy: '5.80029008', rx, ry}, shadow);
-            }
+            DOM.createSVG('ellipse', {cx: 13.5, cy: 34.8, rx: 10.5, ry: 5.25, fill: 'url(#shadowGradient)'}, svg); // shadow
 
-            const background = DOM.createSVG('g', {fill: this._color}, page1);
-            DOM.createSVG('path', {d: 'M27,13.5 C27,19.074644 20.250001,27.000002 14.75,34.500002 C14.016665,35.500004 12.983335,35.500004 12.25,34.500002 C6.7499993,27.000002 0,19.222562 0,13.5 C0,6.0441559 6.0441559,0 13.5,0 C20.955844,0 27,6.0441559 27,13.5 Z'}, background);
+            DOM.createSVG('path', { // marker shape
+                fill: this._color,
+                d: 'M27,13.5C27,19.07 20.25,27 14.75,34.5C14.02,35.5 12.98,35.5 12.25,34.5C6.75,27 0,19.22 0,13.5C0,6.04 6.04,0 13.5,0C20.96,0 27,6.04 27,13.5Z'
+            }, svg);
 
-            const border = DOM.createSVG('g', {opacity: '0.25', fill: '#000000'}, page1);
-            DOM.createSVG('path', {d: 'M13.5,0 C6.0441559,0 0,6.0441559 0,13.5 C0,19.222562 6.7499993,27 12.25,34.5 C13,35.522727 14.016664,35.500004 14.75,34.5 C20.250001,27 27,19.074644 27,13.5 C27,6.0441559 20.955844,0 13.5,0 Z M13.5,1 C20.415404,1 26,6.584596 26,13.5 C26,15.898657 24.495584,19.181431 22.220703,22.738281 C19.945823,26.295132 16.705119,30.142167 13.943359,33.908203 C13.743445,34.180814 13.612715,34.322738 13.5,34.441406 C13.387285,34.322738 13.256555,34.180814 13.056641,33.908203 C10.284481,30.127985 7.4148684,26.314159 5.015625,22.773438 C2.6163816,19.232715 1,15.953538 1,13.5 C1,6.584596 6.584596,1 13.5,1 Z'}, border);
-            DOM.createSVG('g', {transform: 'translate(6.0, 7.0)', fill: '#FFFFFF'}, page1);
+            DOM.createSVG('path', { // border
+                opacity: 0.25,
+                fill: 'black',
+                d: 'M13.5,0C6.04,0 0,6.04 0,13.5C0,19.22 6.75,27 12.25,34.5C13,35.52 14.02,35.5 14.75,34.5C20.25,27 27,19.07 27,13.5C27,6.04 20.96,0 13.5,0ZM13.5,1C20.42,1 26,6.58 26,13.5C26,15.9 24.5,19.18 22.22,22.74C19.95,26.3 16.71,30.14 13.94,33.91C13.74,34.18 13.61,34.32 13.5,34.44C13.39,34.32 13.26,34.18 13.06,33.91C10.28,30.13 7.41,26.31 5.02,22.77C2.62,19.23 1,15.95 1,13.5C1,6.58 6.58,1 13.5,1Z'
+            }, svg);
 
-            const circles = DOM.createSVG('g', {transform: 'translate(8.0, 8.0)'}, page1);
-            DOM.createSVG('circle', {fill: '#000000', opacity: '0.25', cx: '5.5', cy: '5.5', r: '5.4999962'}, circles);
-            DOM.createSVG('circle', {fill: '#FFFFFF', cx: '5.5', cy: '5.5', r: '5.4999962'}, circles);
+            DOM.createSVG('circle', {fill: 'white', cx: 13.5, cy: 13.5, r: 5.5}, svg); // circle
 
             // if no element and no offset option given apply an offset for the default marker
             // the -14 as the y value of the default marker offset was determined as follows
             //
             // the marker tip is at the center of the shadow ellipse from the default svg
-            // the y value of the center of the shadow ellipse relative to the svg top left is "shadow transform translate-y (29.0) + ellipse cy (5.80029008)"
-            // offset to the svg center "height (41 / 2)" gives (29.0 + 5.80029008) - (41 / 2) and rounded for an integer pixel offset gives 14
+            // the y value of the center of the shadow ellipse relative to the svg top left is 34.8
+            // offset to the svg center "height (41 / 2)" gives 34.8 - (41 / 2) and rounded for an integer pixel offset gives 14
             // negative is used to move the marker up from the center so the tip is at the Marker lngLat
             this._offset = Point.convert(options && options.offset || [0, -14]);
         } else {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -204,11 +204,11 @@ export default class Popup extends Evented {
      */
     remove() {
         if (this._content) {
-            DOM.remove(this._content);
+            this._content.remove();
         }
 
         if (this._container) {
-            DOM.remove(this._container);
+            this._container.remove();
             delete this._container;
         }
 
@@ -621,7 +621,7 @@ export default class Popup extends Evented {
             const offsetedPos = pos.add(offset[anchor]).round();
             this._map._requestDomTask(() => {
                 if (this._container && anchor) {
-                    DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
+                    this._container.style.transform = `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`;
                 }
             });
         }

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -15,7 +15,7 @@ DOM.create = function (tagName: string, className: ?string, container?: HTMLElem
     return el;
 };
 
-DOM.createSVG = function (tagName: string, attributes: {[string]: string}, container?: HTMLElement) {
+DOM.createSVG = function (tagName: string, attributes: {[string]: string | number}, container?: HTMLElement) {
     const el = window.document.createElementNS('http://www.w3.org/2000/svg', tagName);
     for (const name of Object.keys(attributes)) {
         el.setAttributeNS(null, name, attributes[name]);

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -15,8 +15,12 @@ DOM.create = function (tagName: string, className: ?string, container?: HTMLElem
     return el;
 };
 
-DOM.createNS = function (namespaceURI: string, tagName: string) {
-    const el = window.document.createElementNS(namespaceURI, tagName);
+DOM.createSVG = function (tagName: string, attributes: {[string]: string}, container?: HTMLElement) {
+    const el = window.document.createElementNS('http://www.w3.org/2000/svg', tagName);
+    for (const name of Object.keys(attributes)) {
+        el.setAttributeNS(null, name, attributes[name]);
+    }
+    if (container) container.appendChild(el);
     return el;
 };
 

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -37,43 +37,6 @@ DOM.enableDrag = function () {
     }
 };
 
-DOM.setTransform = function(el: HTMLElement, value: string) {
-    el.style.transform = value;
-};
-
-// Feature detection for {passive: false} support in add/removeEventListener.
-let passiveSupported = false;
-
-try {
-    // https://github.com/facebook/flow/issues/285
-    // $FlowFixMe
-    const options = Object.defineProperty({}, "passive", {
-        get() { // eslint-disable-line
-            passiveSupported = true;
-        }
-    });
-    window.addEventListener("test", options, options);
-    window.removeEventListener("test", options, options);
-} catch (err) {
-    passiveSupported = false;
-}
-
-DOM.addEventListener = function(target: *, type: *, callback: *, options: {passive?: boolean, capture?: boolean} = {}) {
-    if ('passive' in options && passiveSupported) {
-        target.addEventListener(type, callback, options);
-    } else {
-        target.addEventListener(type, callback, options.capture);
-    }
-};
-
-DOM.removeEventListener = function(target: *, type: *, callback: *, options: {passive?: boolean, capture?: boolean} = {}) {
-    if ('passive' in options && passiveSupported) {
-        target.removeEventListener(type, callback, options);
-    } else {
-        target.removeEventListener(type, callback, options.capture);
-    }
-};
-
 // Suppress the next click, but only if it's immediate.
 const suppressClick: MouseEventListener = function (e) {
     e.preventDefault();
@@ -113,12 +76,6 @@ DOM.mouseButton = function (e: MouseEvent) {
         return 0;
     }
     return e.button;
-};
-
-DOM.remove = function(node: HTMLElement) {
-    if (node.parentNode) {
-        node.parentNode.removeChild(node);
-    }
 };
 
 function getScaledPoint(el: HTMLElement, rect: ClientRect, e: MouseEvent | WheelEvent | Touch) {


### PR DESCRIPTION
- Remove `DOM.setTransform(el, ...)` in favor of `el.style.transform = ...`.
- Remove `DOM.remove` in favor of `el.remove()` (supported everywhere except IE11).
- Remove `DOM.addEventListener`/`DOM.removeEventListener` in favor of `el.addEventListener` (options / passive listeners supported everywhere except IE11).
- Introduce `DOM.createSVG` utility in place of `DOM.createNS` which we only used for SVG.
- Overhaul default marker SVG generation code, removing redundant elements and simplifying code so that default markers are now more performant while looking slightly nicer — previously the shadow was approximated by 8 ellipses of varying opacity, now it's one with a gradient.
- Consequently, reduce the gzipped bundle size by 688 bytes.

Marker before:

![image](https://user-images.githubusercontent.com/25395/144307736-e01c4e9f-5782-4145-a943-0e48bbec13cf.png)

Marker after:

![image](https://user-images.githubusercontent.com/25395/144307792-c5182d9e-c899-4cc5-8287-814cbe0b9d0d.png)

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - n/a write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improved default marker performance.</changelog>`
