### PR TITLE
Globe View: Allow terrain render pipeline to be used without preexisting DEM sources

### DIFF
--- a/debug/globe-view.html
+++ b/debug/globe-view.html
@@ -26,7 +26,7 @@
     <label><input id='show-overdraw-checkbox' type='checkbox'> overdraw debug</label><br />
     <label><input id='freeze-tile-coverage-checkbox' type='checkbox'> freeze tile coverage </label><br />
     <label><input id='terrain-checkbox' type='checkbox'> terrain</label><br />
-    <label><input id='globe-checkbox' type='checkbox'> globe</label><br />
+    <label><input id='globe-checkbox' type='checkbox' checked> globe</label><br />
     <label><input id='show-terrain-wireframe-checkbox' type='checkbox'> terrain wireframe</label><br />
     <label><input id='satellite-checkbox' type='checkbox'> satellite</label><br />
     <label><input id='buildings-checkbox' type='checkbox'> buildings</label><br />
@@ -47,7 +47,8 @@ var map = window.map = new mapboxgl.Map({
     center: [-122.45814, 37.76159],
     style: 'mapbox://styles/mapbox/streets-v11',
     // style: 'mapbox://styles/claretrainor/ck2pc4ljf1jbe1codiy7oxzjg', // Style with additional traffic vector source.
-    hash: true
+    hash: true,
+    projection: 'globe'
 });
 
 map.addControl(new mapboxgl.NavigationControl());

--- a/src/style-spec/validate/validate_terrain.js
+++ b/src/style-spec/validate/validate_terrain.js
@@ -3,7 +3,6 @@ import ValidationError from '../error/validation_error.js';
 import validate from './validate.js';
 import getType from '../util/get_type.js';
 import {unbundle} from '../util/unbundle_jsonlint.js';
-import {DrapeRenderMode} from '../../style/terrain.js';
 
 export default function validateTerrain(options) {
     const terrain = options.value;
@@ -45,17 +44,15 @@ export default function validateTerrain(options) {
         }
     }
 
-    if (terrain.drapeRenderMode === DrapeRenderMode.elevated) {
-        if (!terrain.source) {
-            errors.push(new ValidationError(key, terrain, `terrain is missing required property "source"`));
-        } else {
-            const source = style.sources && style.sources[terrain.source];
-            const sourceType = source && unbundle(source.type);
-            if (!source) {
-                errors.push(new ValidationError(key, terrain.source, `source "${terrain.source}" not found`));
-            } else if (sourceType !== 'raster-dem') {
-                errors.push(new ValidationError(key, terrain.source, `terrain cannot be used with a source of type ${sourceType}, it only be used with a "raster-dem" source type`));
-            }
+    if (!terrain.source) {
+        errors.push(new ValidationError(key, terrain, `terrain is missing required property "source"`));
+    } else {
+        const source = style.sources && style.sources[terrain.source];
+        const sourceType = source && unbundle(source.type);
+        if (!source) {
+            errors.push(new ValidationError(key, terrain.source, `source "${terrain.source}" not found`));
+        } else if (sourceType !== 'raster-dem') {
+            errors.push(new ValidationError(key, terrain.source, `terrain cannot be used with a source of type ${sourceType}, it only be used with a "raster-dem" source type`));
         }
     }
 

--- a/src/style-spec/validate/validate_terrain.js
+++ b/src/style-spec/validate/validate_terrain.js
@@ -3,6 +3,7 @@ import ValidationError from '../error/validation_error.js';
 import validate from './validate.js';
 import getType from '../util/get_type.js';
 import {unbundle} from '../util/unbundle_jsonlint.js';
+import {DrapeRenderMode} from '../../style/terrain.js';
 
 export default function validateTerrain(options) {
     const terrain = options.value;
@@ -44,15 +45,17 @@ export default function validateTerrain(options) {
         }
     }
 
-    if (!terrain.source) {
-        errors.push(new ValidationError(key, terrain, `terrain is missing required property "source"`));
-    } else {
-        const source = style.sources && style.sources[terrain.source];
-        const sourceType = source && unbundle(source.type);
-        if (!source) {
-            errors.push(new ValidationError(key, terrain.source, `source "${terrain.source}" not found`));
-        } else if (sourceType !== 'raster-dem') {
-            errors.push(new ValidationError(key, terrain.source, `terrain cannot be used with a source of type ${sourceType}, it only be used with a "raster-dem" source type`));
+    if (terrain.drapeRenderMode === DrapeRenderMode.elevated) {
+        if (!terrain.source) {
+            errors.push(new ValidationError(key, terrain, `terrain is missing required property "source"`));
+        } else {
+            const source = style.sources && style.sources[terrain.source];
+            const sourceType = source && unbundle(source.type);
+            if (!source) {
+                errors.push(new ValidationError(key, terrain.source, `source "${terrain.source}" not found`));
+            } else if (sourceType !== 'raster-dem') {
+                errors.push(new ValidationError(key, terrain.source, `terrain cannot be used with a source of type ${sourceType}, it only be used with a "raster-dem" source type`));
+            }
         }
     }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -330,8 +330,9 @@ class Style extends Evented {
         this.dispatcher.broadcast('setLayers', this._serializeLayers(this._order));
 
         this.light = new Light(this.stylesheet.light);
-        if (this.stylesheet.terrain) {
-            this._createTerrain(this.stylesheet.terrain, this.terrain ? this.terrain.drapeRenderMode : DrapeRenderMode.elevated);
+        const terrainSetForDrapingOnly = this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.deferred;
+        if (this.stylesheet.terrain && !terrainSetForDrapingOnly) {
+            this._createTerrain(this.stylesheet.terrain, DrapeRenderMode.elevated);
         }
         if (this.stylesheet.fog) {
             this._createFog(this.stylesheet.fog);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -331,7 +331,7 @@ class Style extends Evented {
 
         this.light = new Light(this.stylesheet.light);
         if (this.stylesheet.terrain) {
-            this._createTerrain(this.stylesheet.terrain, this.terrain ? this.terrain.drapeRenderMode : DrapeRenderMode.elevated);
+            this._createTerrain(this.stylesheet.terrain, DrapeRenderMode.elevated);
         }
         if (this.stylesheet.fog) {
             this._createFog(this.stylesheet.fog);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -356,9 +356,13 @@ class Style extends Evented {
         const projection = this.map.transform.projection;
 
         if (this._loaded) {
-            const terrain = this.getTerrain();
-            if (!terrain && !this.stylesheet.terrain && projection.requiresDraping) {
-                this.setTerrainForDraping();
+            if (projection.requiresDraping) {
+                const hasTerrain = this.getTerrain() || this.stylesheet.terrain;
+                if (!hasTerrain) {
+                    this.setTerrainForDraping();
+                }
+            } else if (!this.getTerrain()) {
+                this.setTerrain(null);
             }
         }
 
@@ -1458,16 +1462,18 @@ class Style extends Evented {
             return;
         }
 
-        // Input validation and source object unrolling
-        if (typeof terrainOptions.source === 'object') {
-            const id = 'terrain-dem-src';
-            this.addSource(id, ((terrainOptions.source): any));
-            terrainOptions = clone(terrainOptions);
-            terrainOptions = (extend(terrainOptions, {source: id}): any);
-        }
+        if (drapeRenderMode === DrapeRenderMode.elevated) {
+            // Input validation and source object unrolling
+            if (typeof terrainOptions.source === 'object') {
+                const id = 'terrain-dem-src';
+                this.addSource(id, ((terrainOptions.source): any));
+                terrainOptions = clone(terrainOptions);
+                terrainOptions = (extend(terrainOptions, {source: id}): any);
+            }
 
-        if (this._validate(validateStyle.terrain, 'terrain', terrainOptions)) {
-            return;
+            if (this._validate(validateStyle.terrain, 'terrain', terrainOptions)) {
+                return;
+            }
         }
 
         // Enabling

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -361,7 +361,7 @@ class Style extends Evented {
                 if (!hasTerrain) {
                     this.setTerrainForDraping();
                 }
-            } else if (!this.getTerrain()) {
+            } else if (this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.deferred) {
                 this.setTerrain(null);
             }
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -331,7 +331,7 @@ class Style extends Evented {
 
         this.light = new Light(this.stylesheet.light);
         if (this.stylesheet.terrain) {
-            this._createTerrain(this.stylesheet.terrain, DrapeRenderMode.elevated);
+            this._createTerrain(this.stylesheet.terrain, this.terrain ? this.terrain.drapeRenderMode : DrapeRenderMode.elevated);
         }
         if (this.stylesheet.fog) {
             this._createFog(this.stylesheet.fog);

--- a/src/style/terrain.js
+++ b/src/style/terrain.js
@@ -14,6 +14,11 @@ type Props = {|
     "exaggeration": DataConstantProperty<number>,
 |};
 
+export const DrapeRenderMode = {
+    deferred: 0,
+    elevated: 1
+};
+
 const properties: Properties<Props> = new Properties({
     "source": new DataConstantProperty(styleSpec.terrain.source),
     "exaggeration": new DataConstantProperty(styleSpec.terrain.exaggeration),
@@ -25,12 +30,14 @@ class Terrain extends Evented {
     _transitionable: Transitionable<Props>;
     _transitioning: Transitioning<Props>;
     properties: PossiblyEvaluated<Props>;
+    drapeRenderMode: number;
 
-    constructor(terrainOptions: TerrainSpecification) {
+    constructor(terrainOptions: TerrainSpecification, drapeRenderMode: number) {
         super();
         this._transitionable = new Transitionable(properties);
         this.set(terrainOptions);
         this._transitioning = this._transitionable.untransitioned();
+        this.drapeRenderMode = drapeRenderMode;
     }
 
     get() {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2427,7 +2427,11 @@ class Map extends Camera {
      */
     setTerrain(terrain: TerrainSpecification) {
         this._lazyInitEmptyStyle();
-        this.style.setTerrain(terrain);
+        if (!terrain && this.transform.projection.requiresDraping) {
+            this.style.setTerrainForDraping();
+        } else {
+            this.style.setTerrain(terrain);
+        }
         this._averageElevationLastSampledAt = -Infinity;
         return this._update(true);
     }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -294,6 +294,69 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('Setting globe projection as part of the style enables draping but does not enable terrain', (t) => {
+            const map = createMap(t, {style: createStyle(), projection: 'globe'});
+            t.equal(map.getProjection().name, 'globe');
+            const initStyleObj = map.style;
+            t.spy(initStyleObj, 'setTerrain');
+            map.on('style.load', () => {
+                t.equal(initStyleObj.setTerrain.callCount, 1);
+                t.ok(map.style.terrain);
+                t.equal(map.getTerrain(), null);
+                t.end();
+            });
+        });
+
+        t.test('Setting globe projection on the map enables draping but does not enable terrain', (t) => {
+            const map = createMap(t, {style: createStyle()});
+            t.equal(map.getProjection().name, 'mercator');
+            const initStyleObj = map.style;
+            t.spy(initStyleObj, 'setTerrain');
+            map.on('style.load', () => {
+                map.setProjection('globe');
+                t.equal(initStyleObj.setTerrain.callCount, 1);
+                t.ok(map.style.terrain);
+                t.equal(map.getTerrain(), null);
+                t.end();
+            });
+        });
+
+        t.test('Setting globe projection retains style.terrain when terrain is set to null', (t) => {
+            const map = createMap(t, {style: createStyle(), projection: 'globe'});
+            t.equal(map.getProjection().name, 'globe');
+            const initStyleObj = map.style;
+            t.spy(initStyleObj, 'setTerrain');
+            map.on('style.load', () => {
+                map.setTerrain(null);
+                t.equal(initStyleObj.setTerrain.callCount, 2);
+                t.ok(map.style.terrain);
+                t.equal(map.getTerrain(), null);
+                t.end();
+            });
+        });
+
+        t.test('Setting globe and terrain as part of the style retains the terrain properties', (t) => {
+            const style = createStyle();
+            style['projection'] = {
+                'name': 'globe'
+            };
+            style['sources']['mapbox-dem'] = {
+                'type': 'raster-dem',
+                'tiles': ['http://example.com/{z}/{x}/{y}.png']
+            };
+            style['terrain'] = {
+                'source': 'mapbox-dem'
+            };
+            const map = createMap(t, {style});
+            map.on('style.load', () => {
+                t.equal(map.getProjection().name, 'globe');
+                t.ok(map.style.terrain);
+                t.deepEqual(map.getTerrain(), style['terrain']);
+
+                t.end();
+            });
+        });
+
         t.test('updating terrain triggers style diffing using setTerrain operation', (t) => {
             t.test('removing terrain', (t) => {
                 const style = createStyle();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -342,7 +342,7 @@ test('Map', (t) => {
                     map.setStyle(styleWithTerrain);
                     t.equal(initStyleObj, map.style);
                     t.equal(initStyleObj.setState.callCount, 1);
-                    t.equal(initStyleObj.setTerrain.callCount, 1);
+                    t.equal(initStyleObj.setTerrain.callCount, 2);
                     t.ok(map.style.terrain);
                     t.end();
                 });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -342,7 +342,7 @@ test('Map', (t) => {
                     map.setStyle(styleWithTerrain);
                     t.equal(initStyleObj, map.style);
                     t.equal(initStyleObj.setState.callCount, 1);
-                    t.equal(initStyleObj.setTerrain.callCount, 2);
+                    t.equal(initStyleObj.setTerrain.callCount, 1);
                     t.ok(map.style.terrain);
                     t.end();
                 });


### PR DESCRIPTION
- Add `terrain:MockSourceCache` with a 1x1px DEM data placeholder: this allows a few things:
  - Lets the user to select globe projection without preexisting terrain enabled, nor DEM data sources added. This allows the renderer to go through the draping pipeline when globe is enabled, effectively removing the dependency globe / DEM data.
  - Allows `globe` to be set as part of the map constructor, similarly to other projections
- Update style flow to allow for the following use cases, combined with terrain on or off:
  - gobe set as part of the projection API: `map.setProjection('globe')`
  - globe set as part of the map constructor: `new mapboxgl.Map({projection: 'globe'})`
  - globe set as part of the style json