### PR TITLE
doc: update link to projection spec

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -96,7 +96,7 @@
     },
     "projection": {
       "type": "projection",
-      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain, fog, sky and CustomLayerInterface are not supported for projections other than mercator.",
+      "doc": "The projection the map should be rendered in. Supported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain, fog, sky and CustomLayerInterface are not supported for projections other than mercator.",
       "example": {
         "name": "albers",
         "center": [-154, 50],

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1002,9 +1002,9 @@ class Map extends Camera {
     /** @section {Point conversion} */
 
     /**
-     * Returns a {@link ProjectionSpecification} object that defines the current map projection.
+     * Returns a [projection](https://www.mapbox.com/mapbox-gl-style-spec/#projection) object that defines the current map projection.
      *
-     * @returns {ProjectionSpecification} The {@link ProjectionSpecification} defining the current map projection.
+     * @returns {ProjectionSpecification} The [projection](https://www.mapbox.com/mapbox-gl-style-spec/#projection) defining the current map projection.
      * @example
      * const projection = map.getProjection();
      */
@@ -1016,7 +1016,7 @@ class Map extends Camera {
      * Sets the map's projection. If called with `null` or `undefined`, the map will reset to Mercator.
      *
      * @param {ProjectionSpecification | string | null | undefined} projection The projection that the map should be rendered in.
-     * This can be a {@link ProjectionSpecification} object or a string of the projection's name.
+     * This can be a [projection](https://www.mapbox.com/mapbox-gl-style-spec/#projection) object or a string of the projection's name.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setProjection('albers');

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1002,9 +1002,9 @@ class Map extends Camera {
     /** @section {Point conversion} */
 
     /**
-     * Returns a [projection](https://www.mapbox.com/mapbox-gl-style-spec/#projection) object that defines the current map projection.
+     * Returns a [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) object that defines the current map projection.
      *
-     * @returns {ProjectionSpecification} The [projection](https://www.mapbox.com/mapbox-gl-style-spec/#projection) defining the current map projection.
+     * @returns {ProjectionSpecification} The [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) defining the current map projection.
      * @example
      * const projection = map.getProjection();
      */
@@ -1016,7 +1016,7 @@ class Map extends Camera {
      * Sets the map's projection. If called with `null` or `undefined`, the map will reset to Mercator.
      *
      * @param {ProjectionSpecification | string | null | undefined} projection The projection that the map should be rendered in.
-     * This can be a [projection](https://www.mapbox.com/mapbox-gl-style-spec/#projection) object or a string of the projection's name.
+     * This can be a [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) object or a string of the projection's name.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setProjection('albers');


### PR DESCRIPTION
## Launch Checklist

Use the link to the [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) page instead of `{@link ProjectionSpecification}`

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
