### PR TITLE
Fix `undefined is not an object` warning (Safari)

### DIFF
--- a/src/render/program.js
+++ b/src/render/program.js
@@ -211,7 +211,9 @@ class Program<Us: UniformBindings> {
         context.setCullFace(cullFaceMode);
 
         const names = Object.keys(this.fixedUniforms);
-        for (const name of names) this.fixedUniforms[name].set(uniformValues[name]);
+        for (const name of names) {
+            this.fixedUniforms[name].set(uniformValues[name]);
+        }
 
         if (configuration) {
             configuration.setUniforms(context, this.binderUniforms, currentProperties, {zoom: (zoom: any)});

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -211,7 +211,7 @@ class Program<Us: UniformBindings> {
         context.setCullFace(cullFaceMode);
 
         for (const name in this.fixedUniforms) {
-            if (uniformValues[name] !== undefined) this.fixedUniforms[name].set(uniformValues[name]);
+            this.fixedUniforms[name].set(uniformValues[name]);
         }
 
         if (configuration) {

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -214,7 +214,7 @@ class Program<Us: UniformBindings> {
             this.fixedUniforms[name].set(uniformValues[name]);
         }
 
-        if (configuration ) {
+        if (configuration) {
             configuration.setUniforms(context, this.binderUniforms, currentProperties, {zoom: (zoom: any)});
         }
 

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -210,8 +210,8 @@ class Program<Us: UniformBindings> {
         context.setColorMode(colorMode);
         context.setCullFace(cullFaceMode);
 
-        const names = Object.keys(this.fixedUniforms);
-        for (const name of names) {
+        const fixedUniformNames = Object.keys(this.fixedUniforms);
+        for (const name of fixedUniformNames) {
             this.fixedUniforms[name].set(uniformValues[name]);
         }
 

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -214,7 +214,7 @@ class Program<Us: UniformBindings> {
             this.fixedUniforms[name].set(uniformValues[name]);
         }
 
-        if (configuration) {
+        if (configuration ) {
             configuration.setUniforms(context, this.binderUniforms, currentProperties, {zoom: (zoom: any)});
         }
 

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -210,9 +210,8 @@ class Program<Us: UniformBindings> {
         context.setColorMode(colorMode);
         context.setCullFace(cullFaceMode);
 
-        for (const name in this.fixedUniforms) {
-            this.fixedUniforms[name].set(uniformValues[name]);
-        }
+        const names = Object.keys(this.fixedUniforms);
+        for (const name of names) this.fixedUniforms[name].set(uniformValues[name]);
 
         if (configuration) {
             configuration.setUniforms(context, this.binderUniforms, currentProperties, {zoom: (zoom: any)});

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -211,7 +211,7 @@ class Program<Us: UniformBindings> {
         context.setCullFace(cullFaceMode);
 
         for (const name in this.fixedUniforms) {
-            this.fixedUniforms[name].set(uniformValues[name]);
+            if (uniformValues[name] !== undefined) this.fixedUniforms[name].set(uniformValues[name]);
         }
 
         if (configuration) {

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -210,8 +210,7 @@ class Program<Us: UniformBindings> {
         context.setColorMode(colorMode);
         context.setCullFace(cullFaceMode);
 
-        const fixedUniformNames = Object.keys(this.fixedUniforms);
-        for (const name of fixedUniformNames) {
+        for (const name of Object.keys(this.fixedUniforms)) {
             this.fixedUniforms[name].set(uniformValues[name]);
         }
 

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -117,9 +117,7 @@ class UniformMatrix4f extends Uniform<Float32Array> {
     set(v: Float32Array): void {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
-        // unnecessary iteration:
-
-        if ((!!v[12] && v[12] !== this.current[12]) || (!!v[0] && v[0] !== this.current[0])) {
+        if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
             this.current = v;
             this.gl.uniformMatrix4fv(this.location, false, v);
             return;

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -117,6 +117,7 @@ class UniformMatrix4f extends Uniform<Float32Array> {
     set(v: Float32Array): void {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
+        // unnecessary iteration:
         if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
             this.current = v;
             this.gl.uniformMatrix4fv(this.location, false, v);

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -56,8 +56,6 @@ class Uniform2f extends Uniform<[number, number]> {
     }
 
     set(v: [number, number]): void {
-        if (v === undefined) return;
-
         if (v[0] !== this.current[0] || v[1] !== this.current[1]) {
             this.current = v;
             this.gl.uniform2f(this.location, v[0], v[1]);
@@ -72,8 +70,6 @@ class Uniform3f extends Uniform<[number, number, number]> {
     }
 
     set(v: [number, number, number]): void {
-        if (v === undefined) return;
-
         if (v[0] !== this.current[0] || v[1] !== this.current[1] || v[2] !== this.current[2]) {
             this.current = v;
             this.gl.uniform3f(this.location, v[0], v[1], v[2]);
@@ -88,8 +84,6 @@ class Uniform4f extends Uniform<[number, number, number, number]> {
     }
 
     set(v: [number, number, number, number]): void {
-        if (v === undefined) return;
-
         if (v[0] !== this.current[0] || v[1] !== this.current[1] ||
             v[2] !== this.current[2] || v[3] !== this.current[3]) {
             this.current = v;
@@ -124,8 +118,6 @@ class UniformMatrix4f extends Uniform<Float32Array> {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
         // unnecessary iteration:
-        if (v === undefined) return;
-
         if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
             this.current = v;
             this.gl.uniformMatrix4fv(this.location, false, v);

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -118,17 +118,19 @@ class UniformMatrix4f extends Uniform<Float32Array> {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
         // unnecessary iteration:
-        if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
-            this.current = v;
-            this.gl.uniformMatrix4fv(this.location, false, v);
-            return;
-        }
-
-        for (let i = 1; i < 16; i++) {
-            if (v[i] !== this.current[i]) {
+        if (v !== undefined) {
+            if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
                 this.current = v;
                 this.gl.uniformMatrix4fv(this.location, false, v);
-                break;
+                return;
+            }
+
+            for (let i = 1; i < 16; i++) {
+                if (v[i] !== this.current[i]) {
+                    this.current = v;
+                    this.gl.uniformMatrix4fv(this.location, false, v);
+                    break;
+                }
             }
         }
     }

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -56,6 +56,8 @@ class Uniform2f extends Uniform<[number, number]> {
     }
 
     set(v: [number, number]): void {
+        if (v === undefined) return;
+
         if (v[0] !== this.current[0] || v[1] !== this.current[1]) {
             this.current = v;
             this.gl.uniform2f(this.location, v[0], v[1]);
@@ -70,6 +72,8 @@ class Uniform3f extends Uniform<[number, number, number]> {
     }
 
     set(v: [number, number, number]): void {
+        if (v === undefined) return;
+
         if (v[0] !== this.current[0] || v[1] !== this.current[1] || v[2] !== this.current[2]) {
             this.current = v;
             this.gl.uniform3f(this.location, v[0], v[1], v[2]);
@@ -84,6 +88,8 @@ class Uniform4f extends Uniform<[number, number, number, number]> {
     }
 
     set(v: [number, number, number, number]): void {
+        if (v === undefined) return;
+
         if (v[0] !== this.current[0] || v[1] !== this.current[1] ||
             v[2] !== this.current[2] || v[3] !== this.current[3]) {
             this.current = v;
@@ -118,19 +124,18 @@ class UniformMatrix4f extends Uniform<Float32Array> {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
         // unnecessary iteration:
-        if (v !== undefined) {
-            if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
+        if (v === undefined) return;
+
+        if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
+            this.current = v;
+            this.gl.uniformMatrix4fv(this.location, false, v);
+            return;
+        }
+        for (let i = 1; i < 16; i++) {
+            if (v[i] !== this.current[i]) {
                 this.current = v;
                 this.gl.uniformMatrix4fv(this.location, false, v);
-                return;
-            }
-
-            for (let i = 1; i < 16; i++) {
-                if (v[i] !== this.current[i]) {
-                    this.current = v;
-                    this.gl.uniformMatrix4fv(this.location, false, v);
-                    break;
-                }
+                break;
             }
         }
     }

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -118,11 +118,13 @@ class UniformMatrix4f extends Uniform<Float32Array> {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
         // unnecessary iteration:
-        if (v[12] !== this.current[12] || v[0] !== this.current[0]) {
+
+        if ((!!v[12] && v[12] !== this.current[12]) || (!!v[0] && v[0] !== this.current[0])) {
             this.current = v;
             this.gl.uniformMatrix4fv(this.location, false, v);
             return;
         }
+
         for (let i = 1; i < 16; i++) {
             if (v[i] !== this.current[i]) {
                 this.current = v;


### PR DESCRIPTION
Closes #11095. After debugging, the t[12] issue is most likely a webkit bug issue. When throwing an error with the name and value of uniformValues if `uniformValues[name] === undefined` at [line 214 in program.js](https://github.com/mapbox/mapbox-gl-js/blob/main/src/render/program.js#L214), the name is always `u_is_size_zoom_constant` and value is always defined as 0. When changing the `for in` loop to a `for of` loop,  the error is not thrown after multiple attempts using the same interaction to trigger. Simply using a check for if uniformValues[name] is undefined hides the warning but still triggers the rendering issue (usually displayed by missing text inside of icons with text or missing text on streets).

You can trigger the error by opening Safari 15 in a private window, emptying the cache, and zooming in/out in a slow-to-medium motion using debug/index.html. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'