### PR TITLE
Fix GeoJSONSource#setData docs example

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -160,7 +160,10 @@ class GeoJSONSource extends Evented implements Source {
      * @example
      * map.addSource('source_id', {
      *     type: 'geojson',
-     *     data: {}
+     *     data: {
+     *         type: 'FeatureCollection',
+     *         features: []
+     *     }
      * });
      * const geojsonSource = map.getSource('source_id');
      * // Update the data after the GeoJSON source was created


### PR DESCRIPTION
## Launch Checklist

Tiny fix to the `GeoJSONSource#setData` example in the docs. It currently shows a method of adding an empty source that results in an error message because `data` is not a valid GeoJSON object.

h/t to @mvl22 for pointing out the error https://github.com/mapbox/mapbox-gl-js/issues/5986#issuecomment-986301766