### PR TITLE
Apply height lift on globe with terrain in fill extrusion shaders

### DIFF
--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -64,12 +64,14 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    // If t > 0 (top) we always add the lift, otherwise (group) we only add it if z > 0
-    float top_offset = float((t + pos.z) > 0.0) * u_height_lift;
+    float lift = u_height_lift;
+#ifndef TERRAIN
+    // If t > 0 (top) we always add the lift, otherwise (ground) we only add it if z > 0
+    lift = float((t + pos.z) > 0.0) * lift;
+#endif
     vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
-    vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (pos.z + top_offset));
+    vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (pos.z + lift));
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, pos.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * pos.z;
-
     pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #endif
 

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -90,12 +90,14 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    // If t > 0 (top) we always add the lift, otherwise (group) we only add it if z > 0
-    float top_offset = float((t + p.z) > 0.0) * u_height_lift;
+    float lift = u_height_lift;
+#ifndef TERRAIN
+    // If t > 0 (top) we always add the lift, otherwise (ground) we only add it if z > 0
+    lift = float((t + p.z) > 0.0) * lift;
+#endif
     vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
-    vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (p.z + top_offset));
+    vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (p.z + lift));
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, p.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * p.z;
-
     p = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #endif
 


### PR DESCRIPTION
Fix related to: https://github.com/mapbox/mapbox-gl-js/pull/11318

In the previous PR a new uniform was added to add an extra elevation the top and bottom of fill extrusions on the globe. For the bottom vertices I've assumed that they need to be elevated in case the height is larger than zero, but I forgot to test it with terrain enabled. As it turned out with terrain we can still have zero elevation in some cases, where the lift won't be applied. 
In this PR I've changed the logic to always apply the lift in case the terrain is enabled on the globe.

Before:
![Screenshot 2021-12-07 at 10 53 20](https://user-images.githubusercontent.com/2576246/145002933-404c3790-b2dd-42ef-be6d-3e2bbb41b9b3.png)

After:
![Screenshot 2021-12-07 at 10 52 31](https://user-images.githubusercontent.com/2576246/145002921-23da8c91-1fbd-453c-a4e6-7dde04525e6c.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
