### PR TITLE
Fix invalid LngLat with no currently loaded DEM tiles

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1302,7 +1302,7 @@ class Transform {
     _getBounds3D(): LngLatBounds {
         assert(this.elevation);
         const elevation = ((this.elevation: any): Elevation);
-        if (!elevation.visibleDemTiles.length){ return this._getBounds(0, 0); }
+        if (!elevation.visibleDemTiles.length) { return this._getBounds(0, 0); }
         const minmax = elevation.visibleDemTiles.reduce((acc, t) => {
             if (t.dem) {
                 const tree = t.dem.tree;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1269,8 +1269,6 @@ class Transform {
     }
 
     _getBounds(min: number, max: number) {
-        assert(min < Number.MAX_VALUE);
-
         const topLeft = new Point(this._edgeInsets.left, this._edgeInsets.top);
         const topRight = new Point(this.width - this._edgeInsets.right, this._edgeInsets.top);
         const bottomRight = new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1269,6 +1269,7 @@ class Transform {
     }
 
     _getBounds(min: number, max: number) {
+        assert(min < Number.MAX_VALUE);
 
         const topLeft = new Point(this._edgeInsets.left, this._edgeInsets.top);
         const topRight = new Point(this.width - this._edgeInsets.right, this._edgeInsets.top);
@@ -1301,6 +1302,7 @@ class Transform {
     _getBounds3D(): LngLatBounds {
         assert(this.elevation);
         const elevation = ((this.elevation: any): Elevation);
+        if (!elevation.visibleDemTiles.length){ return this._getBounds(0, 0); }
         const minmax = elevation.visibleDemTiles.reduce((acc, t) => {
             if (t.dem) {
                 const tree = t.dem.tree;
@@ -1309,6 +1311,7 @@ class Transform {
             }
             return acc;
         }, {min: Number.MAX_VALUE, max: 0});
+        assert(minmax.min !== Number.MAX_VALUE);
         return this._getBounds(minmax.min * elevation.exaggeration(), minmax.max * elevation.exaggeration());
     }
 

--- a/test/unit/terrain/terrain.test.js
+++ b/test/unit/terrain/terrain.test.js
@@ -1534,6 +1534,33 @@ test('terrain getBounds', (t) => {
         });
     });
 
+    test("Does not break with no visible DEM tiles (#10610)", (t) => {
+        const style = createStyle();
+        const map = createMap(t, { style, zoom: 1, bearing: 45 });
+        map.setCenter([0, 0]);
+
+        map.on("load", () => {
+            setMockElevationTerrain(map, zeroDem, TILE_SIZE);
+            map.setTerrain({ source: "mapbox-dem" });
+            map.once("render", () => {
+                t.ok(map.transform.elevation);
+                const bounds = toFixed(map.getBounds().toArray());
+
+                // Mocking the behavior when the map zooms quickly
+                map.transform.elevation._visibleDemTiles = [];
+
+                t.same(
+                    toFixed([
+                        [-49.7184455522, -44.445415806],
+                        [49.7184455522, 44.445415806],
+                    ]),
+                    bounds
+                );
+                t.end();
+            });
+        });
+    });
+
     function toFixed(bounds) {
         const n = 9;
         return [

--- a/test/unit/terrain/terrain.test.js
+++ b/test/unit/terrain/terrain.test.js
@@ -1536,12 +1536,12 @@ test('terrain getBounds', (t) => {
 
     test("Does not break with no visible DEM tiles (#10610)", (t) => {
         const style = createStyle();
-        const map = createMap(t, { style, zoom: 1, bearing: 45 });
+        const map = createMap(t, {style, zoom: 1, bearing: 45});
         map.setCenter([0, 0]);
 
         map.on("load", () => {
             setMockElevationTerrain(map, zeroDem, TILE_SIZE);
-            map.setTerrain({ source: "mapbox-dem" });
+            map.setTerrain({source: "mapbox-dem"});
             map.once("render", () => {
                 t.ok(map.transform.elevation);
                 const bounds = toFixed(map.getBounds().toArray());


### PR DESCRIPTION
## Launch Checklist
Closes #10610

When terrain is enabled and the map is quickly zoomed, `map.elevation.visibleDemTiles` occasionally returns an empty array while awaiting DEM tile loading. This previously caused `getBounds` to return null values,  As explained [here](https://github.com/mapbox/mapbox-gl-js/issues/10610#issuecomment-985742211) by @ted-piotrowski:

>  If `elevation.visibleDemTiles` is empty array and `elevation.exaggeration()` > 1 then `minmax.min * elevation.exaggeration()` will equal `Infinity`, possibly producing a `NaN` down the line:

This PR adds a fix by defaulting to the 2D `getBounds` behavior if no terrain is available.

This leaves undefined behavior in the application, where `getBounds` returns different results depending on whether terrain is loaded or not. It's also likely that if 1+ but not all DEM tiles are loaded, the bounds returned could be insufficient to completely cover all terrain, though this did not nor will they now throw an error.

I suspect that these cases are subtle enough to be only a minor issue. If we decide to address this in the future, we should consider the performance cost of delaying `getBounds`calls until terrain is loaded.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed 'getBounds' sometimes returning invalid LngLat when zooming on a map with terrain.</changelog>`
