### PR TITLE
Use base height for fill extrusion lift

### DIFF
--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -64,11 +64,8 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    float lift = u_height_lift;
-#ifndef TERRAIN
-    // If t > 0 (top) we always add the lift, otherwise (ground) we only add it if z > 0
-    lift = float((t + pos.z) > 0.0) * lift;
-#endif
+    // If t > 0 (top) we always add the lift, otherwise (ground) we only add it if base height is > 0
+    float lift = float((t + base) > 0.0) * u_height_lift;
     vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
     vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (pos.z + lift));
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, pos.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * pos.z;

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -90,11 +90,8 @@ void main() {
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW
-    float lift = u_height_lift;
-#ifndef TERRAIN
-    // If t > 0 (top) we always add the lift, otherwise (ground) we only add it if z > 0
-    lift = float((t + p.z) > 0.0) * lift;
-#endif
+    // If t > 0 (top) we always add the lift, otherwise (ground) we only add it if base height is > 0
+    float lift = float((t + base) > 0.0) * u_height_lift;
     vec3 globe_normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
     vec3 globe_pos = a_pos_3 + globe_normal * (u_tile_up_scale * (p.z + lift));
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, p.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * p.z;


### PR DESCRIPTION
Related to: https://github.com/mapbox/mapbox-gl-js/pull/11335

This PR corrects the previous PR, which assumed that height lift is always needed for fill extrusions with terrain on globe. Instead, we only add the lift for the top surface or in case the base height is not zero.

Before:
<img width="711" alt="Screenshot 2021-12-13 at 9 55 43" src="https://user-images.githubusercontent.com/2576246/145773427-1bdbb786-613a-439c-966d-0bf231ce4343.png">

After:
![Screenshot 2021-12-13 at 9 56 08](https://user-images.githubusercontent.com/2576246/145773482-1039d105-4a5f-4306-ab1b-c9449a96990d.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
