### PR TITLE
Disable unsupported layers on globe

### DIFF
--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -16,6 +16,7 @@ export default {
     zAxisUnit: "meters",
     conic: true,
     isReprojectedInTileSpace: true,
+    unsupportedLayers: ['custom'],
 
     // based on https://github.com/d3/d3-geo-projection, MIT-licensed
 

--- a/src/geo/projection/cylindrical_equal_area.js
+++ b/src/geo/projection/cylindrical_equal_area.js
@@ -11,6 +11,7 @@ export default function(phi: number) {
     return {
         wrap: true,
         supportsWorldCopies: true,
+        unsupportedLayers: ['custom'],
         project(lng: number, lat: number) {
             const x = degToRad(lng) * cosPhi;
             const y = Math.sin(degToRad(lat)) / cosPhi;

--- a/src/geo/projection/equal_earth.js
+++ b/src/geo/projection/equal_earth.js
@@ -19,6 +19,7 @@ export default {
     range: [3.5, 7],
     zAxisUnit: "meters",
     isReprojectedInTileSpace: true,
+    unsupportedLayers: ['custom'],
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -15,6 +15,7 @@ export default {
     zAxisUnit: "meters",
     wrap: true,
     isReprojectedInTileSpace: true,
+    unsupportedLayers: ['custom'],
 
     project(lng: number, lat: number) {
         const x = 0.5 + lng / 360;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -41,6 +41,13 @@ export default {
     supportsFreeCamera: true,
     zAxisUnit: "pixels",
     center: [0, 0],
+    unsupportedLayers: new Set([
+        'circle',
+        'heatmap',
+        'fill-extrusion',
+        'debug',
+        'custom'
+    ]),
 
     project(lng: number, lat: number) {
         const x = mercatorXfromLng(lng);

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -41,13 +41,13 @@ export default {
     supportsFreeCamera: true,
     zAxisUnit: "pixels",
     center: [0, 0],
-    unsupportedLayers: new Set([
+    unsupportedLayers: [
         'circle',
         'heatmap',
         'fill-extrusion',
         'debug',
         'custom'
-    ]),
+    ],
 
     project(lng: number, lat: number) {
         const x = mercatorXfromLng(lng);

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -28,10 +28,9 @@ export type Projection = {
     requiresDraping?: boolean,
     supportsTerrain?: boolean;
     supportsFog?: boolean;
-    supportsCustomLayers?: boolean,
     supportsFreeCamera?: boolean,
     supportsWorldCopies?: boolean,
-    unsupportedLayers?: Set<string>,
+    unsupportedLayers?: Array<string>,
 
     // Whether the projection reprojects data in tile space
     isReprojectedInTileSpace?: boolean;

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -31,6 +31,8 @@ export type Projection = {
     supportsCustomLayers?: boolean,
     supportsFreeCamera?: boolean,
     supportsWorldCopies?: boolean,
+    unsupportedLayers?: Set<string>,
+
     // Whether the projection reprojects data in tile space
     isReprojectedInTileSpace?: boolean;
     zAxisUnit: "meters" | "pixels",

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -24,6 +24,7 @@ export default {
 
     conic: true,
     isReprojectedInTileSpace: true,
+    unsupportedLayers: ['custom'],
 
     initializeConstants() {
         if (this.constants && vec2.exactEquals(this.parallels, this.constants.parallels)) {

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -19,7 +19,6 @@ export default {
     supportsWorldCopies: true,
     supportsTerrain: true,
     supportsFog: true,
-    supportsCustomLayers: true,
     supportsFreeCamera: true,
     zAxisUnit: "meters",
     center: [0, 0],

--- a/src/geo/projection/natural_earth.js
+++ b/src/geo/projection/natural_earth.js
@@ -15,6 +15,7 @@ export default {
     range: [3.5, 7],
     isReprojectedInTileSpace: true,
     zAxisUnit: "meters",
+    unsupportedLayers: ['custom'],
 
     project(lng: number, lat: number) {
         // based on https://github.com/d3/d3-geo, MIT-licensed

--- a/src/geo/projection/winkel_tripel.js
+++ b/src/geo/projection/winkel_tripel.js
@@ -15,6 +15,7 @@ export default {
     range: [3.5, 7],
     zAxisUnit: "meters",
     isReprojectedInTileSpace: true,
+    unsupportedLayers: ['custom'],
 
     project(lng: number, lat: number) {
         lat = degToRad(lat);

--- a/src/render/draw_custom.js
+++ b/src/render/draw_custom.js
@@ -15,7 +15,7 @@ function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomSty
     const context = painter.context;
     const implementation = layer.implementation;
 
-    if (!painter.transform.projection.supportsCustomLayers) {
+    if (painter.transform.projection.unsupportedLayers && painter.transform.projection.unsupportedLayers.includes("custom")) {
         warnOnce('Custom layers are not yet supported with non-mercator projections. Use mercator to enable custom layers.');
         return;
     }

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -690,7 +690,7 @@ class Painter {
         this.id = layer.id;
 
         this.gpuTimingStart(layer);
-        if (!painter.transform.projection.unsupportedLayers || !painter.transform.projection.unsupportedLayers.has(layer.type)) {
+        if (!painter.transform.projection.unsupportedLayers || !painter.transform.projection.unsupportedLayers.includes(layer.type)) {
             draw[layer.type](painter, sourceCache, layer, coords, this.style.placement.variableOffsets, this.options.isInitialLoad);
         }
         this.gpuTimingEnd();

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -690,7 +690,9 @@ class Painter {
         this.id = layer.id;
 
         this.gpuTimingStart(layer);
-        draw[layer.type](painter, sourceCache, layer, coords, this.style.placement.variableOffsets, this.options.isInitialLoad);
+        if (!painter.transform.projection.unsupportedLayers || !painter.transform.projection.unsupportedLayers.has(layer.type)) {
+            draw[layer.type](painter, sourceCache, layer, coords, this.style.placement.variableOffsets, this.options.isInitialLoad);
+        }
         this.gpuTimingEnd();
     }
 


### PR DESCRIPTION
This PR adds a new field to projections to help us disable the rendering of unsupported layers. In case of the globe it disables the currently unsupported layers.

For example, the heatmap layer would be rendered like this, so we just ignore it at the moment:

![Screenshot 2021-12-14 at 16 00 36](https://user-images.githubusercontent.com/2576246/146015010-e97e6999-9bfb-4dcd-8790-6165e7b81210.png)

In later follow-up PRs the support for these layer types will be backported from gl-native.