### PR TITLE
Fix gl-js-team/issues/309

### DIFF
--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -657,7 +657,7 @@ export class Terrain extends Elevation {
             this.renderedToTile = false; // reset flag.
             if (fbo.dirty) {
                 // Clear on start.
-                context.clear({color: Color.transparent});
+                context.clear({color: Color.transparent, stencil: 0});
                 fbo.dirty = false;
             }
 


### PR DESCRIPTION
Since the stencil renderbuffer may be shared between different tiles we need to ensure that it is cleared when recycled. Otherwise stale data left in that buffer may interfere with the new tiles sharing that same buffer, resulting in flickering in complex source overlap situations. The flicker is very difficult to trigger in a render tests environment, as it require toggling terrain on and off and zooming fast in and out.

https://github.com/mapbox/gl-js-team/issues/309

`<changelog>Fix a rare terrain flickering issue when using terrain with multiple vector data sources</changelog>`