### PR TITLE
Sets a default aria-label for interactive markers

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -113,6 +113,7 @@ export default class Marker extends Evented {
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
         this._updateMoving = () => this._update(true);
+
         if (!options || !options.element) {
             this._defaultMarker = true;
             this._element = DOM.create('div');

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -113,7 +113,6 @@ export default class Marker extends Evented {
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
         this._updateMoving = () => this._update(true);
-
         if (!options || !options.element) {
             this._defaultMarker = true;
             this._element = DOM.create('div');

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -117,7 +117,6 @@ export default class Marker extends Evented {
         if (!options || !options.element) {
             this._defaultMarker = true;
             this._element = DOM.create('div');
-            this._element.setAttribute('aria-label', 'Map marker');
 
             // create default map marker SVG
             const defaultHeight = 41;
@@ -159,7 +158,10 @@ export default class Marker extends Evented {
             this._offset = Point.convert(options && options.offset || [0, 0]);
         }
 
+        if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');
+
         this._element.classList.add('mapboxgl-marker');
+
         this._element.addEventListener('dragstart', (e: DragEvent) => {
             e.preventDefault();
         });
@@ -334,7 +336,6 @@ export default class Marker extends Evented {
             if (this._lngLat) this._popup.setLngLat(this._lngLat);
 
             this._element.setAttribute('role', 'button');
-            if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');
             this._originalTabIndex = this._element.getAttribute('tabindex');
             if (!this._originalTabIndex) {
                 this._element.setAttribute('tabindex', '0');

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -334,6 +334,7 @@ export default class Marker extends Evented {
             if (this._lngLat) this._popup.setLngLat(this._lngLat);
 
             this._element.setAttribute('role', 'button');
+            if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');
             this._originalTabIndex = this._element.getAttribute('tabindex');
             if (!this._originalTabIndex) {
                 this._element.setAttribute('tabindex', '0');

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -159,9 +159,7 @@ export default class Marker extends Evented {
         }
 
         if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');
-
         this._element.classList.add('mapboxgl-marker');
-
         this._element.addEventListener('dragstart', (e: DragEvent) => {
             e.preventDefault();
         });

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -171,9 +171,9 @@ test('Enter key on Marker opens a popup that was closed', (t) => {
     t.end();
 });
 
-test('Interactive marker have a default aria-label and role attribute is set to button', (t) => {
+test('Interactive markers should have a default aria-label and a role attribute set to button', (t) => {
     const map = createMap(t);
-    const element = window.document.createElement('div'); 
+    const element = window.document.createElement('div');
     const marker = new Marker({color: "#FFFFFF", element})
         .setLngLat([0, 0])
         .addTo(map)
@@ -184,7 +184,7 @@ test('Interactive marker have a default aria-label and role attribute is set to 
 
     map.remove();
     t.end();
-})
+});
 
 test('Space key on Marker opens a popup that was closed', (t) => {
     const map = createMap(t);

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -171,6 +171,21 @@ test('Enter key on Marker opens a popup that was closed', (t) => {
     t.end();
 });
 
+test('Interactive marker have a default aria-label and role attribute is set to button', (t) => {
+    const map = createMap(t);
+    const element = window.document.createElement('div'); 
+    const marker = new Marker({color: "#FFFFFF", element})
+        .setLngLat([0, 0])
+        .addTo(map)
+        .setPopup(new Popup());
+
+    t.ok(marker.getElement().hasAttribute('aria-label'));
+    t.equal(marker.getElement().getAttribute('role'), 'button');
+
+    map.remove();
+    t.end();
+})
+
 test('Space key on Marker opens a popup that was closed', (t) => {
     const map = createMap(t);
     const marker = new Marker()


### PR DESCRIPTION
In the case that a marker has an option, an option element, and not an aria-label set, a default aria-label is not being set for interactive markers. WCAG warns users in these use-cases that a button must be accompanied by an accessible name. See issue #11030 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Sets a default aria-label for interactive markers (accessibility)</changelog>`
