### PR TITLE
drop default tiles preloading on camera animations

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1226,10 +1226,6 @@ class Camera extends Evented {
             return this;
         }
 
-        // emulate the last transform and start preloading tiles for it
-        const lastTransform = frame(tr.clone())(1);
-        this._preloadTiles(lastTransform);
-
         const currently = {
             moving: this._moving,
             zooming: this._zooming,
@@ -1535,10 +1531,6 @@ class Camera extends Evented {
             this._preloadTiles(predictedTransforms);
             return this;
         }
-
-        // emulate the last transform and start preloading tiles for it
-        const lastTransform = frame(tr.clone())(1);
-        this._preloadTiles(lastTransform);
 
         this._zooming = zoomChanged;
         this._rotating = bearingChanged;


### PR DESCRIPTION
This behavior was introduced in #11328

In some cases, e.g. when starting animation right after enabling terrain, this causes the map to crash.