### PR TITLE
Fix redundant title in Map Feedback attribution

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -97,6 +97,7 @@ class AttributionControl {
 
     _setElementTitle(element: HTMLElement, title: string) {
         const str = this._map._getUIString(`AttributionControl.${title}`);
+        element.setAttribute('aria-label', str);
         if (element.hasAttribute('title')) element.removeAttribute('title');
         if (element.firstElementChild) element.firstElementChild.setAttribute('title', str);
     }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -98,7 +98,7 @@ class AttributionControl {
     _setElementTitle(element: HTMLElement, title: string) {
         const str = this._map._getUIString(`AttributionControl.${title}`);
         element.setAttribute('aria-label', str);
-        if (element.hasAttribute('title')) element.removeAttribute('title');
+        element.removeAttribute('title');
         if (element.firstElementChild) element.firstElementChild.setAttribute('title', str);
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -5,6 +5,7 @@ import {bindAll} from '../../util/util.js';
 import config from '../../util/config.js';
 
 import type Map from '../map.js';
+import { addConsoleHandler } from 'selenium-webdriver/lib/logging';
 
 type Options = {
     compact?: boolean,
@@ -97,7 +98,7 @@ class AttributionControl {
 
     _setElementTitle(element: HTMLElement, title: string) {
         const str = this._map._getUIString(`AttributionControl.${title}`);
-        element.setAttribute('aria-label', str);
+        if (element.hasAttribute('title')) element.removeAttribute('title');
         if (element.firstElementChild) element.firstElementChild.setAttribute('title', str);
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -5,7 +5,6 @@ import {bindAll} from '../../util/util.js';
 import config from '../../util/config.js';
 
 import type Map from '../map.js';
-import { addConsoleHandler } from 'selenium-webdriver/lib/logging';
 
 type Options = {
     compact?: boolean,


### PR DESCRIPTION
Closes #11324. PR #11064 removed adding a title attribute to Map Feedback (which was overwriting the previous title attribute "improve this map" that comes from the vector tile source). This quick fix removes the title attribute for Map Feedback as aria-label is being used instead.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the mapbox-gl-js changelog: <changelog>Removes redundant title attribute from `Improve this Map` attribution element</changelog>