### PR TITLE
Better validation against 'TypeError: window.URL.createObjectURL is not a function' error. Fixes Grsmto/sanity-plugin-mapbox-input#5. Fixes #11390.

### DIFF
--- a/rollup/bundle_prelude.js
+++ b/rollup/bundle_prelude.js
@@ -14,7 +14,7 @@ if (!shared) {
     var sharedChunk = {};
     shared(sharedChunk);
     mapboxgl = chunk(sharedChunk);
-    if (window && typeof window !== 'undefined' && window.URL?.createObjectURL) {
+    if (typeof window !== 'undefined' && window?.URL?.createObjectURL) {
         mapboxgl.workerUrl = window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' }));
     }
 }

--- a/rollup/bundle_prelude.js
+++ b/rollup/bundle_prelude.js
@@ -14,7 +14,7 @@ if (!shared) {
     var sharedChunk = {};
     shared(sharedChunk);
     mapboxgl = chunk(sharedChunk);
-    if (typeof window !== 'undefined' && window?.URL?.createObjectURL) {
+    if (typeof window !== 'undefined' && window && window.URL && window.URL.createObjectURL) {
         mapboxgl.workerUrl = window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' }));
     }
 }

--- a/rollup/bundle_prelude.js
+++ b/rollup/bundle_prelude.js
@@ -14,7 +14,7 @@ if (!shared) {
     var sharedChunk = {};
     shared(sharedChunk);
     mapboxgl = chunk(sharedChunk);
-    if (typeof window !== 'undefined') {
+    if (window && typeof window !== 'undefined' && window.URL?.createObjectURL) {
         mapboxgl.workerUrl = window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' }));
     }
 }


### PR DESCRIPTION
**The former check:**

```
if (typeof window !== 'undefined') {
```

...was insufficient in many situations, so instead of doing a simplistic check, I went all the way and checked for the whole functional chain.

There's basically no change in functionality or in code, I'm just doing a more strict check that makes sure we have everything we need to run the worker as expected.

**The change:**

```
if (typeof window !== 'undefined' && window && window.URL && window.URL.createObjectURL) {
```

A somewhat lengthy check, but totally valid ES5. I attempted using the following ES6 syntax, but got an 'invalid token' error when importing the module:

```
if (typeof window !== 'undefined' && window?.URL?.createObjectURL) {
```

It was this issue that brought me here https://github.com/Grsmto/sanity-plugin-mapbox-input/issues/5, and this PR will solve that one issue.