### PR TITLE
Coalesce on missing images to return ResolvedImage instead of String

### DIFF
--- a/src/style-spec/expression/definitions/coalesce.js
+++ b/src/style-spec/expression/definitions/coalesce.js
@@ -54,19 +54,21 @@ class Coalesce implements Expression {
     evaluate(ctx: EvaluationContext) {
         let result = null;
         let argCount = 0;
-        let requestedImageName;
+        let firstImage;
         for (const arg of this.args) {
             argCount++;
             result = arg.evaluate(ctx);
             // we need to keep track of the first requested image in a coalesce statement
-            // if coalesce can't find a valid image, we return the first image name so styleimagemissing can fire
+            // if coalesce can't find a valid image, we return the first image so styleimagemissing can fire
             if (result && result instanceof ResolvedImage && !result.available) {
-                if (!requestedImageName) {
-                    requestedImageName = result.name;
+                // set to first image
+                if (!firstImage) {
+                    firstImage = result;
                 }
                 result = null;
+                // if we reach the end, return the first image
                 if (argCount === this.args.length) {
-                    result = requestedImageName;
+                    return firstImage;
                 }
             }
 

--- a/test/integration/expression-tests/image/coalesce/test.json
+++ b/test/integration/expression-tests/image/coalesce/test.json
@@ -22,7 +22,7 @@
     },
     "outputs": [
       {"name":"monument-15","available":true},
-      "foo"
+      {"name": "foo", "available": false}
     ],
     "serialized": [
       "coalesce",


### PR DESCRIPTION
Coalesce expressions currently behave differently between Native and JS. GL JS and Native alike return a `ResolvedImage` object like `{name: "foo", available:"true"}` when an image is found.

But when no images are available, Native returns `{name: "foo", available:"false"}`, but GL JS returns just the string `"foo"`.  In #11359, I added a test to this behavior [here](https://github.com/mapbox/mapbox-gl-js/pull/11359/files#diff-4bd16e6f5b0feaaffd4ac624910679fe9a460209fefbd6e0834ca601991e7ee0), which is triggering a failure in Native.

This P.R. changes the behavior of GL JS to the more consistent behavior of GL JS of always returning a `ResolvedImage`, and changes the test so that GL JS and GL Native should both pass. This also makes the GL JS behavior consistent with the current documentation as of #10952.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [X] write tests for all new functionality
 - [x] manually test that `styleimagemissing` still works.
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
