### PR TITLE
Globe view fix #11352

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -330,8 +330,7 @@ class Style extends Evented {
         this.dispatcher.broadcast('setLayers', this._serializeLayers(this._order));
 
         this.light = new Light(this.stylesheet.light);
-        const terrainSetForDrapingOnly = this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.deferred;
-        if (this.stylesheet.terrain && !terrainSetForDrapingOnly) {
+        if (this.stylesheet.terrain && !this.terrainSetForDrapingOnly()) {
             this._createTerrain(this.stylesheet.terrain, DrapeRenderMode.elevated);
         }
         if (this.stylesheet.fog) {
@@ -341,6 +340,10 @@ class Style extends Evented {
 
         this.fire(new Event('data', {dataType: 'style'}));
         this.fire(new Event('style.load'));
+    }
+
+    terrainSetForDrapingOnly() {
+        return this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.deferred;
     }
 
     setProjection(projection?: ?ProjectionSpecification) {
@@ -363,7 +366,7 @@ class Style extends Evented {
                 if (!hasTerrain) {
                     this.setTerrainForDraping();
                 }
-            } else if (this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.deferred) {
+            } else if (this.terrainSetForDrapingOnly()) {
                 this.setTerrain(null);
             }
         }
@@ -1833,8 +1836,16 @@ class Style extends Evented {
         return this._numCircleLayers > 0;
     }
 
-    clearWorkerCaches() {
+    _clearWorkerCaches() {
         this.dispatcher.broadcast('clearCaches');
+    }
+
+    destroy() {
+        this._clearWorkerCaches();
+        if (this.terrainSetForDrapingOnly()) {
+            delete this.terrain;
+            delete this.stylesheet.terrain;
+        }
     }
 }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3215,7 +3215,7 @@ class Map extends Camera {
         this._renderTaskQueue.clear();
         this._domRenderTaskQueue.clear();
         if (this.style) {
-            this.style.clearWorkerCaches();
+            this.style.destroy();
         }
         this.painter.destroy();
         this.handlers.destroy();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -357,6 +357,31 @@ test('Map', (t) => {
             });
         });
 
+        t.test('https://github.com/mapbox/mapbox-gl-js/issues/11352', (t) => {
+            const styleSheet = new window.CSSStyleSheet();
+            styleSheet.insertRule('.mapboxgl-canary { background-color: rgb(250, 128, 114); }', 0);
+            window.document.styleSheets[0] = styleSheet;
+            window.document.styleSheets.length = 1;
+            const style = createStyle();
+            const div = window.document.createElement('div');
+            let map = new Map({style, container: div, testMode: true});
+            map.on('load', () => {
+                map.setProjection('globe');
+                t.equal(map.getProjection().name, 'globe');
+                t.ok(map.style.terrain);
+                t.equal(map.getTerrain(), null);
+                t.ok(style.terrain);
+                t.equal(style.terrain.source, '');
+                map.remove();
+
+                map = new Map({style, container: div, testMode: true});
+                t.equal(map.getProjection().name, 'mercator');
+                t.equal(map.getTerrain(), null);
+                t.equal(style.terrain, undefined);
+                t.end();
+            });
+        });
+
         t.test('updating terrain triggers style diffing using setTerrain operation', (t) => {
             t.test('removing terrain', (t) => {
                 const style = createStyle();


### PR DESCRIPTION
Bug fix for https://github.com/mapbox/mapbox-gl-js/issues/11352:
- Make sure to clear the mock terrain from the style when removing the map with a call to `map.remove()` but still referencing the same style instance, which is sequence that can happen within the Studio context
- Add regression test with the case provided in the original issue

cc @tristen 