### PR TITLE
Relaxed tolerance allowing four new render tests to pass on GL-Native linux

### DIFF
--- a/test/integration/render-tests/image-fallback-nested/feature-state-inside/style.json
+++ b/test/integration/render-tests/image-fallback-nested/feature-state-inside/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 64,
       "height": 64,
+      "allowed": 0.0015,
       "operations": [
         [
           "setFeatureState",

--- a/test/integration/render-tests/image-fallback-nested/feature-state-outside/style.json
+++ b/test/integration/render-tests/image-fallback-nested/feature-state-outside/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 64,
       "height": 64,
+      "allowed": 0.0015,
       "operations": [
         [
           "setFeatureState",

--- a/test/integration/render-tests/image-fallback-nested/verbose/feature-state-inside/style.json
+++ b/test/integration/render-tests/image-fallback-nested/verbose/feature-state-inside/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 64,
       "height": 64,
+      "allowed": 0.0015,
       "operations": [
         [
           "setFeatureState",

--- a/test/integration/render-tests/image-fallback-nested/verbose/feature-state-outside/style.json
+++ b/test/integration/render-tests/image-fallback-nested/verbose/feature-state-outside/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 64,
       "height": 64,
+      "allowed": 0.0015,
       "operations": [
         [
           "setFeatureState",


### PR DESCRIPTION
## Launch Checklist

The new feature-state tests introduced in  #11049 and #11359 were failing.
![image](https://user-images.githubusercontent.com/14878684/148439455-4c7b1611-93c3-4dba-8179-36a5b093b7f5.png)
This is caused by differences in antialiasing of different operating systems. Interestingly, it occurs in this case only when zoom > 0, possibly because it stems from the way that different operating systems handle subpixel floating point values.

This behavior is an existing and acceptable difference as demonstrated by other tests such as this one:
![image](https://user-images.githubusercontent.com/14878684/148440020-7d1558f3-5e2d-4dd4-bd5c-5cc5c8590ba8.png)
This change increased the tolerance to enable these tests to pass.

Similar to #11308

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
