### PR TITLE
Relaxing tolerance to geojson/inline-linestring-line

### DIFF
--- a/test/integration/render-tests/geojson/inline-linestring-line/style.json
+++ b/test/integration/render-tests/geojson/inline-linestring-line/style.json
@@ -3,7 +3,8 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64
+      "height": 64,
+      "tolerance": 0.0015
     }
   },
   "sources": {


### PR DESCRIPTION
Relaxing tolerance to the `geojson/inline-linestring-line`, which is currently failing on [this PR](https://github.com/mapbox/mapbox-gl-native-internal/pull/2655) with  [`linux-asan`](https://app.circleci.com/pipelines/github/mapbox/mapbox-gl-native-internal/15590/workflows/2023a358-8796-40e2-b521-9a28e6afa871/jobs/390506) Render Cache tests.

![image](https://user-images.githubusercontent.com/14878684/148625081-37a86f63-11c9-412f-b86f-254aaff84e38.png)

The visual difference is acceptably small here. More concerning is that it is combined with an the increase in memory usage by a factor of 257. [Other tests in this run](https://390506-244947398-gh.circle-artifacts.com/0/tests/render-cache/linux-asan-render-cache.html) show metrics changes including several with the same numbers but as a decrease:

![image](https://user-images.githubusercontent.com/14878684/148625214-e7aaadb6-20d1-46fa-b45c-01a13fd264b9.png)

Can I get confirmation from @mapbox/gl-native  that these baselines are safe to update before I merge this change?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [X] include before/after visuals or gifs if this PR includes visual changes
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
