### PR TITLE
Add globe view support to the debug shader

### DIFF
--- a/src/shaders/debug.vertex.glsl
+++ b/src/shaders/debug.vertex.glsl
@@ -1,4 +1,7 @@
 attribute vec2 a_pos;
+#ifdef PROJECTION_GLOBE_VIEW
+attribute vec3 a_pos_3;
+#endif
 varying vec2 v_uv;
 
 uniform mat4 u_matrix;
@@ -9,5 +12,9 @@ void main() {
     // The UV co-ordinates for the overlay texture can be calculated using that knowledge
     float h = elevation(a_pos);
     v_uv = a_pos / 8192.0;
+#ifdef PROJECTION_GLOBE_VIEW
+    gl_Position = u_matrix * vec4(a_pos_3 + elevationVector(a_pos) * h, 1);
+#else
     gl_Position = u_matrix * vec4(a_pos * u_overlay_scale, h, 1);
+#endif
 }


### PR DESCRIPTION
This PR modifies `debug.vertex.glsl` to work with the globe view. It is a no-op change for gl-js as shader changes are guarded by the `PROJECTION_GLOBE_VIEW` define.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
