### PR TITLE
Fix e.isSourceLoaded to check if specific source is loaded 

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -704,6 +704,7 @@ class Style extends Evented {
         if (this.map && this.map._collectResourceTiming) (source: any).collectResourceTiming = true;
 
         const sourceInstance = createSource(id, source, this.dispatcher, this);
+
         sourceInstance.setEventedParent(this, () => ({
             isSourceLoaded: this.map.isSourceLoaded(id),
             source: sourceInstance.serialize(),

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -704,9 +704,8 @@ class Style extends Evented {
         if (this.map && this.map._collectResourceTiming) (source: any).collectResourceTiming = true;
 
         const sourceInstance = createSource(id, source, this.dispatcher, this);
-
         sourceInstance.setEventedParent(this, () => ({
-            isSourceLoaded: this.loaded(),
+            isSourceLoaded: this.map.isSourceLoaded(id),
             source: sourceInstance.serialize(),
             sourceId: id
         }));

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1784,7 +1784,7 @@ class Style extends Evented {
     }
 
     _isSourceCacheLoaded(source: string) {
-        const sourceCaches = this && this._getSourceCaches(source);
+        const sourceCaches = this._getSourceCaches(source);
         if (sourceCaches.length === 0) {
             this.fire(new ErrorEvent(new Error(`There is no source with ID '${source}'`)));
             return;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -706,7 +706,7 @@ class Style extends Evented {
         const sourceInstance = createSource(id, source, this.dispatcher, this);
 
         sourceInstance.setEventedParent(this, () => ({
-            isSourceLoaded: this.map.isSourceLoaded(id),
+            isSourceLoaded: this._isSourceCacheLoaded(id),
             source: sourceInstance.serialize(),
             sourceId: id
         }));
@@ -1781,6 +1781,15 @@ class Style extends Evented {
             sourceCaches.push(this._symbolSourceCaches[source]);
         }
         return sourceCaches;
+    }
+
+    _isSourceCacheLoaded(source: string) {
+        const sourceCaches = this && this._getSourceCaches(source);
+        if (sourceCaches.length === 0) {
+            this.fire(new ErrorEvent(new Error(`There is no source with ID '${source}'`)));
+            return;
+        }
+        return sourceCaches.every(sc => sc.loaded());
     }
 
     has3DLayers(): boolean {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1789,13 +1789,7 @@ class Map extends Camera {
      * const sourceLoaded = map.isSourceLoaded('bathymetry-data');
      */
     isSourceLoaded(id: string) {
-        const sourceCaches = this.style && this.style._getSourceCaches(id);
-        if (sourceCaches.length === 0) {
-            this.fire(new ErrorEvent(new Error(`There is no source with ID '${id}'`)));
-            return;
-        }
-
-        return sourceCaches.every(sc => sc.loaded());
+        return this.style._isSourceCacheLoaded(id);
     }
 
     /**

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1789,7 +1789,7 @@ class Map extends Camera {
      * const sourceLoaded = map.isSourceLoaded('bathymetry-data');
      */
     isSourceLoaded(id: string) {
-        return this.style._isSourceCacheLoaded(id);
+        return this.style && this.style._isSourceCacheLoaded(id);
     }
 
     /**

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -468,6 +468,7 @@ test('Map', (t) => {
             map.on('load', () => {
                 map.on('data', (e) => {
                     if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                        t.equal(e.isSourceLoaded, true, 'true when loaded');
                         t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
                         t.end();
                     }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -478,6 +478,17 @@ test('Map', (t) => {
             });
         });
 
+        t.test('Map#isStyleLoaded', (t) => {
+            const style = createStyle();
+            const map = createMap(t, {style});
+
+            t.equal(map.isStyleLoaded(), false, 'false before style has loaded');
+            map.on('load', () => {
+                t.equal(map.isStyleLoaded(), true, 'true when style is loaded');
+                t.end();
+            });
+        });
+
         t.test('Map#areTilesLoaded', (t) => {
             const style = createStyle();
             const map = createMap(t, {style});
@@ -493,7 +504,7 @@ test('Map', (t) => {
             });
         });
 
-        t.test('e.isSourceLoaded should return `false` if source tiles are not loaded', (t) => {
+        t.test('e.isSourceLoaded if source tiles are not loaded', (t) => {
             const style = createStyle();
             const map = createMap(t, {style});
 
@@ -530,7 +541,6 @@ test('Map', (t) => {
         });
         t.end();
     });
-
 
     t.test('#getStyle', (t) => {
         t.test('returns the style', (t) => {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -13,8 +13,6 @@ import {fixedLngLat, fixedNum} from '../../util/fixed.js';
 import Fog from '../../../src/style/fog.js';
 import Color from '../../../src/style-spec/util/color.js';
 import {MAX_MERCATOR_LATITUDE} from '../../../src/geo/mercator_coordinate.js';
-import { convertChangesToXML } from 'diff';
-import GeoJSONSource from '../../../src/source/geojson_source.js';
 
 function createStyleSource() {
     return {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -526,42 +526,27 @@ test('Map', (t) => {
 
             map.on('load', () => {
                 map.on('data', (e) => {
-                    if (e.sourceId === 'geojson' && e.sourceDataType === 'metadata') {
-                        t.equal(e.isSourceLoaded, true, 'true when source is loaded');
-                        t.end();
+                    if (source._data.features.length === 0 && e.sourceId === 'geojson' && e.sourceDataType === 'metadata') {
+                        t.equal(e.isSourceLoaded, true, 'true when source is loaded after calling `addSource`');
+                        source.setData({
+                            'type': 'FeatureCollection',
+                            'features': [{
+                                'type': 'Feature',
+                                'properties': {'name': 'Null Island'}
+                            }]
+                        });
                     }
-                });
-                map.addSource('geojson', createStyleSource());
-                const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
-                map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
-                map.style._getSourceCache('geojson')._tiles[fakeTileId.key].state = 'loaded';
-            });
-        });
-
-        t.test('e.isSourceLoaded should return `true` after calling `setData` when tiles are loaded', (t) => {
-            const map = createMap(t);
-
-            map.on('load', () => {
-                map.on('data', (e) => {
-                    if (source._data.features.length > 0 && e.sourceDataType === 'metadata') {
-                        t.equal(e.isSourceLoaded, true);
+                    if (source._data.features.length > 0 && e.sourceId === 'geojson' && e.sourceDataType === 'metadata') {
+                        t.equal(e.isSourceLoaded, true, 'true when source is loaded after calling `setData`');
                         t.end();
                     }
                 });
                 map.addSource('geojson', createStyleSource());
                 const source = map.getSource('geojson');
-                source.setData({
-                    'type': 'FeatureCollection',
-                    'features': [{
-                        'type': 'Feature',
-                        'properties': {'name': 'Null Island'}
-                    }]
-                });
                 const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
                 map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
                 map.style._getSourceCache('geojson')._tiles[fakeTileId.key].state = 'loaded';
             });
-
         });
 
         t.end();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -517,7 +517,6 @@ test('Map', (t) => {
                 map.addSource('geojson', createStyleSource());
                 const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
                 map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
-
             });
         });
 
@@ -538,6 +537,7 @@ test('Map', (t) => {
                 map.style._getSourceCache('geojson')._tiles[fakeTileId.key].state = 'loaded';
             });
         });
+
         t.end();
     });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -467,25 +467,14 @@ test('Map', (t) => {
 
             map.on('load', () => {
                 map.on('data', (e) => {
+
                     if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                        t.equal(e.isSourceLoaded, true, 'true when loaded');
                         t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
                         t.end();
                     }
                 });
                 map.addSource('geojson', createStyleSource());
                 t.equal(map.isSourceLoaded('geojson'), false, 'false before loaded');
-            });
-        });
-
-        t.test('Map#isStyleLoaded', (t) => {
-            const style = createStyle();
-            const map = createMap(t, {style});
-
-            t.equal(map.isStyleLoaded(), false, 'false before style has loaded');
-            map.on('load', () => {
-                t.equal(map.isStyleLoaded(), true, 'true when style is loaded');
-                t.end();
             });
         });
 
@@ -503,8 +492,45 @@ test('Map', (t) => {
                 t.end();
             });
         });
+
+        t.test('e.isSourceLoaded should return `false` if source tiles are not loaded', (t) => {
+            const style = createStyle();
+            const map = createMap(t, {style});
+
+            map.on('load', () => {
+                map.on('data', (e) => {
+                    if (e.sourceId === 'geojson' && e.sourceDataType === 'metadata') {
+                        t.equal(e.isSourceLoaded, false, 'false when source is not loaded');
+                        t.end();
+                    }
+                });
+                map.addSource('geojson', createStyleSource());
+                const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
+                map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
+
+            });
+        });
+
+        t.test('e.isSourceLoaded should return `true` if source tiles are loaded', (t) => {
+            const style = createStyle();
+            const map = createMap(t, {style});
+
+            map.on('load', () => {
+                map.on('data', (e) => {
+                    if (e.sourceId === 'geojson' && e.sourceDataType === 'metadata') {
+                        t.equal(e.isSourceLoaded, true, 'true when source is loaded');
+                        t.end();
+                    }
+                });
+                map.addSource('geojson', createStyleSource());
+                const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
+                map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
+                map.style._getSourceCache('geojson')._tiles[fakeTileId.key].state = 'loaded';
+            });
+        });
         t.end();
     });
+
 
     t.test('#getStyle', (t) => {
         t.test('returns the style', (t) => {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -503,7 +503,7 @@ test('Map', (t) => {
             });
         });
 
-        t.test('e.isSourceLoaded if source tiles are not loaded', (t) => {
+        t.test('e.isSourceLoaded should return `false` if source tiles are not loaded', (t) => {
             const style = createStyle();
             const map = createMap(t, {style});
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -467,7 +467,6 @@ test('Map', (t) => {
 
             map.on('load', () => {
                 map.on('data', (e) => {
-
                     if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                         t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
                         t.end();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -13,6 +13,8 @@ import {fixedLngLat, fixedNum} from '../../util/fixed.js';
 import Fog from '../../../src/style/fog.js';
 import Color from '../../../src/style-spec/util/color.js';
 import {MAX_MERCATOR_LATITUDE} from '../../../src/geo/mercator_coordinate.js';
+import { convertChangesToXML } from 'diff';
+import GeoJSONSource from '../../../src/source/geojson_source.js';
 
 function createStyleSource() {
     return {
@@ -504,8 +506,7 @@ test('Map', (t) => {
         });
 
         t.test('e.isSourceLoaded should return `false` if source tiles are not loaded', (t) => {
-            const style = createStyle();
-            const map = createMap(t, {style});
+            const map = createMap(t);
 
             map.on('load', () => {
                 map.on('data', (e) => {
@@ -521,8 +522,7 @@ test('Map', (t) => {
         });
 
         t.test('e.isSourceLoaded should return `true` if source tiles are loaded', (t) => {
-            const style = createStyle();
-            const map = createMap(t, {style});
+            const map = createMap(t);
 
             map.on('load', () => {
                 map.on('data', (e) => {
@@ -536,6 +536,32 @@ test('Map', (t) => {
                 map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
                 map.style._getSourceCache('geojson')._tiles[fakeTileId.key].state = 'loaded';
             });
+        });
+
+        t.test('e.isSourceLoaded should return `true` after calling `setData` when tiles are loaded', (t) => {
+            const map = createMap(t);
+
+            map.on('load', () => {
+                map.on('data', (e) => {
+                    if (source._data.features.length > 0 && e.sourceDataType === 'metadata') {
+                        t.equal(e.isSourceLoaded, true);
+                        t.end();
+                    }
+                });
+                map.addSource('geojson', createStyleSource());
+                const source = map.getSource('geojson');
+                source.setData({
+                    'type': 'FeatureCollection',
+                    'features': [{
+                        'type': 'Feature',
+                        'properties': {'name': 'Null Island'}
+                    }]
+                });
+                const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
+                map.style._getSourceCache('geojson')._tiles[fakeTileId.key] = new Tile(fakeTileId);
+                map.style._getSourceCache('geojson')._tiles[fakeTileId.key].state = 'loaded';
+            });
+
         });
 
         t.end();


### PR DESCRIPTION
`e.isSourceLoaded` is intended to return true if a source has no outstanding network requests (see [docs](https://docs.mapbox.com/mapbox-gl-js/api/events/#mapdataevent) for isSourceLoaded in the Map Data Event). Previously, `e.isSourceLoaded` used `this.loaded()` from style.js to determine its value. `this.loaded()` in [src/style/style.js](https://github.com/mapbox/mapbox-gl-js/blob/main/src/style/style.js#L429) however checks all sources to see if they are loaded rather than that specific source id. This fix uses the logic of [`map.isSourceLoaded`](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#issourceloaded) to check if that specific source id is loaded.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix e.isSourceLoaded to check if specific source has loaded.</changelog>`
