### PR TITLE
Log a warning when the map container isn't empty

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -483,6 +483,10 @@ class Map extends Camera {
             throw new Error(`Invalid type: 'container' must be a String or HTMLElement.`);
         }
 
+        if (this._container.childNodes.length > 0) {
+            warnOnce(`The map container element should be empty; otherwise the map's interactivity will be negatively impacted. If you want to display a message when WebGL is not supported, use the Mapbox GL Supported plugin instead.`);
+        }
+
         if (options.maxBounds) {
             this.setMaxBounds(options.maxBounds);
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -484,7 +484,7 @@ class Map extends Camera {
         }
 
         if (this._container.childNodes.length > 0) {
-            warnOnce(`The map container element should be empty; otherwise the map's interactivity will be negatively impacted. If you want to display a message when WebGL is not supported, use the Mapbox GL Supported plugin instead.`);
+            warnOnce(`The map container element should be empty, otherwise the map's interactivity will be negatively impacted. If you want to display a message when WebGL is not supported, use the Mapbox GL Supported plugin instead.`);
         }
 
         if (options.maxBounds) {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -55,6 +55,18 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('warns when map container is not empty', (t) => {
+        const container = window.document.createElement('div');
+        container.textContent = 'Hello World';
+
+        const stub = t.stub(console, 'warn');
+        new Map({container, testMode: true});
+
+        t.ok(stub.calledOnce);
+
+        t.end();
+    });
+
     t.test('bad map-specific token breaks map', (t) => {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'offsetWidth', {value: 512});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -58,9 +58,9 @@ test('Map', (t) => {
     t.test('warns when map container is not empty', (t) => {
         const container = window.document.createElement('div');
         container.textContent = 'Hello World';
-
         const stub = t.stub(console, 'warn');
-        new Map({container, testMode: true});
+
+        createMap(t, {container, testMode: true});
 
         t.ok(stub.calledOnce);
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - Closes https://github.com/mapbox/mapbox-gl-js/issues/9721 by logging a warning if the map container is not an empty element
 - [x] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
