### PR TITLE
Apply border-radius to control buttons

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -147,15 +147,15 @@
     box-shadow: none;
 }
 
-.mapboxgl-ctrl-group button:focus:first-child {
+.mapboxgl-ctrl-group button:first-child {
     border-radius: 4px 4px 0 0;
 }
 
-.mapboxgl-ctrl-group button:focus:last-child {
+.mapboxgl-ctrl-group button:last-child {
     border-radius: 0 0 4px 4px;
 }
 
-.mapboxgl-ctrl-group button:focus:only-child {
+.mapboxgl-ctrl-group button:only-child {
     border-radius: inherit;
 }
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -135,18 +135,6 @@
     opacity: 0.25;
 }
 
-.mapboxgl-ctrl button:not(:disabled):hover {
-    background-color: rgba(0, 0, 0, 0.05);
-}
-
-.mapboxgl-ctrl-group button:focus:focus-visible {
-    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
-}
-
-.mapboxgl-ctrl-group button:focus:not(:focus-visible) {
-    box-shadow: none;
-}
-
 .mapboxgl-ctrl-group button:first-child {
     border-radius: 4px 4px 0 0;
 }
@@ -157,6 +145,18 @@
 
 .mapboxgl-ctrl-group button:only-child {
     border-radius: inherit;
+}
+
+.mapboxgl-ctrl button:not(:disabled):hover {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.mapboxgl-ctrl-group button:focus:focus-visible {
+    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
+}
+
+.mapboxgl-ctrl-group button:focus:not(:focus-visible) {
+    box-shadow: none;
 }
 
 .mapboxgl-ctrl button.mapboxgl-ctrl-zoom-out .mapboxgl-ctrl-icon {


### PR DESCRIPTION
This PR applies the correct border radius to control buttons with hover effects. Currently, it is only applied to the button with a focus.

**Before:**

<img width="145" alt="Screen Shot 2022-01-20 at 1 45 28 PM" src="https://user-images.githubusercontent.com/723188/150321732-57c24790-7f97-4f41-aa5e-ab934e5f121b.png"> <img width="145" alt="Screen Shot 2022-01-20 at 1 45 37 PM" src="https://user-images.githubusercontent.com/723188/150321747-5babe50e-0171-410b-a06f-b9a41cb2b0be.png">

**After:**
<img width="145" alt="Screen Shot 2022-01-20 at 1 43 13 PM" src="https://user-images.githubusercontent.com/723188/150321786-686d0f9e-18a4-4237-9688-d90ff46a9d17.png"> <img width="145" alt="Screen Shot 2022-01-20 at 1 44 50 PM" src="https://user-images.githubusercontent.com/723188/150321793-3ae8b865-7852-4839-bb66-2894007f1b2d.png">



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Apply border-radius to control buttons</changelog>`
