### PR TITLE
Upgrade Flow to v0.130

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -47,7 +47,7 @@
 .*/_site/.*
 
 [version]
-0.118.0
+0.130.0
 
 [options]
 server.max_workers=4

--- a/.flowconfig
+++ b/.flowconfig
@@ -47,7 +47,7 @@
 .*/_site/.*
 
 [version]
-0.108.0
+0.109.0
 
 [options]
 server.max_workers=4

--- a/.flowconfig
+++ b/.flowconfig
@@ -47,7 +47,7 @@
 .*/_site/.*
 
 [version]
-0.109.0
+0.118.0
 
 [options]
 server.max_workers=4

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.118.0",
+    "flow-bin": "0.130.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.109.0",
+    "flow-bin": "0.118.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.108.0",
+    "flow-bin": "0.109.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/src/gl/index_buffer.js
+++ b/src/gl/index_buffer.js
@@ -23,10 +23,6 @@ class IndexBuffer {
 
         context.bindElementBuffer.set(this.buffer);
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, array.arrayBuffer, this.dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
-
-        if (!this.dynamicDraw) {
-            delete array.arrayBuffer;
-        }
     }
 
     bind() {

--- a/src/gl/vertex_buffer.js
+++ b/src/gl/vertex_buffer.js
@@ -53,10 +53,6 @@ class VertexBuffer {
         this.buffer = gl.createBuffer();
         context.bindVertexBuffer.set(this.buffer);
         gl.bufferData(gl.ARRAY_BUFFER, array.arrayBuffer, this.dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
-
-        if (!this.dynamicDraw) {
-            delete array.arrayBuffer;
-        }
     }
 
     bind() {

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -93,26 +93,29 @@ function drawTileQueryGeometry(painter, sourceCache, coord: OverscaledTileID) {
     // Bind the empty texture for drawing outlines
     painter.emptyTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
-    if (tile.queryGeometryDebugViz && tile.queryGeometryDebugViz.vertices.length > 0) {
-        tile.queryGeometryDebugViz.lazyUpload(context);
-        const vertexBuffer = tile.queryGeometryDebugViz.vertexBuffer;
-        const indexBuffer = tile.queryGeometryDebugViz.indexBuffer;
-        const segments = tile.queryGeometryDebugViz.segments;
+    const queryViz = tile.queryGeometryDebugViz;
+    const boundsViz = tile.queryBoundsDebugViz;
+
+    if (queryViz && queryViz.vertices.length > 0) {
+        queryViz.lazyUpload(context);
+        const vertexBuffer = queryViz.vertexBuffer;
+        const indexBuffer = queryViz.indexBuffer;
+        const segments = queryViz.segments;
         if (vertexBuffer != null && indexBuffer != null && segments != null) {
             program.draw(context, gl.LINE_STRIP, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
-                debugUniformValues(posMatrix, tile.queryGeometryDebugViz.color), id,
+                debugUniformValues(posMatrix, queryViz.color), id,
                 vertexBuffer, indexBuffer, segments);
         }
     }
 
-    if (tile.queryBoundsDebugViz && tile.queryBoundsDebugViz.vertices.length > 0) {
-        tile.queryBoundsDebugViz.lazyUpload(context);
-        const vertexBuffer = tile.queryBoundsDebugViz.vertexBuffer;
-        const indexBuffer = tile.queryBoundsDebugViz.indexBuffer;
-        const segments = tile.queryBoundsDebugViz.segments;
+    if (boundsViz && boundsViz.vertices.length > 0) {
+        boundsViz.lazyUpload(context);
+        const vertexBuffer = boundsViz.vertexBuffer;
+        const indexBuffer = boundsViz.indexBuffer;
+        const segments = boundsViz.segments;
         if (vertexBuffer != null && indexBuffer != null && segments != null) {
             program.draw(context, gl.LINE_STRIP, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
-                debugUniformValues(posMatrix, tile.queryBoundsDebugViz.color), id,
+                debugUniformValues(posMatrix, boundsViz.color), id,
                 vertexBuffer, indexBuffer, segments);
         }
     }

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -84,7 +84,8 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
         painter.prepareDrawProgram(context, program, unwrappedTileID);
 
         if (source instanceof ImageSource) {
-            program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.disabled,
+            if (source.boundsBuffer && source.boundsSegments) program.draw(
+                context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.disabled,
                 uniformValues, layer.id, source.boundsBuffer,
                 painter.quadTriangleIndexBuffer, source.boundsSegments);
         } else {

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -3,8 +3,6 @@
 import ImageSource from './image_source.js';
 
 import window from '../util/window.js';
-import boundsAttributes from '../data/bounds_attributes.js';
-import SegmentVector from '../data/segment.js';
 import Texture from '../render/texture.js';
 import {ErrorEvent} from '../util/evented.js';
 import ValidationError from '../style-spec/error/validation_error.js';
@@ -207,33 +205,14 @@ class CanvasSource extends ImageSource {
         if (Object.keys(this.tiles).length === 0) return; // not enough data for current position
 
         const context = this.map.painter.context;
-        const gl = context.gl;
-
-        if (!this._boundsArray) {
-            this._makeBoundsArray();
-        }
-
-        if (!this.boundsBuffer) {
-            this.boundsBuffer = context.createVertexBuffer(this._boundsArray, boundsAttributes.members);
-        }
-
-        if (!this.boundsSegments) {
-            this.boundsSegments = SegmentVector.simpleSegment(0, 0, 4, 2);
-        }
 
         if (!this.texture) {
-            this.texture = new Texture(context, this.canvas, gl.RGBA, {premultiply: true});
+            this.texture = new Texture(context, this.canvas, context.gl.RGBA, {premultiply: true});
         } else if (resize || this._playing) {
             this.texture.update(this.canvas, {premultiply: true});
         }
 
-        for (const w in this.tiles) {
-            const tile = this.tiles[w];
-            if (tile.state !== 'loaded') {
-                tile.state = 'loaded';
-                tile.texture = this.texture;
-            }
-        }
+        this._prepareData(context);
     }
 
     serialize(): Object {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -136,8 +136,8 @@ class Tile {
     dependencies: Object;
     projection: Projection;
 
-    queryGeometryDebugViz: TileSpaceDebugBuffer;
-    queryBoundsDebugViz: TileSpaceDebugBuffer;
+    queryGeometryDebugViz: ?TileSpaceDebugBuffer;
+    queryBoundsDebugViz: ?TileSpaceDebugBuffer;
 
     _tileDebugBuffer: ?VertexBuffer;
     _tileBoundsBuffer: ?VertexBuffer;
@@ -391,15 +391,17 @@ class Tile {
                           visualizeQueryGeometry: boolean): {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
         Debug.run(() => {
             if (visualizeQueryGeometry) {
-                if (!this.queryGeometryDebugViz) {
-                    this.queryGeometryDebugViz = new TileSpaceDebugBuffer(this.tileSize);
+                let geometryViz = this.queryGeometryDebugViz;
+                let boundsViz = this.queryBoundsDebugViz;
+                if (!geometryViz) {
+                    geometryViz = this.queryGeometryDebugViz = new TileSpaceDebugBuffer(this.tileSize);
                 }
-                if (!this.queryBoundsDebugViz) {
-                    this.queryBoundsDebugViz = new TileSpaceDebugBuffer(this.tileSize, Color.blue);
+                if (!boundsViz) {
+                    boundsViz = this.queryBoundsDebugViz = new TileSpaceDebugBuffer(this.tileSize, Color.blue);
                 }
 
-                this.queryGeometryDebugViz.addPoints(tileResult.tilespaceGeometry);
-                this.queryBoundsDebugViz.addPoints(tileResult.bufferedTilespaceGeometry);
+                geometryViz.addPoints(tileResult.tilespaceGeometry);
+                boundsViz.addPoints(tileResult.bufferedTilespaceGeometry);
             }
         });
 

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -3,8 +3,6 @@
 import {getVideo, ResourceType} from '../util/ajax.js';
 
 import ImageSource from './image_source.js';
-import boundsAttributes from '../data/bounds_attributes.js';
-import SegmentVector from '../data/segment.js';
 import Texture from '../render/texture.js';
 import {ErrorEvent} from '../util/evented.js';
 import ValidationError from '../style-spec/error/validation_error.js';
@@ -219,25 +217,7 @@ class VideoSource extends ImageSource {
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.video);
         }
 
-        if (!this._boundsArray) {
-            this._makeBoundsArray();
-        }
-
-        if (!this.boundsBuffer) {
-            this.boundsBuffer = context.createVertexBuffer(this._boundsArray, boundsAttributes.members);
-        }
-
-        if (!this.boundsSegments) {
-            this.boundsSegments = SegmentVector.simpleSegment(0, 0, 4, 2);
-        }
-
-        for (const w in this.tiles) {
-            const tile = this.tiles[w];
-            if (tile.state !== 'loaded') {
-                tile.state = 'loaded';
-                tile.texture = this.texture;
-            }
-        }
+        this._prepareData(context);
     }
 
     serialize() {

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -56,7 +56,7 @@ class WorkerTile {
     collisionBoxArray: CollisionBoxArray;
 
     abort: ?() => void;
-    reloadCallback: WorkerTileCallback;
+    reloadCallback: ?WorkerTileCallback;
     vectorTile: VectorTile;
 
     constructor(params: WorkerTileParameters) {

--- a/src/style-spec/feature_filter/convert.js
+++ b/src/style-spec/feature_filter/convert.js
@@ -94,11 +94,11 @@ function _convertFilter(filter: FilterSpecification, expectedTypes: ExpectedType
         const children = (filter: any).slice(1).map(f => _convertFilter(f, expectedTypes));
         return children.length > 1 ? ['all'].concat(children) : [].concat(...children);
     } else if (op === 'none') {
-        return ['!', _convertFilter(['any'].concat(filter.slice(1)), {})];
+        return ['!', _convertFilter(['any'].concat((filter.slice: any)(1)), {})];
     } else if (op === 'in') {
-        converted = convertInOp((filter[1]: any), filter.slice(2));
+        converted = convertInOp((filter[1]: any), (filter.slice: any)(2));
     } else if (op === '!in') {
-        converted = convertInOp((filter[1]: any), filter.slice(2), true);
+        converted = convertInOp((filter[1]: any), (filter.slice: any)(2), true);
     } else if (op === 'has') {
         converted = convertHasOp((filter[1]: any));
     } else if (op === '!has') {

--- a/src/style-spec/feature_filter/convert.js
+++ b/src/style-spec/feature_filter/convert.js
@@ -94,11 +94,11 @@ function _convertFilter(filter: FilterSpecification, expectedTypes: ExpectedType
         const children = (filter: any).slice(1).map(f => _convertFilter(f, expectedTypes));
         return children.length > 1 ? ['all'].concat(children) : [].concat(...children);
     } else if (op === 'none') {
-        return ['!', _convertFilter(['any'].concat((filter.slice: any)(1)), {})];
+        return ['!', _convertFilter(['any'].concat((filter: any).slice(1)), {})];
     } else if (op === 'in') {
-        converted = convertInOp((filter[1]: any), (filter.slice: any)(2));
+        converted = convertInOp((filter[1]: any), filter.slice(2));
     } else if (op === '!in') {
-        converted = convertInOp((filter[1]: any), (filter.slice: any)(2), true);
+        converted = convertInOp((filter[1]: any), filter.slice(2), true);
     } else if (op === 'has') {
         converted = convertHasOp((filter[1]: any));
     } else if (op === '!has') {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -214,8 +214,8 @@ export class Terrain extends Elevation {
     _stencilRef: number;
 
     _exaggeration: number;
-    _depthFBO: Framebuffer;
-    _depthTexture: Texture;
+    _depthFBO: ?Framebuffer;
+    _depthTexture: ?Texture;
     _previousZoom: number;
     _updateTimestamp: number;
     _useVertexMorphing: boolean;
@@ -385,8 +385,8 @@ export class Terrain extends Elevation {
         this.pool = [];
         if (this._depthFBO) {
             this._depthFBO.destroy();
-            delete this._depthFBO;
-            delete this._depthTexture;
+            this._depthFBO = undefined;
+            this._depthTexture = undefined;
         }
     }
 
@@ -643,8 +643,8 @@ export class Terrain extends Elevation {
 
         context.activeTexture.set(gl.TEXTURE3);
         if (options && options.useDepthForOcclusion) {
-            this._depthTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
-            uniforms['u_depth_size_inv'] = [1 / this._depthFBO.width, 1 / this._depthFBO.height];
+            if (this._depthTexture) this._depthTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+            if (this._depthFBO) uniforms['u_depth_size_inv'] = [1 / this._depthFBO.width, 1 / this._depthFBO.height];
         } else {
             this.emptyDepthBufferTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
             uniforms['u_depth_size_inv'] = [1, 1];
@@ -1213,8 +1213,8 @@ export class Terrain extends Elevation {
         const width = Math.ceil(painter.width), height = Math.ceil(painter.height);
         if (this._depthFBO && (this._depthFBO.width !== width || this._depthFBO.height !== height)) {
             this._depthFBO.destroy();
-            delete this._depthFBO;
-            delete this._depthTexture;
+            this._depthFBO = undefined;
+            this._depthTexture = undefined;
         }
         if (!this._depthFBO) {
             const gl = context.gl;

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -647,7 +647,7 @@ class GeolocateControl extends Evented {
 
         if (typeof window.DeviceMotionEvent !== "undefined" &&
             typeof window.DeviceMotionEvent.requestPermission === 'function') {
-            //$FlowFixMe[incompatible-type]
+            // $FlowFixMe
             DeviceOrientationEvent.requestPermission()
                 .then(response => {
                     if (response === 'granted') {

--- a/src/ui/handler/map_event.js
+++ b/src/ui/handler/map_event.js
@@ -6,7 +6,7 @@ import type Map from '../map.js';
 
 export class MapEventHandler {
 
-    _mousedownPos: Point;
+    _mousedownPos: ?Point;
     _clickTolerance: number;
     _map: Map;
 
@@ -16,7 +16,7 @@ export class MapEventHandler {
     }
 
     reset() {
-        delete this._mousedownPos;
+        this._mousedownPos = undefined;
     }
 
     wheel(e: WheelEvent) {
@@ -110,7 +110,7 @@ export class MapEventHandler {
 export class BlockableMapEventHandler {
     _map: Map;
     _delayContextMenu: boolean;
-    _contextMenuEvent: MouseEvent;
+    _contextMenuEvent: ?MouseEvent;
 
     constructor(map: Map) {
         this._map = map;
@@ -118,7 +118,7 @@ export class BlockableMapEventHandler {
 
     reset() {
         this._delayContextMenu = false;
-        delete this._contextMenuEvent;
+        this._contextMenuEvent = undefined;
     }
 
     mousemove(e: MouseEvent) {

--- a/src/ui/handler/mouse.js
+++ b/src/ui/handler/mouse.js
@@ -21,8 +21,8 @@ class MouseHandler {
 
     _enabled: boolean;
     _active: boolean;
-    _lastPoint: Point;
-    _eventButton: number;
+    _lastPoint: ?Point;
+    _eventButton: ?number;
     _moved: boolean;
     _clickTolerance: number;
 
@@ -38,8 +38,8 @@ class MouseHandler {
     reset() {
         this._active = false;
         this._moved = false;
-        delete this._lastPoint;
-        delete this._eventButton;
+        this._lastPoint = undefined;
+        this._eventButton = undefined;
     }
 
     _correctButton(e: MouseEvent, button: number) {  //eslint-disable-line
@@ -65,7 +65,7 @@ class MouseHandler {
         if (!lastPoint) return;
         e.preventDefault();
 
-        if (buttonStillPressed(e, this._eventButton)) {
+        if (this._eventButton != null && buttonStillPressed(e, this._eventButton)) {
             // Some browsers don't fire a `mouseup` when the mouseup occurs outside
             // the window or iframe:
             // https://github.com/mapbox/mapbox-gl-js/issues/4622

--- a/src/ui/handler/tap_drag_zoom.js
+++ b/src/ui/handler/tap_drag_zoom.js
@@ -7,7 +7,7 @@ export default class TapDragZoomHandler {
 
     _enabled: boolean;
     _active: boolean;
-    _swipePoint: Point;
+    _swipePoint: ?Point;
     _swipeTouch: number;
     _tapTime: number;
     _tap: TapRecognizer;
@@ -24,9 +24,9 @@ export default class TapDragZoomHandler {
 
     reset() {
         this._active = false;
-        delete this._swipePoint;
-        delete this._swipeTouch;
-        delete this._tapTime;
+        this._swipePoint = undefined;
+        this._swipeTouch = 0;
+        this._tapTime = 0;
         this._tap.reset();
     }
 

--- a/src/ui/handler/tap_recognizer.js
+++ b/src/ui/handler/tap_recognizer.js
@@ -18,7 +18,7 @@ const MAX_DIST = 30;
 export class SingleTapRecognizer {
 
     numTouches: number;
-    centroid: Point;
+    centroid: ?Point;
     startTime: number;
     aborted: boolean;
     touches: { [number | string]: Point };
@@ -29,9 +29,9 @@ export class SingleTapRecognizer {
     }
 
     reset() {
-        delete this.centroid;
-        delete this.startTime;
-        delete this.touches;
+        this.centroid = undefined;
+        this.startTime = 0;
+        this.touches = {};
         this.aborted = false;
     }
 
@@ -86,7 +86,7 @@ export class TapRecognizer {
     singleTap: SingleTapRecognizer;
     numTaps: number;
     lastTime: number;
-    lastTap: Point;
+    lastTap: ?Point;
     count: number;
 
     constructor(options: { numTaps: number, numTouches: number }) {
@@ -97,7 +97,7 @@ export class TapRecognizer {
 
     reset() {
         this.lastTime = Infinity;
-        delete this.lastTap;
+        this.lastTap = undefined;
         this.count = 0;
         this.singleTap.reset();
     }

--- a/src/ui/handler/tap_recognizer.js
+++ b/src/ui/handler/tap_recognizer.js
@@ -44,7 +44,7 @@ export class SingleTapRecognizer {
             return;
         }
 
-        if (this.startTime === undefined) {
+        if (this.startTime === 0) {
             this.startTime = e.timeStamp;
         }
 

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -8,9 +8,9 @@ class TwoTouchHandler {
 
     _enabled: boolean;
     _active: boolean;
-    _firstTwoTouches: [number, number];
-    _vector: Point;
-    _startVector: Point;
+    _firstTwoTouches: ?[number, number];
+    _vector: ?Point;
+    _startVector: ?Point;
     _aroundCenter: boolean;
 
     constructor() {
@@ -19,7 +19,7 @@ class TwoTouchHandler {
 
     reset() {
         this._active = false;
-        delete this._firstTwoTouches;
+        this._firstTwoTouches = undefined;
     }
 
     _start(points: [Point, Point]) {} //eslint-disable-line
@@ -40,11 +40,12 @@ class TwoTouchHandler {
     }
 
     touchmove(e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) {
-        if (!this._firstTwoTouches) return;
+        const firstTouches = this._firstTwoTouches;
+        if (!firstTouches) return;
 
         e.preventDefault();
 
-        const [idA, idB] = this._firstTwoTouches;
+        const [idA, idB] = firstTouches;
         const a = getTouchById(mapTouches, points, idA);
         const b = getTouchById(mapTouches, points, idB);
         if (!a || !b) return;
@@ -112,8 +113,8 @@ export class TouchZoomHandler extends TwoTouchHandler {
 
     reset() {
         super.reset();
-        delete this._distance;
-        delete this._startDistance;
+        this._distance = 0;
+        this._startDistance = 0;
     }
 
     _start(points: [Point, Point]) {
@@ -145,9 +146,9 @@ export class TouchRotateHandler extends TwoTouchHandler {
 
     reset() {
         super.reset();
-        delete this._minDiameter;
-        delete this._startVector;
-        delete this._vector;
+        this._minDiameter = 0;
+        this._startVector = undefined;
+        this._vector = undefined;
     }
 
     _start(points: [Point, Point]) {
@@ -204,8 +205,8 @@ const ALLOWED_SINGLE_TOUCH_TIME = 100;
 export class TouchPitchHandler extends TwoTouchHandler {
 
     _valid: boolean | void;
-    _firstMove: number;
-    _lastPoints: [Point, Point];
+    _firstMove: ?number;
+    _lastPoints: ?[Point, Point];
     _map: Map;
 
     constructor(map: Map) {
@@ -216,8 +217,8 @@ export class TouchPitchHandler extends TwoTouchHandler {
     reset() {
         super.reset();
         this._valid = undefined;
-        delete this._firstMove;
-        delete this._lastPoints;
+        this._firstMove = undefined;
+        this._lastPoints = undefined;
     }
 
     _start(points: [Point, Point]) {
@@ -225,14 +226,15 @@ export class TouchPitchHandler extends TwoTouchHandler {
         if (isVertical(points[0].sub(points[1]))) {
             // fingers are more horizontal than vertical
             this._valid = false;
-
         }
 
     }
 
     _move(points: [Point, Point], center: Point, e: TouchEvent) {
-        const vectorA = points[0].sub(this._lastPoints[0]);
-        const vectorB = points[1].sub(this._lastPoints[1]);
+        const lastPoints = this._lastPoints;
+        if (!lastPoints) return;
+        const vectorA = points[0].sub(lastPoints[0]);
+        const vectorB = points[1].sub(lastPoints[1]);
 
         if (this._map._cooperativeGestures && e.touches.length < 3) return;
 
@@ -262,7 +264,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
         // One finger has moved and the other has not.
         // If enough time has passed, decide it is not a pitch.
         if (!movedA || !movedB) {
-            if (this._firstMove === undefined) {
+            if (this._firstMove == null) {
                 this._firstMove = timeStamp;
             }
 

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -148,7 +148,7 @@ class HandlerManager {
     _el: HTMLElement;
     _handlers: Array<{ handlerName: string, handler: Handler, allowed: any }>;
     _eventsInProgress: Object;
-    _frameId: number;
+    _frameId: ?number;
     _inertia: HandlerInertia;
     _bearingSnap: number;
     _handlersById: { [string]: Handler };
@@ -645,7 +645,7 @@ class HandlerManager {
     _requestFrame() {
         this._map.triggerRepaint();
         return this._map._renderTaskQueue.add(timeStamp => {
-            delete this._frameId;
+            this._frameId = undefined;
             this.handleEvent(new RenderFrameEvent('renderFrame', {timeStamp}));
             this._applyChanges();
         });

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -13,7 +13,7 @@ import type Map from './map.js';
  * @returns {Hash} `this`
  */
 class Hash {
-    _map: Map;
+    _map: ?Map;
     _updateHash: () => ?TimeoutID;
     _hashName: ?string;
 
@@ -48,24 +48,28 @@ class Hash {
      * @returns {Popup} `this`
      */
     remove() {
-        window.removeEventListener('hashchange', this._onHashChange, false);
+        if (!this._map) return this;
+
         this._map.off('moveend', this._updateHash);
+        window.removeEventListener('hashchange', this._onHashChange, false);
         clearTimeout(this._updateHash());
 
-        delete this._map;
+        this._map = undefined;
         return this;
     }
 
     getHashString(mapFeedback?: boolean) {
-        const center = this._map.getCenter(),
-            zoom = Math.round(this._map.getZoom() * 100) / 100,
+        const map = this._map;
+        if (!map) return;
+        const center = map.getCenter(),
+            zoom = Math.round(map.getZoom() * 100) / 100,
             // derived from equation: 512px * 2^z / 360 / 10^d < 0.5px
             precision = Math.ceil((zoom * Math.LN2 + Math.log(512 / 360 / 0.5)) / Math.LN10),
             m = Math.pow(10, precision),
             lng = Math.round(center.lng * m) / m,
             lat = Math.round(center.lat * m) / m,
-            bearing = this._map.getBearing(),
-            pitch = this._map.getPitch();
+            bearing = map.getBearing(),
+            pitch = map.getPitch();
         let hash = '';
         if (mapFeedback) {
             // new map feedback site has some constraints that don't allow
@@ -117,10 +121,12 @@ class Hash {
     }
 
     _onHashChange() {
+        const map = this._map;
+        if (!map) return;
         const loc = this._getCurrentHash();
         if (loc.length >= 3 && !loc.some(v => isNaN(v))) {
-            const bearing = this._map.dragRotate.isEnabled() && this._map.touchZoomRotate.isEnabled() ? +(loc[3] || 0) : this._map.getBearing();
-            this._map.jumpTo({
+            const bearing = map.dragRotate.isEnabled() && map.touchZoomRotate.isEnabled() ? +(loc[3] || 0) : map.getBearing();
+            map.jumpTo({
                 center: [+loc[2], +loc[1]],
                 zoom: +loc[0],
                 bearing,

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -38,7 +38,7 @@ class Hash {
     addTo(map: Map) {
         this._map = map;
         window.addEventListener('hashchange', this._onHashChange, false);
-        this._map.on('moveend', this._updateHash);
+        map.on('moveend', this._updateHash);
         return this;
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1173,7 +1173,7 @@ class Map extends Camera {
                 }
             };
 
-            return {layers: new Set(layers), listener, delegates: {[type]: delegate}};
+            return {layers: new Set(layers), listener, delegates: {[(type: string)]: delegate}};
         }
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -306,7 +306,7 @@ const defaultOptions = {
 class Map extends Camera {
     style: Style;
     painter: Painter;
-    handlers: HandlerManager;
+    handlers: ?HandlerManager;
 
     _container: HTMLElement;
     _missingCSSCanary: HTMLElement;
@@ -1098,7 +1098,7 @@ class Map extends Camera {
      * const isMoving = map.isMoving();
      */
     isMoving(): boolean {
-        return this._moving || this.handlers && this.handlers.isMoving();
+        return this._moving || this.handlers && this.handlers.isMoving() || false;
     }
 
     /**
@@ -1109,7 +1109,7 @@ class Map extends Camera {
      * const isZooming = map.isZooming();
      */
     isZooming(): boolean {
-        return this._zooming || this.handlers && this.handlers.isZooming();
+        return this._zooming || this.handlers && this.handlers.isZooming() || false;
     }
 
     /**
@@ -1120,7 +1120,7 @@ class Map extends Camera {
      * map.isRotating();
      */
     isRotating(): boolean {
-        return this._rotating || this.handlers && this.handlers.isRotating();
+        return this._rotating || this.handlers && this.handlers.isRotating() || false;
     }
 
     _createDelegatedListener(type: MapEvent, layers: Array<any>, listener: any) {
@@ -1662,7 +1662,7 @@ class Map extends Camera {
         if (this.style) {
             this.style.setEventedParent(null);
             this.style._remove();
-            delete this.style;
+            this.style = (undefined: any); // we lazy-init it so it's never undefined when accessed
         }
 
         if (style) {
@@ -3222,9 +3222,10 @@ class Map extends Camera {
             this.style.destroy();
         }
         this.painter.destroy();
-        this.handlers.destroy();
-        delete this.handlers;
+        if (this.handlers) this.handlers.destroy();
+        this.handlers = undefined;
         this.setStyle(null);
+
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
             window.removeEventListener('orientationchange', this._onWindowResize, false);

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -60,7 +60,7 @@ export const TERRAIN_OCCLUDED_OPACITY = 0.2;
  * @see [Example: Create a draggable Marker](https://www.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
  */
 export default class Marker extends Evented {
-    _map: Map;
+    _map: ?Map;
     _anchor: Anchor;
     _offset: Point;
     _element: HTMLElement;
@@ -203,7 +203,7 @@ export default class Marker extends Evented {
         // If we attached the `click` listener to the marker element, the popup
         // would close once the event propogated to `map` due to the
         // `Popup#_onClickClose` listener.
-        this._map.on('click', this._onMapClick);
+        map.on('click', this._onMapClick);
 
         return this;
     }
@@ -217,19 +217,20 @@ export default class Marker extends Evented {
      * @returns {Marker} Returns itself to allow for method chaining.
      */
     remove() {
-        if (this._map) {
-            this._map.off('click', this._onMapClick);
-            this._map.off('move', this._updateMoving);
-            this._map.off('moveend', this._update);
-            this._map.off('mousedown', this._addDragHandler);
-            this._map.off('touchstart', this._addDragHandler);
-            this._map.off('mouseup', this._onUp);
-            this._map.off('touchend', this._onUp);
-            this._map.off('mousemove', this._onMove);
-            this._map.off('touchmove', this._onMove);
-            this._map.off('remove', this._clearFadeTimer);
-            this._map._removeMarker(this);
-            delete this._map;
+        const map = this._map;
+        if (map) {
+            map.off('click', this._onMapClick);
+            map.off('move', this._updateMoving);
+            map.off('moveend', this._update);
+            map.off('mousedown', this._addDragHandler);
+            map.off('touchstart', this._addDragHandler);
+            map.off('mouseup', this._onUp);
+            map.off('touchend', this._onUp);
+            map.off('mousemove', this._onMove);
+            map.off('touchmove', this._onMove);
+            map.off('remove', this._clearFadeTimer);
+            map._removeMarker(this);
+            this._map = undefined;
         }
         this._clearFadeTimer();
         this._element.remove();

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -402,7 +402,7 @@ export default class Marker extends Evented {
         } else if (popup.isOpen()) {
             popup.remove();
             this._element.setAttribute('aria-expanded', 'false');
-        } else {
+        } else if (this._map) {
             popup.addTo(this._map);
             this._element.setAttribute('aria-expanded', 'true');
         }
@@ -410,18 +410,21 @@ export default class Marker extends Evented {
     }
 
     _evaluateOpacity() {
-        const position = this._pos ? this._pos.sub(this._transformedOffset()) : null;
+        const map = this._map;
+        if (!map) return;
 
-        if (!this._withinScreenBounds(position)) {
+        const pos = this._pos ? this._pos.sub(this._transformedOffset()) : null;
+
+        if (!pos || pos.x < 0 || pos.x > map.transform.width || pos.y < 0 || pos.y > map.transform.height) {
             this._clearFadeTimer();
             return;
         }
 
-        const mapLocation = this._map.unproject(position);
+        const mapLocation = map.unproject(pos);
 
         let terrainOccluded = false;
-        if (this._map.transform._terrainEnabled() && this._map.getTerrain()) {
-            const camera = this._map.getFreeCameraOptions();
+        if (map.transform._terrainEnabled() && map.getTerrain()) {
+            const camera = map.getFreeCameraOptions();
             if (camera.position) {
                 const cameraPos = camera.position.toLngLat();
                 // the distance to the marker lat/lng + marker offset location
@@ -431,7 +434,7 @@ export default class Marker extends Evented {
             }
         }
 
-        const fogOpacity = this._map._queryFogOpacity(mapLocation);
+        const fogOpacity = map._queryFogOpacity(mapLocation);
         const opacity = (1.0 - fogOpacity) * (terrainOccluded ? TERRAIN_OCCLUDED_OPACITY : 1.0);
         this._element.style.opacity = `${opacity}`;
         if (this._popup) this._popup._setOpacity(`${opacity}`);
@@ -446,13 +449,6 @@ export default class Marker extends Evented {
         }
     }
 
-    _withinScreenBounds(position: ?Point): boolean {
-        const tr = this._map.transform;
-        return !!position &&
-            position.x >= 0 && position.x < tr.width &&
-            position.y >= 0 && position.y < tr.height;
-    }
-
     _updateDOM() {
         const pos = this._pos || new Point(0, 0);
         const pitch = this._calculatePitch();
@@ -463,7 +459,7 @@ export default class Marker extends Evented {
     _calculatePitch() {
         if (this._pitchAlignment === "viewport" || this._pitchAlignment === "auto") {
             return 0;
-        } if (this._pitchAlignment === "map") {
+        } if (this._map && this._pitchAlignment === "map") {
             return this._map.getPitch();
         }
         return 0;
@@ -472,7 +468,7 @@ export default class Marker extends Evented {
     _calculateRotation() {
         if (this._rotationAlignment === "viewport" || this._rotationAlignment === "auto") {
             return this._rotation;
-        } if (this._rotationAlignment === "map") {
+        } if (this._map && this._rotationAlignment === "map") {
             return this._rotation - this._map.getBearing();
         }
         return 0;
@@ -480,13 +476,14 @@ export default class Marker extends Evented {
 
     _update(delaySnap?: boolean) {
         window.cancelAnimationFrame(this._updateFrameId);
-        if (!this._map) return;
+        const map = this._map;
+        if (!map) return;
 
-        if (this._map.transform.renderWorldCopies) {
-            this._lngLat = smartWrap(this._lngLat, this._pos, this._map.transform);
+        if (map.transform.renderWorldCopies) {
+            this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
         }
 
-        this._pos = this._map.project(this._lngLat)._add(this._transformedOffset());
+        this._pos = map.project(this._lngLat)._add(this._transformedOffset());
 
         // because rounding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
@@ -502,14 +499,14 @@ export default class Marker extends Evented {
             this._pos = this._pos.round();
         }
 
-        this._map._requestDomTask(() => {
+        map._requestDomTask(() => {
             if (!this._map) return;
 
             if (this._element && this._pos && this._anchor) {
                 this._updateDOM();
             }
 
-            if ((this._map.getTerrain() || this._map.getFog()) && !this._fadeTimer) {
+            if ((map.getTerrain() || map.getFog()) && !this._fadeTimer) {
                 this._fadeTimer = setTimeout(this._evaluateOpacity.bind(this), 60);
             }
         });
@@ -521,7 +518,7 @@ export default class Marker extends Evented {
      * @private
      */
     _transformedOffset() {
-        if (!this._defaultMarker) return this._offset;
+        if (!this._defaultMarker || !this._map) return this._offset;
         const tr = this._map.transform;
         const offset = this._offset.mult(this._scale);
         if (this._rotationAlignment === "map") offset._rotate(tr.angle);
@@ -555,14 +552,17 @@ export default class Marker extends Evented {
     }
 
     _onMove(e: MapMouseEvent | MapTouchEvent) {
+        const map = this._map;
+        if (!map) return;
+
         if (!this._isDragging) {
-            const clickTolerance = this._clickTolerance || this._map._clickTolerance;
+            const clickTolerance = this._clickTolerance || map._clickTolerance;
             this._isDragging = e.point.dist(this._pointerdownPos) >= clickTolerance;
         }
         if (!this._isDragging) return;
 
         this._pos = e.point.sub(this._positionDelta);
-        this._lngLat = this._map.unproject(this._pos);
+        this._lngLat = map.unproject(this._pos);
         this.setLngLat(this._lngLat);
         // suppress click event so that popups don't toggle on drag
         this._element.style.pointerEvents = 'none';
@@ -603,8 +603,12 @@ export default class Marker extends Evented {
         this._positionDelta = null;
         this._pointerdownPos = null;
         this._isDragging = false;
-        this._map.off('mousemove', this._onMove);
-        this._map.off('touchmove', this._onMove);
+
+        const map = this._map;
+        if (map) {
+            map.off('mousemove', this._onMove);
+            map.off('touchmove', this._onMove);
+        }
 
         // only fire dragend if it was preceded by at least one drag event
         if (this._state === 'active') {
@@ -624,6 +628,9 @@ export default class Marker extends Evented {
     }
 
     _addDragHandler(e: MapMouseEvent | MapTouchEvent) {
+        const map = this._map;
+        if (!map) return;
+
         if (this._element.contains((e.originalEvent.target: any))) {
             e.preventDefault();
 
@@ -638,10 +645,10 @@ export default class Marker extends Evented {
             this._pointerdownPos = e.point;
 
             this._state = 'pending';
-            this._map.on('mousemove', this._onMove);
-            this._map.on('touchmove', this._onMove);
-            this._map.once('mouseup', this._onUp);
-            this._map.once('touchend', this._onUp);
+            map.on('mousemove', this._onMove);
+            map.on('touchmove', this._onMove);
+            map.once('mouseup', this._onUp);
+            map.once('touchend', this._onUp);
         }
     }
 
@@ -658,13 +665,14 @@ export default class Marker extends Evented {
 
         // handle case where map may not exist yet
         // for example, when setDraggable is called before addTo
-        if (this._map) {
+        const map = this._map;
+        if (map) {
             if (shouldBeDraggable) {
-                this._map.on('mousedown', this._addDragHandler);
-                this._map.on('touchstart', this._addDragHandler);
+                map.on('mousedown', this._addDragHandler);
+                map.on('touchstart', this._addDragHandler);
             } else {
-                this._map.off('mousedown', this._addDragHandler);
-                this._map.off('touchstart', this._addDragHandler);
+                map.off('mousedown', this._addDragHandler);
+                map.off('touchstart', this._addDragHandler);
             }
         }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -100,12 +100,12 @@ const focusQuerySelector = [
  * @see [Example: Attach a popup to a marker instance](https://www.mapbox.com/mapbox-gl-js/example/set-popup/)
  */
 export default class Popup extends Evented {
-    _map: Map;
+    _map: ?Map;
     options: PopupOptions;
-    _content: HTMLElement;
-    _container: HTMLElement;
-    _closeButton: HTMLElement;
-    _tip: HTMLElement;
+    _content: ?HTMLElement;
+    _container: ?HTMLElement;
+    _closeButton: ?HTMLElement;
+    _tip: ?HTMLElement;
     _lngLat: LngLat;
     _trackPointer: boolean;
     _pos: ?Point;
@@ -140,23 +140,23 @@ export default class Popup extends Evented {
 
         this._map = map;
         if (this.options.closeOnClick) {
-            this._map.on('preclick', this._onClose);
+            map.on('preclick', this._onClose);
         }
 
         if (this.options.closeOnMove) {
-            this._map.on('move', this._onClose);
+            map.on('move', this._onClose);
         }
 
-        this._map.on('remove', this.remove);
+        map.on('remove', this.remove);
         this._update();
         this._focusFirstElement();
 
         if (this._trackPointer) {
-            this._map.on('mousemove', this._onMouseMove);
-            this._map.on('mouseup', this._onMouseUp);
-            this._map._canvasContainer.classList.add('mapboxgl-track-pointer');
+            map.on('mousemove', this._onMouseMove);
+            map.on('mouseup', this._onMouseUp);
+            map._canvasContainer.classList.add('mapboxgl-track-pointer');
         } else {
-            this._map.on('move', this._update);
+            map.on('move', this._update);
         }
 
         /**
@@ -209,18 +209,19 @@ export default class Popup extends Evented {
 
         if (this._container) {
             this._container.remove();
-            delete this._container;
+            this._container = undefined;
         }
 
-        if (this._map) {
-            this._map.off('move', this._update);
-            this._map.off('move', this._onClose);
-            this._map.off('click', this._onClose);
-            this._map.off('remove', this.remove);
-            this._map.off('mousemove', this._onMouseMove);
-            this._map.off('mouseup', this._onMouseUp);
-            this._map.off('drag', this._onDrag);
-            delete this._map;
+        const map = this._map;
+        if (map) {
+            map.off('move', this._update);
+            map.off('move', this._onClose);
+            map.off('click', this._onClose);
+            map.off('remove', this.remove);
+            map.off('mousemove', this._onMouseMove);
+            map.off('mouseup', this._onMouseUp);
+            map.off('drag', this._onDrag);
+            this._map = undefined;
         }
 
         /**
@@ -278,10 +279,11 @@ export default class Popup extends Evented {
 
         this._update();
 
-        if (this._map) {
-            this._map.on('move', this._update);
-            this._map.off('mousemove', this._onMouseMove);
-            this._map._canvasContainer.classList.remove('mapboxgl-track-pointer');
+        const map = this._map;
+        if (map) {
+            map.on('move', this._update);
+            map.off('mousemove', this._onMouseMove);
+            map._canvasContainer.classList.remove('mapboxgl-track-pointer');
         }
 
         return this;
@@ -302,11 +304,12 @@ export default class Popup extends Evented {
         this._trackPointer = true;
         this._pos = null;
         this._update();
-        if (this._map) {
-            this._map.off('move', this._update);
-            this._map.on('mousemove', this._onMouseMove);
-            this._map.on('drag', this._onDrag);
-            this._map._canvasContainer.classList.add('mapboxgl-track-pointer');
+        const map = this._map;
+        if (map) {
+            map.off('move', this._update);
+            map.on('mousemove', this._onMouseMove);
+            map.on('drag', this._onDrag);
+            map._canvasContainer.classList.add('mapboxgl-track-pointer');
         }
 
         return this;
@@ -423,20 +426,29 @@ export default class Popup extends Evented {
      *     .addTo(map);
      */
     setDOMContent(htmlNode: Node) {
-        if (this._content) {
+        let content = this._content;
+        if (content) {
             // Clear out children first.
-            while (this._content.hasChildNodes()) {
-                if (this._content.firstChild) {
-                    this._content.removeChild(this._content.firstChild);
+            while (content.hasChildNodes()) {
+                if (content.firstChild) {
+                    content.removeChild(content.firstChild);
                 }
             }
         } else {
-            this._content = DOM.create('div', 'mapboxgl-popup-content', this._container);
+            content = this._content = DOM.create('div', 'mapboxgl-popup-content', this._container || undefined);
         }
 
         // The close button should be the last tabbable element inside the popup for a good keyboard UX.
-        this._content.appendChild(htmlNode);
-        this._createCloseButton();
+        content.appendChild(htmlNode);
+
+        if (this.options.closeButton) {
+            const button = this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', content);
+            button.type = 'button';
+            button.setAttribute('aria-label', 'Close popup');
+            button.setAttribute('aria-hidden', 'true');
+            button.innerHTML = '&#215;';
+            button.addEventListener('click', this._onClose);
+        }
         this._update();
         this._focusFirstElement();
         return this;
@@ -454,9 +466,7 @@ export default class Popup extends Evented {
      */
     addClassName(className: string) {
         this._classList.add(className);
-        if (this._container) {
-            this._updateClassList();
-        }
+        this._updateClassList();
         return this;
     }
 
@@ -472,9 +482,7 @@ export default class Popup extends Evented {
      */
     removeClassName(className: string) {
         this._classList.delete(className);
-        if (this._container) {
-            this._updateClassList();
-        }
+        this._updateClassList();
         return this;
     }
 
@@ -523,21 +531,8 @@ export default class Popup extends Evented {
             this._classList.add(className);
             finalState = true;
         }
-        if (this._container) {
-            this._updateClassList();
-        }
+        this._updateClassList();
         return finalState;
-    }
-
-    _createCloseButton() {
-        if (this.options.closeButton) {
-            this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._content);
-            this._closeButton.type = 'button';
-            this._closeButton.setAttribute('aria-label', 'Close popup');
-            this._closeButton.setAttribute('aria-hidden', 'true');
-            this._closeButton.innerHTML = '&#215;';
-            this._closeButton.addEventListener('click', this._onClose);
-        }
     }
 
     _onMouseUp(event: MapMouseEvent) {
@@ -555,14 +550,19 @@ export default class Popup extends Evented {
     _getAnchor(offset: any) {
         if (this.options.anchor) { return this.options.anchor; }
 
-        const pos: any = this._pos;
-        const width = this._container.offsetWidth;
-        const height = this._container.offsetHeight;
+        const map = this._map;
+        const container = this._container;
+        const pos = this._pos;
+
+        if (!map || !container || !pos) return 'bottom';
+
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
         let anchorComponents;
 
         if (pos.y + offset.bottom.y < height) {
             anchorComponents = ['top'];
-        } else if (pos.y > this._map.transform.height - height) {
+        } else if (pos.y > map.transform.height - height) {
             anchorComponents = ['bottom'];
         } else {
             anchorComponents = [];
@@ -570,7 +570,7 @@ export default class Popup extends Evented {
 
         if (pos.x < width / 2) {
             anchorComponents.push('left');
-        } else if (pos.x > this._map.transform.width - width / 2) {
+        } else if (pos.x > map.transform.width - width / 2) {
             anchorComponents.push('right');
         }
 
@@ -582,6 +582,9 @@ export default class Popup extends Evented {
     }
 
     _updateClassList() {
+        const container = this._container;
+        if (!container) return;
+
         const classes = [...this._classList];
         classes.push('mapboxgl-popup');
         if (this._anchor) {
@@ -590,36 +593,39 @@ export default class Popup extends Evented {
         if (this._trackPointer) {
             classes.push('mapboxgl-popup-track-pointer');
         }
-        this._container.className = classes.join(' ');
+        container.className = classes.join(' ');
     }
 
     _update(cursor: ?PointLike) {
         const hasPosition = this._lngLat || this._trackPointer;
+        const map = this._map;
 
-        if (!this._map || !hasPosition || !this._content) { return; }
+        if (!map || !hasPosition || !this._content) { return; }
 
-        if (!this._container) {
-            this._container = DOM.create('div', 'mapboxgl-popup', this._map.getContainer());
-            this._tip       = DOM.create('div', 'mapboxgl-popup-tip', this._container);
-            this._container.appendChild(this._content);
+        let container = this._container;
+
+        if (!container) {
+            container = this._container = DOM.create('div', 'mapboxgl-popup', map.getContainer());
+            this._tip = DOM.create('div', 'mapboxgl-popup-tip', container);
+            container.appendChild(this._content);
         }
 
-        if (this.options.maxWidth && this._container.style.maxWidth !== this.options.maxWidth) {
-            this._container.style.maxWidth = this.options.maxWidth;
+        if (this.options.maxWidth && container.style.maxWidth !== this.options.maxWidth) {
+            container.style.maxWidth = this.options.maxWidth;
         }
 
-        if (this._map.transform.renderWorldCopies && !this._trackPointer) {
-            this._lngLat = smartWrap(this._lngLat, this._pos, this._map.transform);
+        if (map.transform.renderWorldCopies && !this._trackPointer) {
+            this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
         }
 
         if (!this._trackPointer || cursor) {
-            const pos = this._pos = this._trackPointer && cursor ? cursor : this._map.project(this._lngLat);
+            const pos = this._pos = this._trackPointer && cursor ? cursor : map.project(this._lngLat);
 
             const offset = normalizeOffset(this.options.offset);
             const anchor = this._anchor = this._getAnchor(offset);
 
             const offsetedPos = pos.add(offset[anchor]).round();
-            this._map._requestDomTask(() => {
+            map._requestDomTask(() => {
                 if (this._container && anchor) {
                     this._container.style.transform = `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`;
                 }

--- a/src/util/throttled_invoker.js
+++ b/src/util/throttled_invoker.js
@@ -7,7 +7,7 @@
  * @private
  */
 class ThrottledInvoker {
-    _channel: MessageChannel;
+    _channel: ?MessageChannel;
     _triggered: boolean;
     _callback: Function
 
@@ -38,7 +38,7 @@ class ThrottledInvoker {
     }
 
     remove() {
-        delete this._channel;
+        this._channel = undefined;
         this._callback = () => {};
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.118.0:
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.118.0.tgz#fb706364a58c682d67a2ca7df39396467dc397d1"
-  integrity sha512-jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==
+flow-bin@0.130.0:
+  version "0.130.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.130.0.tgz#e25eaf891af96da371ff6a9fa99d709f24ce9252"
+  integrity sha512-1TSLwCPXvKPwiae7Fh+dpipCzwlHQ1UcBHfCpQImz+hsxYIUWkLWJWEm34bY6I7dSM4ekSiVeP02BhzVJGwtpw==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.108.0:
-  version "0.108.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.108.0.tgz#6a42c85fd664d23dd937d925851e8e6ab5d71393"
-  integrity sha512-hPEyCP1J8rdhNDfCAA5w7bN6HUNBDcHVg/ABU5JVo0gUFMx+uRewpyEH8LlLBGjVQuIpbaPpaqpoaQhAVyaYww==
+flow-bin@0.109.0:
+  version "0.109.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.109.0.tgz#dcdcb7402dd85b58200392d8716ccf14e5a8c24c"
+  integrity sha512-tpcMTpAGIRivYhFV3KJq+zHI2HzcXo8MoGe9pXS4G/UZuey2Faq/e8/gdph2WF0erRlML5hmwfwiq7v9c25c7w==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.109.0:
-  version "0.109.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.109.0.tgz#dcdcb7402dd85b58200392d8716ccf14e5a8c24c"
-  integrity sha512-tpcMTpAGIRivYhFV3KJq+zHI2HzcXo8MoGe9pXS4G/UZuey2Faq/e8/gdph2WF0erRlML5hmwfwiq7v9c25c7w==
+flow-bin@0.118.0:
+  version "0.118.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.118.0.tgz#fb706364a58c682d67a2ca7df39396467dc397d1"
+  integrity sha512-jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
A part of #11426. Upgrades Flow from v0.108 to v0.130, encompassing 10 months of Flow improvements and unblocking further upgrade. Partially reapplies fixes from @kkaefer's closed #9188. Main changes:

- Flow now type-checks properties that can be deleted or overwritten with null or undefined, so we have to type them as optional, and add nullish checks in many parts of the code.
- In places where I fixed the issue above, I replaced `delete this._prop` with `this._prop = undefined`, which is doesn't change things in practice but is more semantically and stylistically correct (the intent is zeroing a property value — we don't delete the property since it's part of a class), and might marginally improve performance in some cases due to less v8 object class deoptimizations.
- Deduplicated some private code across `ImageSource`, `VideoSource` and `CanvasSource`.
- Removed `delete array.arrayBuffer` in vertex/index buffer objects as per original PR and @kkaefer's comment:
> It doesn't really make sense to remove the arrayBuffer from the StructArray because there are still views of the ArrayBuffer that we didn't remove here, so it couldn't be GCed anyway.