### PR TITLE
Free vertex/index buffers after uploading to GPU

### DIFF
--- a/src/gl/index_buffer.js
+++ b/src/gl/index_buffer.js
@@ -25,7 +25,7 @@ class IndexBuffer {
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, array.arrayBuffer, this.dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
 
         if (!this.dynamicDraw) {
-            delete array.arrayBuffer;
+            array.destroy();
         }
     }
 

--- a/src/gl/vertex_buffer.js
+++ b/src/gl/vertex_buffer.js
@@ -55,7 +55,7 @@ class VertexBuffer {
         gl.bufferData(gl.ARRAY_BUFFER, array.arrayBuffer, this.dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
 
         if (!this.dynamicDraw) {
-            delete array.arrayBuffer;
+            array.destroy();
         }
     }
 

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -189,6 +189,12 @@ class StructArray {
     _refreshViews() {
         throw new Error('_refreshViews() must be implemented by each concrete StructArray layout');
     }
+
+    destroy() {
+        // $FlowFixMe
+        this.int8 = this.uint8 = this.int16 = this.uint16 = this.int32 = this.uint32 = this.float32 = null;
+        this.arrayBuffer = (null: any);
+    }
 }
 
 /**


### PR DESCRIPTION
Closes #11432. Array buffers weren't actually freed because we didn't also remove views that pointed to them. This PR restores the original intent of the optimization. I've launched some benchmarks on it — let's see if this makes a difference to performance.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve GL JS memory footprint by freeing memory more eagerly after loading tiles.</changelog>`
