### PR TITLE
Tile URL: placeholders can be duplicated 

### DIFF
--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -31,9 +31,9 @@ export class CanonicalTileID {
 
         return urls[(this.x + this.y) % urls.length]
             .replace('{prefix}', (this.x % 16).toString(16) + (this.y % 16).toString(16))
-            .replace('{z}', String(this.z))
-            .replace('{x}', String(this.x))
-            .replace('{y}', String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
+            .replace(/{z}/g, String(this.z))
+            .replace(/{x}/g, String(this.x))
+            .replace(/{y}/g, String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
             .replace('{quadkey}', quadkey)
             .replace('{bbox-epsg-3857}', bbox);
     }

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -38,6 +38,7 @@ test('CanonicalTileID', (t) => {
 
     t.test('.url', (t) => {
         t.test('replaces {z}/{x}/{y}', (t) => {
+            t.equal(new CanonicalTileID(1, 0, 0).url(['{z}/{x}/{y}.json']), '1/0/0.json');
             t.equal(new CanonicalTileID(15, 9876, 4321).url(['{z}/{x}/{z}_{x}_{y}.json']), '15/9876/15_9876_4321.json');
             t.end();
         });

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -38,7 +38,7 @@ test('CanonicalTileID', (t) => {
 
     t.test('.url', (t) => {
         t.test('replaces {z}/{x}/{y}', (t) => {
-            t.equal(new CanonicalTileID(1, 0, 0).url(['{z}/{x}/{y}.json']), '1/0/0.json');
+            t.equal(new CanonicalTileID(15, 9876, 4321).url(['{z}/{x}/{z}_{x}_{y}.json']), '15/9876/15_9876_4321.json');
             t.end();
         });
 


### PR DESCRIPTION
**mapbox-gl-js version**: v2.7.0-beta.1 through v2.8.0-beta.1

**browser**: Chrome and Firefox

### Steps to Trigger Behavior
Open a map with tile url that contains duplicated placeholders.

Example: `https://maptile.example.com/asset/{z}/{x}/{z}_{x}_{y}.gif`


### Expected Behavior

- Assume z=15, x=9876, y=4321,
- Tile URL: `https://maptile.example.com/asset/{z}/{x}/{z}_{x}_{y}.gif`
- -> Request URL: `https://maptile.example.com/asset/15/9876/15_9876_4321.gif`


### Actual Behavior

- Assume z=15, x=9876, y=4321
- Tile URL: `https://maptile.example.com/asset/{z}/{x}/{z}_{x}_{y}.gif`
- -> Request URL: `https://maptile.example.com/asset/15/9876/{z}_{x}_4321.gif`

`<changelog>Allow duplicated coordinates in tile request URLs.</changelog>`
