### PR TITLE
Optimize StructArray views

### DIFF
--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -55,13 +55,11 @@ function createStructArrayType(name: string, layout: StructArrayLayout, includeS
     const arrayClass = `${camelize(name)}Array`;
 
     if (includeStructAccessors) {
-        const usedTypes = new Set(['Uint8']);
-        const members = normalizeMembers(layout.members, usedTypes);
+        const members = normalizeMembers(layout.members);
         arraysWithStructAccessors.push({
             arrayClass,
             members,
             size: layout.size,
-            usedTypes,
             layoutClass,
             includeStructAccessors
         });
@@ -71,8 +69,10 @@ function createStructArrayType(name: string, layout: StructArrayLayout, includeS
 }
 
 function createStructArrayLayoutType({members, size, alignment}) {
-    const usedTypes = new Set(['Uint8']);
-    members = normalizeMembers(members, usedTypes);
+    const usedTypesSet = new Set();
+    members = normalizeMembers(members, usedTypesSet);
+
+    const usedTypes = Array.from(usedTypesSet).sort((a, b) => sizeOf(a) - sizeOf(b));
 
     // combine consecutive 'members' with same underlying type, summing their
     // component counts

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -13,11 +13,10 @@ import {register} from '../util/web_worker_transfer.js';
  * @private
  */
 class StructArrayLayout2i4 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
     }
 
@@ -29,8 +28,9 @@ class StructArrayLayout2i4 extends StructArray {
 
     emplace(i: number, v0: number, v1: number) {
         const o2 = i * 2;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
+        const {int16} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
         return i;
     }
 }
@@ -45,11 +45,10 @@ register('StructArrayLayout2i4', StructArrayLayout2i4);
  * @private
  */
 class StructArrayLayout4i8 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
     }
 
@@ -61,10 +60,11 @@ class StructArrayLayout4i8 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number) {
         const o2 = i * 4;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
+        const {int16} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
+        int16[o2 + 3] = v3;
         return i;
     }
 }
@@ -81,6 +81,7 @@ register('StructArrayLayout4i8', StructArrayLayout4i8);
  * @private
  */
 class StructArrayLayout2i4ub1f12 extends StructArray {
+    view: Uint8Array;
     uint8: Uint8Array;
     int16: Int16Array;
     float32: Float32Array;
@@ -101,13 +102,14 @@ class StructArrayLayout2i4ub1f12 extends StructArray {
         const o2 = i * 6;
         const o1 = i * 12;
         const o4 = i * 3;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.uint8[o1 + 4] = v2;
-        this.uint8[o1 + 5] = v3;
-        this.uint8[o1 + 6] = v4;
-        this.uint8[o1 + 7] = v5;
-        this.float32[o4 + 2] = v6;
+        const {uint8, int16, float32} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        uint8[o1 + 4] = v2;
+        uint8[o1 + 5] = v3;
+        uint8[o1 + 6] = v4;
+        uint8[o1 + 7] = v5;
+        float32[o4 + 2] = v6;
         return i;
     }
 }
@@ -122,11 +124,10 @@ register('StructArrayLayout2i4ub1f12', StructArrayLayout2i4ub1f12);
  * @private
  */
 class StructArrayLayout3f12 extends StructArray {
-    uint8: Uint8Array;
+    view: Float32Array;
     float32: Float32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
@@ -138,9 +139,10 @@ class StructArrayLayout3f12 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number) {
         const o4 = i * 3;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
+        const {float32} = this;
+        float32[o4 + 0] = v0;
+        float32[o4 + 1] = v1;
+        float32[o4 + 2] = v2;
         return i;
     }
 }
@@ -155,11 +157,10 @@ register('StructArrayLayout3f12', StructArrayLayout3f12);
  * @private
  */
 class StructArrayLayout10ui20 extends StructArray {
-    uint8: Uint8Array;
+    view: Uint16Array;
     uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
     }
 
@@ -171,16 +172,17 @@ class StructArrayLayout10ui20 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number) {
         const o2 = i * 10;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
-        this.uint16[o2 + 2] = v2;
-        this.uint16[o2 + 3] = v3;
-        this.uint16[o2 + 4] = v4;
-        this.uint16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
-        this.uint16[o2 + 8] = v8;
-        this.uint16[o2 + 9] = v9;
+        const {uint16} = this;
+        uint16[o2 + 0] = v0;
+        uint16[o2 + 1] = v1;
+        uint16[o2 + 2] = v2;
+        uint16[o2 + 3] = v3;
+        uint16[o2 + 4] = v4;
+        uint16[o2 + 5] = v5;
+        uint16[o2 + 6] = v6;
+        uint16[o2 + 7] = v7;
+        uint16[o2 + 8] = v8;
+        uint16[o2 + 9] = v9;
         return i;
     }
 }
@@ -195,11 +197,10 @@ register('StructArrayLayout10ui20', StructArrayLayout10ui20);
  * @private
  */
 class StructArrayLayout8ui16 extends StructArray {
-    uint8: Uint8Array;
+    view: Uint16Array;
     uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
     }
 
@@ -211,14 +212,15 @@ class StructArrayLayout8ui16 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
         const o2 = i * 8;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
-        this.uint16[o2 + 2] = v2;
-        this.uint16[o2 + 3] = v3;
-        this.uint16[o2 + 4] = v4;
-        this.uint16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
+        const {uint16} = this;
+        uint16[o2 + 0] = v0;
+        uint16[o2 + 1] = v1;
+        uint16[o2 + 2] = v2;
+        uint16[o2 + 3] = v3;
+        uint16[o2 + 4] = v4;
+        uint16[o2 + 5] = v5;
+        uint16[o2 + 6] = v6;
+        uint16[o2 + 7] = v7;
         return i;
     }
 }
@@ -236,12 +238,11 @@ register('StructArrayLayout8ui16', StructArrayLayout8ui16);
  * @private
  */
 class StructArrayLayout4i4ui4i4i32 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
     uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
     }
@@ -254,22 +255,23 @@ class StructArrayLayout4i4ui4i4i32 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number) {
         const o2 = i * 16;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.uint16[o2 + 4] = v4;
-        this.uint16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
-        this.int16[o2 + 8] = v8;
-        this.int16[o2 + 9] = v9;
-        this.int16[o2 + 10] = v10;
-        this.int16[o2 + 11] = v11;
-        this.int16[o2 + 12] = v12;
-        this.int16[o2 + 13] = v13;
-        this.int16[o2 + 14] = v14;
-        this.int16[o2 + 15] = v15;
+        const {int16, uint16} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
+        int16[o2 + 3] = v3;
+        uint16[o2 + 4] = v4;
+        uint16[o2 + 5] = v5;
+        uint16[o2 + 6] = v6;
+        uint16[o2 + 7] = v7;
+        int16[o2 + 8] = v8;
+        int16[o2 + 9] = v9;
+        int16[o2 + 10] = v10;
+        int16[o2 + 11] = v11;
+        int16[o2 + 12] = v12;
+        int16[o2 + 13] = v13;
+        int16[o2 + 14] = v14;
+        int16[o2 + 15] = v15;
         return i;
     }
 }
@@ -284,11 +286,10 @@ register('StructArrayLayout4i4ui4i4i32', StructArrayLayout4i4ui4i4i32);
  * @private
  */
 class StructArrayLayout1ul4 extends StructArray {
-    uint8: Uint8Array;
+    view: Uint32Array;
     uint32: Uint32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.uint32 = new Uint32Array(this.arrayBuffer);
     }
 
@@ -300,7 +301,8 @@ class StructArrayLayout1ul4 extends StructArray {
 
     emplace(i: number, v0: number) {
         const o4 = i * 1;
-        this.uint32[o4 + 0] = v0;
+        const {uint32} = this;
+        uint32[o4 + 0] = v0;
         return i;
     }
 }
@@ -319,18 +321,17 @@ register('StructArrayLayout1ul4', StructArrayLayout1ul4);
  * @private
  */
 class StructArrayLayout5i4f1i1ul2ui40 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
+    uint16: Uint16Array;
     float32: Float32Array;
     uint32: Uint32Array;
-    uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
+        this.uint16 = new Uint16Array(this.arrayBuffer);
         this.float32 = new Float32Array(this.arrayBuffer);
         this.uint32 = new Uint32Array(this.arrayBuffer);
-        this.uint16 = new Uint16Array(this.arrayBuffer);
     }
 
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number) {
@@ -342,19 +343,20 @@ class StructArrayLayout5i4f1i1ul2ui40 extends StructArray {
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number) {
         const o2 = i * 20;
         const o4 = i * 10;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.int16[o2 + 4] = v4;
-        this.float32[o4 + 3] = v5;
-        this.float32[o4 + 4] = v6;
-        this.float32[o4 + 5] = v7;
-        this.float32[o4 + 6] = v8;
-        this.int16[o2 + 14] = v9;
-        this.uint32[o4 + 8] = v10;
-        this.uint16[o2 + 18] = v11;
-        this.uint16[o2 + 19] = v12;
+        const {int16, uint16, float32, uint32} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
+        int16[o2 + 3] = v3;
+        int16[o2 + 4] = v4;
+        float32[o4 + 3] = v5;
+        float32[o4 + 4] = v6;
+        float32[o4 + 5] = v7;
+        float32[o4 + 6] = v8;
+        int16[o2 + 14] = v9;
+        uint32[o4 + 8] = v10;
+        uint16[o2 + 18] = v11;
+        uint16[o2 + 19] = v12;
         return i;
     }
 }
@@ -371,11 +373,10 @@ register('StructArrayLayout5i4f1i1ul2ui40', StructArrayLayout5i4f1i1ul2ui40);
  * @private
  */
 class StructArrayLayout3i2i2i16 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
     }
 
@@ -387,13 +388,14 @@ class StructArrayLayout3i2i2i16 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number) {
         const o2 = i * 8;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 4] = v3;
-        this.int16[o2 + 5] = v4;
-        this.int16[o2 + 6] = v5;
-        this.int16[o2 + 7] = v6;
+        const {int16} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
+        int16[o2 + 4] = v3;
+        int16[o2 + 5] = v4;
+        int16[o2 + 6] = v5;
+        int16[o2 + 7] = v6;
         return i;
     }
 }
@@ -410,14 +412,13 @@ register('StructArrayLayout3i2i2i16', StructArrayLayout3i2i2i16);
  * @private
  */
 class StructArrayLayout2f1f2i16 extends StructArray {
-    uint8: Uint8Array;
-    float32: Float32Array;
+    view: Int16Array;
     int16: Int16Array;
+    float32: Float32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
-        this.float32 = new Float32Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
+        this.float32 = new Float32Array(this.arrayBuffer);
     }
 
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number) {
@@ -429,11 +430,12 @@ class StructArrayLayout2f1f2i16 extends StructArray {
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number) {
         const o4 = i * 4;
         const o2 = i * 8;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.int16[o2 + 6] = v3;
-        this.int16[o2 + 7] = v4;
+        const {int16, float32} = this;
+        float32[o4 + 0] = v0;
+        float32[o4 + 1] = v1;
+        float32[o4 + 2] = v2;
+        int16[o2 + 6] = v3;
+        int16[o2 + 7] = v4;
         return i;
     }
 }
@@ -449,6 +451,7 @@ register('StructArrayLayout2f1f2i16', StructArrayLayout2f1f2i16);
  * @private
  */
 class StructArrayLayout2ub2f12 extends StructArray {
+    view: Uint8Array;
     uint8: Uint8Array;
     float32: Float32Array;
 
@@ -466,10 +469,11 @@ class StructArrayLayout2ub2f12 extends StructArray {
     emplace(i: number, v0: number, v1: number, v2: number, v3: number) {
         const o1 = i * 12;
         const o4 = i * 3;
-        this.uint8[o1 + 0] = v0;
-        this.uint8[o1 + 1] = v1;
-        this.float32[o4 + 1] = v2;
-        this.float32[o4 + 2] = v3;
+        const {uint8, float32} = this;
+        uint8[o1 + 0] = v0;
+        uint8[o1 + 1] = v1;
+        float32[o4 + 1] = v2;
+        float32[o4 + 2] = v3;
         return i;
     }
 }
@@ -484,11 +488,10 @@ register('StructArrayLayout2ub2f12', StructArrayLayout2ub2f12);
  * @private
  */
 class StructArrayLayout3ui6 extends StructArray {
-    uint8: Uint8Array;
+    view: Uint16Array;
     uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
     }
 
@@ -500,9 +503,10 @@ class StructArrayLayout3ui6 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number) {
         const o2 = i * 3;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
-        this.uint16[o2 + 2] = v2;
+        const {uint16} = this;
+        uint16[o2 + 0] = v0;
+        uint16[o2 + 1] = v1;
+        uint16[o2 + 2] = v2;
         return i;
     }
 }
@@ -526,17 +530,18 @@ register('StructArrayLayout3ui6', StructArrayLayout3ui6);
  * @private
  */
 class StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60 extends StructArray {
+    view: Uint8Array;
     uint8: Uint8Array;
     int16: Int16Array;
-    float32: Float32Array;
     uint16: Uint16Array;
+    float32: Float32Array;
     uint32: Uint32Array;
 
     _refreshViews() {
         this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
-        this.float32 = new Float32Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
+        this.float32 = new Float32Array(this.arrayBuffer);
         this.uint32 = new Uint32Array(this.arrayBuffer);
     }
 
@@ -550,27 +555,28 @@ class StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60 extends StructArray {
         const o2 = i * 30;
         const o4 = i * 15;
         const o1 = i * 60;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.float32[o4 + 2] = v3;
-        this.float32[o4 + 3] = v4;
-        this.uint16[o2 + 8] = v5;
-        this.uint16[o2 + 9] = v6;
-        this.uint32[o4 + 5] = v7;
-        this.uint32[o4 + 6] = v8;
-        this.uint32[o4 + 7] = v9;
-        this.uint16[o2 + 16] = v10;
-        this.uint16[o2 + 17] = v11;
-        this.uint16[o2 + 18] = v12;
-        this.float32[o4 + 10] = v13;
-        this.float32[o4 + 11] = v14;
-        this.uint8[o1 + 48] = v15;
-        this.uint8[o1 + 49] = v16;
-        this.uint8[o1 + 50] = v17;
-        this.uint32[o4 + 13] = v18;
-        this.int16[o2 + 28] = v19;
-        this.uint8[o1 + 58] = v20;
+        const {uint8, int16, uint16, float32, uint32} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
+        float32[o4 + 2] = v3;
+        float32[o4 + 3] = v4;
+        uint16[o2 + 8] = v5;
+        uint16[o2 + 9] = v6;
+        uint32[o4 + 5] = v7;
+        uint32[o4 + 6] = v8;
+        uint32[o4 + 7] = v9;
+        uint16[o2 + 16] = v10;
+        uint16[o2 + 17] = v11;
+        uint16[o2 + 18] = v12;
+        float32[o4 + 10] = v13;
+        float32[o4 + 11] = v14;
+        uint8[o1 + 48] = v15;
+        uint8[o1 + 49] = v16;
+        uint8[o1 + 50] = v17;
+        uint32[o4 + 13] = v18;
+        int16[o2 + 28] = v19;
+        uint8[o1 + 58] = v20;
         return i;
     }
 }
@@ -590,17 +596,16 @@ register('StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60', StructArrayLayout3i2f2
  * @private
  */
 class StructArrayLayout3i2f6i15ui1ul3f76 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
-    float32: Float32Array;
     uint16: Uint16Array;
+    float32: Float32Array;
     uint32: Uint32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
-        this.float32 = new Float32Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
+        this.float32 = new Float32Array(this.arrayBuffer);
         this.uint32 = new Uint32Array(this.arrayBuffer);
     }
 
@@ -613,36 +618,37 @@ class StructArrayLayout3i2f6i15ui1ul3f76 extends StructArray {
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number, v17: number, v18: number, v19: number, v20: number, v21: number, v22: number, v23: number, v24: number, v25: number, v26: number, v27: number, v28: number, v29: number) {
         const o2 = i * 38;
         const o4 = i * 19;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.float32[o4 + 2] = v3;
-        this.float32[o4 + 3] = v4;
-        this.int16[o2 + 8] = v5;
-        this.int16[o2 + 9] = v6;
-        this.int16[o2 + 10] = v7;
-        this.int16[o2 + 11] = v8;
-        this.int16[o2 + 12] = v9;
-        this.int16[o2 + 13] = v10;
-        this.uint16[o2 + 14] = v11;
-        this.uint16[o2 + 15] = v12;
-        this.uint16[o2 + 16] = v13;
-        this.uint16[o2 + 17] = v14;
-        this.uint16[o2 + 18] = v15;
-        this.uint16[o2 + 19] = v16;
-        this.uint16[o2 + 20] = v17;
-        this.uint16[o2 + 21] = v18;
-        this.uint16[o2 + 22] = v19;
-        this.uint16[o2 + 23] = v20;
-        this.uint16[o2 + 24] = v21;
-        this.uint16[o2 + 25] = v22;
-        this.uint16[o2 + 26] = v23;
-        this.uint16[o2 + 27] = v24;
-        this.uint16[o2 + 28] = v25;
-        this.uint32[o4 + 15] = v26;
-        this.float32[o4 + 16] = v27;
-        this.float32[o4 + 17] = v28;
-        this.float32[o4 + 18] = v29;
+        const {int16, uint16, float32, uint32} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
+        float32[o4 + 2] = v3;
+        float32[o4 + 3] = v4;
+        int16[o2 + 8] = v5;
+        int16[o2 + 9] = v6;
+        int16[o2 + 10] = v7;
+        int16[o2 + 11] = v8;
+        int16[o2 + 12] = v9;
+        int16[o2 + 13] = v10;
+        uint16[o2 + 14] = v11;
+        uint16[o2 + 15] = v12;
+        uint16[o2 + 16] = v13;
+        uint16[o2 + 17] = v14;
+        uint16[o2 + 18] = v15;
+        uint16[o2 + 19] = v16;
+        uint16[o2 + 20] = v17;
+        uint16[o2 + 21] = v18;
+        uint16[o2 + 22] = v19;
+        uint16[o2 + 23] = v20;
+        uint16[o2 + 24] = v21;
+        uint16[o2 + 25] = v22;
+        uint16[o2 + 26] = v23;
+        uint16[o2 + 27] = v24;
+        uint16[o2 + 28] = v25;
+        uint32[o4 + 15] = v26;
+        float32[o4 + 16] = v27;
+        float32[o4 + 17] = v28;
+        float32[o4 + 18] = v29;
         return i;
     }
 }
@@ -657,11 +663,10 @@ register('StructArrayLayout3i2f6i15ui1ul3f76', StructArrayLayout3i2f6i15ui1ul3f7
  * @private
  */
 class StructArrayLayout1f4 extends StructArray {
-    uint8: Uint8Array;
+    view: Float32Array;
     float32: Float32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
@@ -673,7 +678,8 @@ class StructArrayLayout1f4 extends StructArray {
 
     emplace(i: number, v0: number) {
         const o4 = i * 1;
-        this.float32[o4 + 0] = v0;
+        const {float32} = this;
+        float32[o4 + 0] = v0;
         return i;
     }
 }
@@ -688,11 +694,10 @@ register('StructArrayLayout1f4', StructArrayLayout1f4);
  * @private
  */
 class StructArrayLayout3i6 extends StructArray {
-    uint8: Uint8Array;
+    view: Int16Array;
     int16: Int16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.int16 = new Int16Array(this.arrayBuffer);
     }
 
@@ -704,9 +709,10 @@ class StructArrayLayout3i6 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number) {
         const o2 = i * 3;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
+        const {int16} = this;
+        int16[o2 + 0] = v0;
+        int16[o2 + 1] = v1;
+        int16[o2 + 2] = v2;
         return i;
     }
 }
@@ -721,11 +727,10 @@ register('StructArrayLayout3i6', StructArrayLayout3i6);
  * @private
  */
 class StructArrayLayout7f28 extends StructArray {
-    uint8: Uint8Array;
+    view: Float32Array;
     float32: Float32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
@@ -737,13 +742,14 @@ class StructArrayLayout7f28 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number) {
         const o4 = i * 7;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.float32[o4 + 3] = v3;
-        this.float32[o4 + 4] = v4;
-        this.float32[o4 + 5] = v5;
-        this.float32[o4 + 6] = v6;
+        const {float32} = this;
+        float32[o4 + 0] = v0;
+        float32[o4 + 1] = v1;
+        float32[o4 + 2] = v2;
+        float32[o4 + 3] = v3;
+        float32[o4 + 4] = v4;
+        float32[o4 + 5] = v5;
+        float32[o4 + 6] = v6;
         return i;
     }
 }
@@ -759,14 +765,13 @@ register('StructArrayLayout7f28', StructArrayLayout7f28);
  * @private
  */
 class StructArrayLayout1ul3ui12 extends StructArray {
-    uint8: Uint8Array;
-    uint32: Uint32Array;
+    view: Uint16Array;
     uint16: Uint16Array;
+    uint32: Uint32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
-        this.uint32 = new Uint32Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
+        this.uint32 = new Uint32Array(this.arrayBuffer);
     }
 
     emplaceBack(v0: number, v1: number, v2: number, v3: number) {
@@ -778,10 +783,11 @@ class StructArrayLayout1ul3ui12 extends StructArray {
     emplace(i: number, v0: number, v1: number, v2: number, v3: number) {
         const o4 = i * 3;
         const o2 = i * 6;
-        this.uint32[o4 + 0] = v0;
-        this.uint16[o2 + 2] = v1;
-        this.uint16[o2 + 3] = v2;
-        this.uint16[o2 + 4] = v3;
+        const {uint16, uint32} = this;
+        uint32[o4 + 0] = v0;
+        uint16[o2 + 2] = v1;
+        uint16[o2 + 3] = v2;
+        uint16[o2 + 4] = v3;
         return i;
     }
 }
@@ -796,11 +802,10 @@ register('StructArrayLayout1ul3ui12', StructArrayLayout1ul3ui12);
  * @private
  */
 class StructArrayLayout2ui4 extends StructArray {
-    uint8: Uint8Array;
+    view: Uint16Array;
     uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
     }
 
@@ -812,8 +817,9 @@ class StructArrayLayout2ui4 extends StructArray {
 
     emplace(i: number, v0: number, v1: number) {
         const o2 = i * 2;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
+        const {uint16} = this;
+        uint16[o2 + 0] = v0;
+        uint16[o2 + 1] = v1;
         return i;
     }
 }
@@ -828,11 +834,10 @@ register('StructArrayLayout2ui4', StructArrayLayout2ui4);
  * @private
  */
 class StructArrayLayout1ui2 extends StructArray {
-    uint8: Uint8Array;
+    view: Uint16Array;
     uint16: Uint16Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.uint16 = new Uint16Array(this.arrayBuffer);
     }
 
@@ -844,7 +849,8 @@ class StructArrayLayout1ui2 extends StructArray {
 
     emplace(i: number, v0: number) {
         const o2 = i * 1;
-        this.uint16[o2 + 0] = v0;
+        const {uint16} = this;
+        uint16[o2 + 0] = v0;
         return i;
     }
 }
@@ -859,11 +865,10 @@ register('StructArrayLayout1ui2', StructArrayLayout1ui2);
  * @private
  */
 class StructArrayLayout2f8 extends StructArray {
-    uint8: Uint8Array;
+    view: Float32Array;
     float32: Float32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
@@ -875,8 +880,9 @@ class StructArrayLayout2f8 extends StructArray {
 
     emplace(i: number, v0: number, v1: number) {
         const o4 = i * 2;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
+        const {float32} = this;
+        float32[o4 + 0] = v0;
+        float32[o4 + 1] = v1;
         return i;
     }
 }
@@ -891,11 +897,10 @@ register('StructArrayLayout2f8', StructArrayLayout2f8);
  * @private
  */
 class StructArrayLayout4f16 extends StructArray {
-    uint8: Uint8Array;
+    view: Float32Array;
     float32: Float32Array;
 
     _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
@@ -907,10 +912,11 @@ class StructArrayLayout4f16 extends StructArray {
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number) {
         const o4 = i * 4;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.float32[o4 + 3] = v3;
+        const {float32} = this;
+        float32[o4 + 0] = v0;
+        float32[o4 + 1] = v1;
+        float32[o4 + 2] = v2;
+        float32[o4 + 3] = v3;
         return i;
     }
 }

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -92,7 +92,6 @@ class StructArray {
     length: number;
     isTransferred: boolean;
     arrayBuffer: ArrayBuffer;
-    uint8: Uint8Array;
 
     // The following properties are defined on the prototype.
     members: Array<StructArrayMember>;
@@ -177,9 +176,11 @@ class StructArray {
             this.capacity = Math.max(n, Math.floor(this.capacity * RESIZE_MULTIPLIER), DEFAULT_CAPACITY);
             this.arrayBuffer = new ArrayBuffer(this.capacity * this.bytesPerElement);
 
-            const oldUint8Array = this.uint8;
+            // $FlowFixMe use generics for StructArray to type `view` properly
+            const oldView = this.view;
             this._refreshViews();
-            if (oldUint8Array) this.uint8.set(oldUint8Array);
+            // $FlowFixMe
+            if (oldView) this.view.set(oldView);
         }
     }
 
@@ -192,7 +193,7 @@ class StructArray {
 
     destroy() {
         // $FlowFixMe
-        this.int8 = this.uint8 = this.int16 = this.uint16 = this.int32 = this.uint32 = this.float32 = null;
+        this.view = this.int8 = this.uint8 = this.int16 = this.uint16 = this.int32 = this.uint32 = this.float32 = null;
         this.arrayBuffer = (null: any);
     }
 }

--- a/src/util/struct_array.js.ejs
+++ b/src/util/struct_array.js.ejs
@@ -3,7 +3,6 @@ const {
     arrayClass,
     members,
     size,
-    usedTypes,
     layoutClass,
     includeStructAccessors
 } = locals

--- a/src/util/struct_array_layout.js.ejs
+++ b/src/util/struct_array_layout.js.ejs
@@ -21,6 +21,7 @@ for (const member of members) {
  * @private
  */
 class <%=StructArrayLayoutClass%> extends StructArray {
+    view: <%=usedTypes[0]%>Array;
 <%
 for (const type of usedTypes) {
 -%>
@@ -31,9 +32,9 @@ for (const type of usedTypes) {
 
     _refreshViews() {
 <%
-for (const type of usedTypes) {
+for (const [i, type] of Object.entries(usedTypes)) {
 -%>
-        this.<%=type.toLowerCase()%> = new <%=type%>Array(this.arrayBuffer);
+        <%if (i === 0) {%>this.view = <%}%>this.<%=type.toLowerCase()%> = new <%=type%>Array(this.arrayBuffer);
 <%
 }
 -%>
@@ -75,6 +76,9 @@ for (const size of usedTypeSizes) {
 }
 
 let argIndex = 0;
+-%>
+        const {<%=usedTypes.map(t => t.toLowerCase()).join(', ')%>} = this;
+<%
 for (const member of members) {
     for (let c = 0; c < member.components; c++) {
         // The index for `member` component `c` into the appropriate type array is:
@@ -83,7 +87,7 @@ for (const member of members) {
         // offset of this member into the array
         const index = `o${member.size.toFixed(0)} + ${(member.offset / member.size + c).toFixed(0)}`;
 -%>
-        this.<%=member.view%>[<%=index%>] = v<%=argIndex++%>;
+        <%=member.view%>[<%=index%>] = v<%=argIndex++%>;
 <%
     }
 }


### PR DESCRIPTION
A small experiment to see if potential optimizations to StructArray (which is on a hot path) could make a difference to load time:

- Do not create `uint8` view when members don't use it; instead, use the smallest used view for resizing array buffers.
- Cache view variables in `emplace`.

Will report back once the benchmarks finish.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality (covered)
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
