### PR TITLE
Add an empty CodeBuild config to keep the build green

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,2 @@
+version: 0.2
+phases:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,2 +1,5 @@
 version: 0.2
 phases:
+  build:
+    commands:
+      - echo TODO


### PR DESCRIPTION
After we enabled CodeBuild for this repo, it seems to run on any branch regardless if it has a config file, and I can't seem to find a way to disable it conditionally. So let's add an empty config for now so that our builds don't show as failed because of the CodeBuild job.