### PR TITLE
Enforce more deliberate grouping of mixed binary or logical operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,6 +59,7 @@
     "no-new": "off",
     "no-unused-vars": ["error", {"argsIgnorePattern": "^_$"}],
     "no-warning-comments": "error",
+    "no-mixed-operators": ["error", {"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}],
     "object-curly-spacing": ["error", "never"],
     "prefer-arrow-callback": "error",
     "prefer-const": ["error", {"destructuring": "all"}],

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -483,7 +483,7 @@ class SymbolBucket implements Bucket {
                 if (
                     !this.hasRTLText || // non-rtl text so can proceed safely
                     getRTLTextPluginStatus() === 'unavailable' || // We don't intend to lazy-load the rtl text plugin, so proceed with incorrect shaping
-                    this.hasRTLText && globalRTLTextPlugin.isParsed() // Use the rtlText plugin to shape text
+                    (this.hasRTLText && globalRTLTextPlugin.isParsed()) // Use the rtlText plugin to shape text
                 ) {
                     text = transformText(formattedText, layer, evaluationFeature);
                 }

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -701,7 +701,7 @@ const defaultLayouts = {
 
 function layoutType(property, type, binderType) {
     const layoutException = propertyExceptions[property];
-    return  layoutException && layoutException[binderType] || defaultLayouts[type][binderType];
+    return (layoutException && layoutException[binderType]) || defaultLayouts[type][binderType];
 }
 
 register('ConstantBinder', ConstantBinder);

--- a/src/gl/value.js
+++ b/src/gl/value.js
@@ -434,7 +434,7 @@ export class BindVertexArrayOES extends BaseValue<any> {
         return null;
     }
     set(v: any) {
-        if (!this.vao || v === this.current && !this.dirty) return;
+        if (!this.vao || (v === this.current && !this.dirty)) return;
         this.vao.bindVertexArrayOES(v);
         this.current = v;
         this.dirty = false;

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -188,12 +188,12 @@ class GlyphManager {
         } else {
             /* eslint-disable new-cap */
             return !!this.localFontFamily &&
-            (isChar['CJK Unified Ideographs'](id) ||
+            ((isChar['CJK Unified Ideographs'](id) ||
                 isChar['Hangul Syllables'](id) ||
                 isChar['Hiragana'](id) ||
                 isChar['Katakana'](id)) ||
                 // gl-native parity: Extend Ideographs rasterization range to include CJK symbols and punctuations
-                isChar['CJK Symbols and Punctuation'](id);
+                isChar['CJK Symbols and Punctuation'](id));
             /* eslint-enable new-cap */
         }
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -531,7 +531,7 @@ class SourceCache extends Evented {
                 assert(tileID.key === +id);
 
                 const tile = this._tiles[id];
-                if (!tile || tile.fadeEndTime && tile.fadeEndTime <= browser.now()) continue;
+                if (!tile || (tile.fadeEndTime && tile.fadeEndTime <= browser.now())) continue;
 
                 // if the tile is loaded but still fading in, find parents to cross-fade with it
                 const parentTile = this.findLoadedParent(tileID, Math.max(tileID.overscaledZ - SourceCache.maxOverzooming, this._source.minzoom));

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -536,7 +536,7 @@ class Tile {
             const sourceLayerStates = states[sourceLayerId];
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
-            bucket.update(sourceLayerStates, sourceLayer, availableImages, this.imageAtlas && this.imageAtlas.patternPositions || {});
+            bucket.update(sourceLayerStates, sourceLayer, availableImages, (this.imageAtlas && this.imageAtlas.patternPositions) || {});
             if (bucket instanceof LineBucket || bucket instanceof FillBucket) {
                 const sourceCache = painter.style._getSourceCache(bucket.layers[0].source);
                 if (painter._terrain && painter._terrain.enabled && sourceCache && bucket.programConfigurations.needsUpload) {

--- a/src/style-spec/expression/evaluation_context.js
+++ b/src/style-spec/expression/evaluation_context.js
@@ -51,7 +51,7 @@ class EvaluationContext {
     }
 
     properties() {
-        return this.feature && this.feature.properties || {};
+        return (this.feature && this.feature.properties) || {};
     }
 
     distanceFromCenter() {

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -231,7 +231,7 @@ function updateLineLabels(bucket: SymbolBucket,
         // Don't do calculations for vertical glyphs unless the previous symbol was horizontal
         // and we determined that vertical glyphs were necessary.
         // Also don't do calculations for symbols that are collided and fully faded out
-        if (symbol.hidden || symbol.writingMode === WritingMode.vertical && !useVertical) {
+        if ((symbol.hidden || symbol.writingMode === WritingMode.vertical) && !useVertical) {
             hideGlyphs(symbol.numGlyphs, dynamicLayoutVertexArray);
             continue;
         }

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -551,7 +551,7 @@ class Camera extends Evented {
      */
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): void | CameraOptions & AnimationOptions {
         bounds = LngLatBounds.convert(bounds);
-        const bearing = options && options.bearing || 0;
+        const bearing = (options && options.bearing) || 0;
         return this._cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), bearing, options);
     }
 

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -90,7 +90,7 @@ function updateScale(map, container, options) {
     // container with maximum length (Default) as 100px.
     // Using spherical law of cosines approximation, the real distance is
     // found between the two coordinates.
-    const maxWidth = options && options.maxWidth || 100;
+    const maxWidth = (options && options.maxWidth) || 100;
 
     const y = map._containerHeight / 2;
     const left = map.unproject([0, y]);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1106,7 +1106,7 @@ class Map extends Camera {
      * const isMoving = map.isMoving();
      */
     isMoving(): boolean {
-        return this._moving || this.handlers && this.handlers.isMoving() || false;
+        return this._moving || (this.handlers && this.handlers.isMoving()) || false;
     }
 
     /**
@@ -1117,7 +1117,7 @@ class Map extends Camera {
      * const isZooming = map.isZooming();
      */
     isZooming(): boolean {
-        return this._zooming || this.handlers && this.handlers.isZooming() || false;
+        return this._zooming || (this.handlers && this.handlers.isZooming()) || false;
     }
 
     /**
@@ -1128,7 +1128,7 @@ class Map extends Camera {
      * map.isRotating();
      */
     isRotating(): boolean {
-        return this._rotating || this.handlers && this.handlers.isRotating() || false;
+        return this._rotating || (this.handlers && this.handlers.isRotating()) || false;
     }
 
     _createDelegatedListener(type: MapEvent, layers: Array<any>, listener: any) {
@@ -3286,7 +3286,7 @@ class Map extends Camera {
      * @returns {Object} Returns `this` | Promise.
      */
     _preloadTiles(transform: Transform | Array<Transform>) {
-        const sources: Array<SourceCache> = this.style && (Object.values(this.style._sourceCaches): any) || [];
+        const sources: Array<SourceCache> = this.style ? (Object.values(this.style._sourceCaches): any) : [];
         asyncAll(sources, (source, done) => source._preloadTiles(transform, done), () => {
             this.triggerRepaint();
         });

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -102,15 +102,15 @@ export default class Marker extends Evented {
             '_clearFadeTimer'
         ], this);
 
-        this._anchor = options && options.anchor || 'center';
-        this._color = options && options.color || '#3FB1CE';
-        this._scale = options && options.scale || 1;
-        this._draggable = options && options.draggable || false;
-        this._clickTolerance = options && options.clickTolerance || 0;
+        this._anchor = (options && options.anchor) || 'center';
+        this._color = (options && options.color) || '#3FB1CE';
+        this._scale = (options && options.scale) || 1;
+        this._draggable = (options && options.draggable) || false;
+        this._clickTolerance = (options && options.clickTolerance) || 0;
         this._isDragging = false;
         this._state = 'inactive';
-        this._rotation = options && options.rotation || 0;
-        this._rotationAlignment = options && options.rotationAlignment || 'auto';
+        this._rotation = (options && options.rotation) || 0;
+        this._rotationAlignment = (options && options.rotationAlignment) || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
         this._updateMoving = () => this._update(true);
 
@@ -152,10 +152,10 @@ export default class Marker extends Evented {
             // the y value of the center of the shadow ellipse relative to the svg top left is 34.8
             // offset to the svg center "height (41 / 2)" gives 34.8 - (41 / 2) and rounded for an integer pixel offset gives 14
             // negative is used to move the marker up from the center so the tip is at the Marker lngLat
-            this._offset = Point.convert(options && options.offset || [0, -14]);
+            this._offset = Point.convert((options && options.offset) || [0, -14]);
         } else {
             this._element = options.element;
-            this._offset = Point.convert(options && options.offset || [0, 0]);
+            this._offset = Point.convert((options && options.offset) || [0, 0]);
         }
 
         if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -361,7 +361,7 @@ export function uniqueId(): number {
  */
 export function uuid(): string {
     function b(a) {
-        return a ? (a ^ Math.random() * 16 >> a / 4).toString(16) :
+        return a ? (a ^ Math.random() * (16 >> a / 4)).toString(16) :
         //$FlowFixMe: Flow doesn't like the implied array literal conversion here
             ([1e7] + -[1e3] + -4e3 + -8e3 + -1e11).replace(/[018]/g, b);
     }

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -8,7 +8,7 @@ import window from '../../../src/util/window.js';
 function createSource(options) {
     window.useFakeHTMLCanvasGetContext();
 
-    const c = options && options.canvas || window.document.createElement('canvas');
+    const c = (options && options.canvas) || window.document.createElement('canvas');
     c.width = 20;
     c.height = 20;
 

--- a/test/unit/source/video_source.test.js
+++ b/test/unit/source/video_source.test.js
@@ -5,7 +5,7 @@ import window from '../../../src/util/window.js';
 
 function createSource(options) {
 
-    const c = options && options.video || window.document.createElement('video');
+    const c = (options && options.video) || window.document.createElement('video');
 
     options = extend({coordinates: [[0, 0], [1, 0], [1, 1], [0, 1]]}, options);
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
   - This PR adds the [no-mixed-operators](https://eslint.org/docs/rules/no-mixed-operators) ESLint rule for binary and logical operators. The motivation for this comes from a bug in v1 which was caused by mixed operators. The offending code is presented below. It no longer exists in v2, but is still functional in v1 and controls sending telemetry events. When a `customAccessToken` is defined, the mixed operators short-circuit the conditional by becoming `config.EVENTS_URL && customAccessToken = true`. This should be grouped instead as `(customAccessToken || config.ACCESS_TOKEN)` which would have prevented the bug. I confirmed that this rule would catch the buggy code and enforce grouping of the conditions. This rule could have prevented the bug before it made it into library.
   - There were 28 errors when this rule was implemented. Most of these were of the form `options && options.someProp || defaultProp`. There's no real danger of these statements causing a bug, but I found some ambiguous statements that required close reading to properly group. This rule seems like a worthwhile tradeoff to capture a class of subtle bugs that have been demonstrated in the library previously.

```
if (config.EVENTS_URL &&
    customAccessToken || config.ACCESS_TOKEN &&
    Array.isArray(tileUrls) &&
    tileUrls.some(url => isMapboxURL(url) || isMapboxHTTPURL(url))) {
    this.queueRequest({id: mapId, timestamp: Date.now()}, customAccessToken);
}
```
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
