### PR TITLE
Always wrap center coordinate to the range [-180, 180]

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1820,6 +1820,9 @@ class Transform {
 
         this._camera.position = vec3.scaleAndAdd([], this._camera.position, translation, t);
         this._updateStateFromCamera();
+
+        if (this.projection.wrap)
+            this.center = this.center.wrap();
     }
 
     _updateStateFromCamera() {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -239,6 +239,19 @@ export function wrap(n: number, min: number, max: number): number {
     return (w === min) ? max : w;
 }
 
+/**
+ * Computes shortest angle in range [-180, 180) between two angles.
+ *
+ * @param {*} a First angle in degrees
+ * @param {*} b Second angle in degrees
+ * @returns Shortest angle
+ * @private
+ */
+export function shortestAngle(a: number, b: number): number {
+    const diff = (b - a + 180) % 360 - 180;
+    return diff < -180 ? diff + 360 : diff;
+}
+
 /*
  * Call an asynchronous function on an array of arguments,
  * calling `callback` with the completed results of all calls.

--- a/test/unit/geo/projection/globe.test.js
+++ b/test/unit/geo/projection/globe.test.js
@@ -1,0 +1,45 @@
+import {test} from '../../../util/test.js';
+import Transform from '../../../../src/geo/transform.js';
+
+test('Globe', (t) => {
+    t.test('pointCoordinate', (t) => {
+        const tr = new Transform();
+        tr.resize(100, 100);
+        tr.zoom = 0;
+        tr.setProjection({name: 'globe'});
+
+        let tileTransform = tr.projection.createTileTransform(tr, tr.worldSize);
+
+        let point = tileTransform.pointCoordinate(50, 50);
+        t.same(point.x.toFixed(2), 0.5);
+        t.same(point.y.toFixed(2), 0.5);
+
+        point = tileTransform.pointCoordinate(0, 50);
+        t.same(point.x.toFixed(4), 0.3736);
+        t.same(point.y.toFixed(4), 0.5);
+
+        point = tileTransform.pointCoordinate(50, 0);
+        t.same(point.x.toFixed(4), 0.5);
+        t.same(point.y.toFixed(4), 0.3577);
+
+        tr.center = {lng:180, lat:0};
+        tileTransform = tr.projection.createTileTransform(tr, tr.worldSize);
+
+        point = tileTransform.pointCoordinate(50, 50);
+        t.same(point.x.toFixed(2), 1.0);
+        t.same(point.y.toFixed(2), 0.5);
+
+        point = tileTransform.pointCoordinate(0, 50);
+        t.same(point.x.toFixed(4), 0.8736);
+        t.same(point.y.toFixed(4), 0.5);
+
+        // Expect x-coordinate not to wrap
+        point = tileTransform.pointCoordinate(100, 50);
+        t.same(point.x.toFixed(4), 1.1264);
+        t.same(point.y.toFixed(4), 0.5);
+
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -2,7 +2,7 @@
 
 import {test} from '../../util/test.js';
 
-import {degToRad, radToDeg, easeCubicInOut, getAABBPointSquareDist, furthestTileCorner, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, smoothstep, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid, nextPowerOfTwo, isPowerOfTwo, bufferConvexPolygon, prevPowerOfTwo} from '../../../src/util/util.js';
+import {degToRad, radToDeg, easeCubicInOut, getAABBPointSquareDist, furthestTileCorner, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, smoothstep, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid, nextPowerOfTwo, isPowerOfTwo, bufferConvexPolygon, prevPowerOfTwo, shortestAngle} from '../../../src/util/util.js';
 import Point from '@mapbox/point-geometry';
 
 const EPSILON = 1e-8;
@@ -410,6 +410,22 @@ test('util', (t) => {
         t.false(validateUuid(uuid().substr(0, 10)));
         t.false(validateUuid('foobar'));
         t.false(validateUuid(null));
+        t.end();
+    });
+
+    t.test('shortestAngle', (t) => {
+        t.equal(shortestAngle(0, 90), 90);
+        t.equal(shortestAngle(0, -270), 90);
+        t.equal(shortestAngle(0, 450), 90);
+
+        t.equal(shortestAngle(0, -90), -90);
+        t.equal(shortestAngle(0, 270), -90);
+        t.equal(shortestAngle(0, -450), -90);
+
+        t.equal(shortestAngle(45, 226), -179);
+        t.equal(shortestAngle(100, 123 * 360 + 100), 0);
+        t.equal(shortestAngle(-45, 335), 20);
+        t.equal(shortestAngle(-100, -270), -170);
         t.end();
     });
 


### PR DESCRIPTION
Panning the map doesn't automatically wrap the center point to the range [-180, 180]. User can move the map outside of the screen so that nothing gets rendered. This is possible as `center.wrap()` is invoked only during easing of the fling gesture and not at all if user pans the map without leaving any inertia.

https://user-images.githubusercontent.com/55925868/151778009-8ab34a71-1e00-410f-8d8f-24b1023f8f05.mp4

This PR fixes the issue by wrapping the center point in `transform._translateCameraConstrained()`. Additionally the `pointCoordinate` implementation for the globe view had to be updated to return non-wrapped coordinates to reflect the change.

Fixes the following issue https://github.com/mapbox/mapbox-gl-js/issues/11354 which was caused by mixed usage of wrapped and unwrapped coordinates in tile coverage computations.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix map center not being wrapped properly after a drag gesture.</changelog>`
