### PR TITLE
Upgrade Flow to v0.142.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -47,10 +47,11 @@
 .*/_site/.*
 
 [version]
-0.131.0
+0.132.0
 
 [options]
 server.max_workers=4
+types_first=false
 
 [strict]
 nonstrict-import

--- a/.flowconfig
+++ b/.flowconfig
@@ -47,7 +47,7 @@
 .*/_site/.*
 
 [version]
-0.134.0
+0.136.0
 
 [options]
 server.max_workers=4

--- a/.flowconfig
+++ b/.flowconfig
@@ -47,7 +47,7 @@
 .*/_site/.*
 
 [version]
-0.132.0
+0.134.0
 
 [options]
 server.max_workers=4

--- a/.flowconfig
+++ b/.flowconfig
@@ -47,7 +47,7 @@
 .*/_site/.*
 
 [version]
-0.136.0
+0.142.0
 
 [options]
 server.max_workers=4

--- a/flow-typed/gl-matrix.js
+++ b/flow-typed/gl-matrix.js
@@ -1,4 +1,4 @@
-
+// @flow
 type VecType = Array<number> | Float32Array | Float64Array;
 
 declare module "gl-matrix" {

--- a/flow-typed/grid-index.js
+++ b/flow-typed/grid-index.js
@@ -1,0 +1,13 @@
+// @flow strict
+declare module 'grid-index' {
+    declare class GridIndex {
+        constructor(extent: number, n: number, padding: number): GridIndex;
+        constructor(data: ArrayBuffer): GridIndex;
+
+        insert(key: number, x1: number, y1: number, x2: number, y2: number): void;
+        query(x1: number, y1: number, x2: number, y2: number, intersectionText?: (number, number, number, number) => boolean): Array<number>;
+        toArrayBuffer(): ArrayBuffer;
+    }
+
+    declare export default Class<GridIndex>;
+}

--- a/flow-typed/pbf.js
+++ b/flow-typed/pbf.js
@@ -1,3 +1,4 @@
+// @flow
 declare module "pbf" {
     declare type ReadFunction<T> = (tag: number, result: T, pbf: Pbf) => void;
 
@@ -21,5 +22,5 @@ declare module "pbf" {
         readBytes(): Uint8Array;
     }
 
-    declare module.exports: typeof Pbf
+    declare export default Class<Pbf>;
 }

--- a/flow-typed/point-geometry.js
+++ b/flow-typed/point-geometry.js
@@ -1,5 +1,6 @@
+// @flow strict
 declare module "@mapbox/point-geometry" {
-    declare type PointLike = Point | [number, number];
+    declare export type PointLike = Point | [number, number];
 
     declare class Point {
         x: number;
@@ -40,5 +41,6 @@ declare module "@mapbox/point-geometry" {
         _round(): Point;
         static convert(a: PointLike): Point;
     }
-    declare module.exports: typeof Point;
+
+    declare export default Class<Point>;
 }

--- a/flow-typed/potpack.js
+++ b/flow-typed/potpack.js
@@ -1,3 +1,4 @@
+// @flow
 declare module "potpack" {
     declare type Bin = {
         x: number,

--- a/flow-typed/tiny-sdf.js
+++ b/flow-typed/tiny-sdf.js
@@ -1,0 +1,31 @@
+
+declare module '@mapbox/tiny-sdf' {
+    declare type TinySDFOptions = {
+        fontSize?: number;
+        buffer?: number;
+        radius?: number;
+        cutoff?: number;
+        fontFamily?: string;
+        fontWeight?: string;
+        fontStyle?: string;
+    };
+
+    declare type TinySDFGlyph = {
+        data: Uint8ClampedArray;
+        width: number;
+        height: number;
+        glyphWidth: number;
+        glyphHeight: number;
+        glyphTop: number;
+        glyphLeft: number;
+        glyphAdvance: number;
+    };
+
+    declare class TinySDF {
+        fontWeight: string;
+        constructor(options: TinySDFOptions): TinySDF;
+        draw(char: string): TinySDFGlyph;
+    }
+
+    declare export default Class<TinySDF>;
+}

--- a/flow-typed/vector-tile.js
+++ b/flow-typed/vector-tile.js
@@ -1,3 +1,4 @@
+// @flow
 import type Pbf from 'pbf';
 import type Point from '@mapbox/point-geometry';
 import type { GeoJSONFeature } from '@mapbox/geojson-types';

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.131.0",
+    "flow-bin": "0.132.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.132.0",
+    "flow-bin": "0.134.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.134.0",
+    "flow-bin": "0.136.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
-    "flow-bin": "0.136.0",
+    "flow-bin": "0.142.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",
     "is-builtin-module": "^3.0.0",

--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -10,6 +10,7 @@ import type {ImagePosition} from '../render/image_atlas.js';
 import type LineAtlas from '../render/line_atlas.js';
 import type {CanonicalTileID} from '../source/tile_id.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
+import type Point from '@mapbox/point-geometry';
 
 export type BucketParameters<Layer: TypedStyleLayer> = {
     index: number,

--- a/src/data/evaluation_feature.js
+++ b/src/data/evaluation_feature.js
@@ -2,6 +2,8 @@
 
 import loadGeometry from './load_geometry.js';
 
+import type Point from '@mapbox/point-geometry';
+
 type EvaluationFeature = {
     +type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon',
     +id?: any,

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -45,6 +45,7 @@ import {GlobeSharedBuffers, globeToMercatorTransition} from '../geo/projection/g
 import {Terrain} from '../terrain/terrain.js';
 import {Debug} from '../util/debug.js';
 import Tile from '../source/tile.js';
+import {RGBAImage} from '../util/image.js';
 
 const draw = {
     symbol,
@@ -270,11 +271,8 @@ class Painter {
         for (const i of [0, 1, 3, 2, 0]) tileLineStripIndices.emplaceBack(i);
         this.debugIndexBuffer = context.createIndexBuffer(tileLineStripIndices);
 
-        this.emptyTexture = new Texture(context, {
-            width: 1,
-            height: 1,
-            data: new Uint8Array([0, 0, 0, 0])
-        }, context.gl.RGBA);
+        this.emptyTexture = new Texture(context,
+            new RGBAImage({width: 1, height: 1}, Uint8Array.of(0, 0, 0, 0)), context.gl.RGBA);
 
         this.identityMat = mat4.create();
 

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -1,7 +1,6 @@
 // @flow
 
 import window from '../util/window.js';
-const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData, ImageBitmap} = window;
 
 import type Context from '../gl/context.js';
 import type {RGBAImage, AlphaImage} from '../util/image.js';
@@ -54,6 +53,7 @@ class Texture {
         const {width, height} = image;
         const {context} = this;
         const {gl} = context;
+        const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData, ImageBitmap} = window;
 
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
 

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -67,6 +67,7 @@ class Texture {
             if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || (ImageBitmap && image instanceof ImageBitmap)) {
                 gl.texImage2D(gl.TEXTURE_2D, 0, this.format, this.format, gl.UNSIGNED_BYTE, image);
             } else {
+                // $FlowFixMe prop-missing - Flow can't refine image type here
                 gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);
             }
 
@@ -75,6 +76,7 @@ class Texture {
             if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || (ImageBitmap && image instanceof ImageBitmap)) {
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, gl.RGBA, gl.UNSIGNED_BYTE, image);
             } else {
+                // $FlowFixMe prop-missing - Flow can't refine image type here
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, image.data);
             }
         }

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -179,7 +179,7 @@ class GeoJSONSource extends Evented implements Source {
      *     }]
      * });
      */
-    setData(data: GeoJSON | string) {
+    setData(data: GeoJSON | string): this {
         this._data = data;
         this._updateWorkerData();
         return this;
@@ -215,7 +215,7 @@ class GeoJSONSource extends Evented implements Source {
      *     );
      * });
      */
-    getClusterExpansionZoom(clusterId: number, callback: Callback<number>) {
+    getClusterExpansionZoom(clusterId: number, callback: Callback<number>): this {
         this.actor.send('geojson.getClusterExpansionZoom', {clusterId, source: this.id}, callback);
         return this;
     }
@@ -243,7 +243,7 @@ class GeoJSONSource extends Evented implements Source {
      * });
      *
      */
-    getClusterChildren(clusterId: number, callback: Callback<Array<GeoJSONFeature>>) {
+    getClusterChildren(clusterId: number, callback: Callback<Array<GeoJSONFeature>>): this {
         this.actor.send('geojson.getClusterChildren', {clusterId, source: this.id}, callback);
         return this;
     }
@@ -273,7 +273,7 @@ class GeoJSONSource extends Evented implements Source {
      *     });
      * });
      */
-    getClusterLeaves(clusterId: number, limit: number, offset: number, callback: Callback<Array<GeoJSONFeature>>) {
+    getClusterLeaves(clusterId: number, limit: number, offset: number, callback: Callback<Array<GeoJSONFeature>>): this {
         this.actor.send('geojson.getClusterLeaves', {
             source: this.id,
             clusterId,

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -197,7 +197,7 @@ class ImageSource extends Evented implements Source {
      *     ]
      * });
      */
-    updateImage(options: {url: string, coordinates?: Coordinates}) {
+    updateImage(options: {url: string, coordinates?: Coordinates}): this {
         if (!this.image || !options.url) {
             return this;
         }
@@ -246,7 +246,7 @@ class ImageSource extends Evented implements Source {
      *     [-76.5452, 39.1787]
      * ]);
      */
-    setCoordinates(coordinates: Coordinates) {
+    setCoordinates(coordinates: Coordinates): this {
         this.coordinates = coordinates;
         this._boundsArray = undefined;
 

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -10,6 +10,8 @@ import type {QueryGeometry} from '../style/query_geometry.js';
 import assert from 'assert';
 import {mat4} from 'gl-matrix';
 
+import type Point from '@mapbox/point-geometry';
+
 /*
  * Returns a matrix that can be used to convert from tile coordinates to viewport pixel coordinates.
  */

--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -2,11 +2,9 @@
 
 import DEMData from '../data/dem_data.js';
 import {RGBAImage} from '../util/image.js';
-import window from '../util/window.js';
 
 import type Actor from '../util/actor.js';
 import type {WorkerDEMTileParameters, WorkerDEMTileCallback} from './worker_source.js';
-const {ImageBitmap} = window;
 
 class RasterDEMTileWorkerSource {
     actor: Actor;
@@ -16,7 +14,7 @@ class RasterDEMTileWorkerSource {
     loadTile(params: WorkerDEMTileParameters, callback: WorkerDEMTileCallback) {
         const {uid, encoding, rawImageData, padding, buildQuadTree} = params;
         // Main thread will transfer ImageBitmap if offscreen decode with OffscreenCanvas is supported, else it will transfer an already decoded image.
-        const imagePixels = (ImageBitmap && rawImageData instanceof ImageBitmap) ? this.getImageData(rawImageData, padding) : rawImageData;
+        const imagePixels = rawImageData instanceof RGBAImage ? rawImageData : this.getImageData(rawImageData, padding);
         const dem = new DEMData(uid, imagePixels, encoding, padding < 1, buildQuadTree);
         callback(null, dem);
     }

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -168,7 +168,7 @@ class VectorTileSource extends Evented implements Source {
      * // Set the endpoint associated with a vector tile source.
      * vectorTileSource.setTiles(['https://another_end_point.net/{z}/{x}/{y}.mvt']);
      */
-    setTiles(tiles: Array<string>) {
+    setTiles(tiles: Array<string>): this {
         this.setSourceProperty(() => {
             this._options.tiles = tiles;
         });
@@ -192,7 +192,7 @@ class VectorTileSource extends Evented implements Source {
      * // Update vector tile source to a new URL endpoint
      * vectorTileSource.setUrl("mapbox://mapbox.mapbox-streets-v8");
      */
-    setUrl(url: string) {
+    setUrl(url: string): this {
         this.setSourceProperty(() => {
             this.url = url;
             this._options.url = url;

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -14,8 +14,6 @@ import type {StyleGlyph} from '../style/style_glyph.js';
 import type {StyleImage} from '../style/style_image.js';
 import type {PromoteIdSpecification} from '../style-spec/types.js';
 import type {Projection} from '../geo/projection/index.js';
-import window from '../util/window.js';
-const {ImageBitmap} = window;
 
 export type TileParameters = {
     source: string,

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -286,11 +286,11 @@ export class StylePropertyFunction<T> {
         extend(this, createFunction(this._parameters, this._specification));
     }
 
-    static deserialize(serialized: {_parameters: PropertyValueSpecification<T>, _specification: StylePropertySpecification}) {
-        return ((new StylePropertyFunction(serialized._parameters, serialized._specification)): StylePropertyFunction<T>);
+    static deserialize(serialized: {_parameters: PropertyValueSpecification<T>, _specification: StylePropertySpecification}): StylePropertyFunction<T> {
+        return new StylePropertyFunction(serialized._parameters, serialized._specification);
     }
 
-    static serialize(input: StylePropertyFunction<T>) {
+    static serialize(input: StylePropertyFunction<T>): {_parameters: PropertyValueSpecification<T>, _specification: StylePropertySpecification} {
         return {
             _parameters: input._parameters,
             _specification: input._specification

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -57,6 +57,12 @@ export type StylePropertySpecification = {
     length?: number,
     transition: boolean,
     default?: Array<string>
+} | {
+    type: 'resolvedImage',
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    transition: boolean,
+    default?: string
 };
 
 import v8 from './reference/v8.json';

--- a/src/style/format_section_override.js
+++ b/src/style/format_section_override.js
@@ -21,7 +21,7 @@ export default class FormatSectionOverride<T> implements Expression {
         this.defaultValue = defaultValue;
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): T {
         if (ctx.formattedSection) {
             const overrides = this.defaultValue.property.overrides;
             if (overrides && overrides.hasOverride(ctx.formattedSection)) {
@@ -33,7 +33,8 @@ export default class FormatSectionOverride<T> implements Expression {
             return this.defaultValue.evaluate(ctx.feature, ctx.featureState);
         }
 
-        return this.defaultValue.property.specification.default;
+        // not sure how to make Flow refine the type properly here — will need investigation
+        return ((this.defaultValue.property.specification.default: any): T);
     }
 
     eachChild(fn: (_: Expression) => void) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -39,6 +39,7 @@ import DEMData from '../data/dem_data.js';
 import {DrapeRenderMode} from '../style/terrain.js';
 import rasterFade from '../render/raster_fade.js';
 import {create as createSource} from '../source/source.js';
+import {RGBAImage} from '../util/image.js';
 
 import type Map from '../ui/map.js';
 import type Painter from '../render/painter.js';
@@ -539,10 +540,7 @@ export class Terrain extends Elevation {
         const context = this.painter.context;
         const gl = context.gl;
         if (!this._emptyDepthBufferTexture) {
-            const image = {
-                width: 1, height: 1,
-                data: new Uint8Array([255, 255, 255, 255])
-            };
+            const image = new RGBAImage({width: 1, height: 1}, Uint8Array.of(255, 255, 255, 255));
             this._emptyDepthBufferTexture = new Texture(context, image, gl.RGBA, {premultiply: false});
         }
         return this._emptyDepthBufferTexture;
@@ -566,10 +564,10 @@ export class Terrain extends Elevation {
         context.activeTexture.set(gl.TEXTURE2);
 
         const min = this._getLoadedAreaMinimum();
-        const image = {
-            width: 1, height: 1,
-            data: new Uint8Array(DEMData.pack(min, ((this.sourceCache.getSource(): any): RasterDEMTileSource).encoding))
-        };
+        const image = new RGBAImage(
+            {width: 1, height: 1},
+            new Uint8Array(DEMData.pack(min, ((this.sourceCache.getSource(): any): RasterDEMTileSource).encoding))
+        );
 
         this._emptyDEMTextureDirty = false;
         let texture = this._emptyDEMTexture;

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -6,6 +6,7 @@ import {MouseRotateHandler, MousePitchHandler} from '../handler/mouse.js';
 import window from '../../util/window.js';
 
 import type Map from '../map.js';
+import type Point from '@mapbox/point-geometry';
 
 type Options = {
     showCompass?: boolean,

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -5,6 +5,7 @@ import DOM from '../../util/dom.js';
 import {Event} from '../../util/evented.js';
 
 import type Map from '../map.js';
+import type Point from '@mapbox/point-geometry';
 
 /**
  * The `BoxZoomHandler` allows the user to zoom the map to fit within a bounding box.

--- a/src/ui/handler/handler_util.js
+++ b/src/ui/handler/handler_util.js
@@ -2,6 +2,8 @@
 
 import assert from 'assert';
 
+import type Point from '@mapbox/point-geometry';
+
 export function indexTouches(touches: Array<Touch>, points: Array<Point>) {
     assert(touches.length === points.length);
     const obj = {};

--- a/src/ui/handler/map_event.js
+++ b/src/ui/handler/map_event.js
@@ -2,7 +2,9 @@
 
 import {extend} from '../../util/util.js';
 import {MapMouseEvent, MapTouchEvent, MapWheelEvent} from '../events.js';
+
 import type Map from '../map.js';
+import type Point from '@mapbox/point-geometry';
 
 export class MapEventHandler {
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -4,7 +4,6 @@ import {version} from '../../package.json';
 import {asyncAll, extend, bindAll, warnOnce, uniqueId} from '../util/util.js';
 import browser from '../util/browser.js';
 import window from '../util/window.js';
-const {HTMLImageElement, HTMLElement, ImageBitmap} = window;
 import DOM from '../util/dom.js';
 import {getImage, getJSON, ResourceType} from '../util/ajax.js';
 import {RequestManager, getMapSessionAPI, postMapLoadEvent, AUTH_ERR_MSG, storeAuthState, removeAuthState} from '../util/mapbox.js';
@@ -485,7 +484,7 @@ class Map extends Camera {
             if (!this._container) {
                 throw new Error(`Container '${options.container}' not found.`);
             }
-        } else if (options.container instanceof HTMLElement) {
+        } else if (options.container instanceof window.HTMLElement) {
             this._container = options.container;
         } else {
             throw new Error(`Invalid type: 'container' must be a String or HTMLElement.`);
@@ -1933,7 +1932,7 @@ class Map extends Camera {
         this._lazyInitEmptyStyle();
         const version = 0;
 
-        if (image instanceof HTMLImageElement || (ImageBitmap && image instanceof ImageBitmap)) {
+        if (image instanceof window.HTMLImageElement || (window.ImageBitmap && image instanceof window.ImageBitmap)) {
             const {width, height, data} = browser.getImageData(image);
             this.style.addImage(id, {data: new RGBAImage({width, height}, data), pixelRatio, stretchX, stretchY, content, sdf, version});
         } else if (image.width === undefined || image.height === undefined) {
@@ -1987,7 +1986,7 @@ class Map extends Camera {
             return this.fire(new ErrorEvent(new Error(
                 'The map has no image with that id. If you are adding a new image use `map.addImage(...)` instead.')));
         }
-        const imageData = (image instanceof HTMLImageElement || (ImageBitmap && image instanceof ImageBitmap)) ? browser.getImageData(image) : image;
+        const imageData = (image instanceof window.HTMLImageElement || (window.ImageBitmap && image instanceof window.ImageBitmap)) ? browser.getImageData(image) : image;
         const {width, height, data} = imageData;
 
         if (width === undefined || height === undefined) {
@@ -2001,7 +2000,7 @@ class Map extends Camera {
                 'The width and height of the updated image must be that same as the previous version of the image')));
         }
 
-        const copy = !(image instanceof HTMLImageElement || (ImageBitmap && image instanceof ImageBitmap));
+        const copy = !(image instanceof window.HTMLImageElement || (window.ImageBitmap && image instanceof window.ImageBitmap));
         existingImage.data.replace(data, copy);
 
         this.style.updateImage(id, existingImage);
@@ -2064,7 +2063,7 @@ class Map extends Camera {
      */
     loadImage(url: string, callback: Function) {
         getImage(this._requestManager.transformRequest(url, ResourceType.Image), (err, img) => {
-            callback(err, img instanceof HTMLImageElement ? browser.getImageData(img) : img);
+            callback(err, img instanceof window.HTMLImageElement ? browser.getImageData(img) : img);
         });
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1940,8 +1940,9 @@ class Map extends Camera {
                 'Invalid arguments to map.addImage(). The second argument must be an `HTMLImageElement`, `ImageData`, `ImageBitmap`, ' +
                 'or object with `width`, `height`, and `data` properties with the same format as `ImageData`')));
         } else {
-            const {width, height, data} = image;
+            const {width, height} = image;
             const userImage = ((image: any): StyleImageInterface);
+            const data = userImage.data;
 
             this.style.addImage(id, {
                 data: new RGBAImage({width, height}, new Uint8Array(data)),
@@ -1987,7 +1988,9 @@ class Map extends Camera {
                 'The map has no image with that id. If you are adding a new image use `map.addImage(...)` instead.')));
         }
         const imageData = (image instanceof window.HTMLImageElement || (window.ImageBitmap && image instanceof window.ImageBitmap)) ? browser.getImageData(image) : image;
-        const {width, height, data} = imageData;
+        const {width, height} = imageData;
+        // Flow can't refine the type enough to exclude ImageBitmap
+        const data = ((imageData: any).data: Uint8Array | Uint8ClampedArray);
 
         if (width === undefined || height === undefined) {
             return this.fire(new ErrorEvent(new Error(

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -596,7 +596,7 @@ export default class Popup extends Evented {
         container.className = classes.join(' ');
     }
 
-    _update(cursor: ?PointLike) {
+    _update(cursor?: Point) {
         const hasPosition = this._lngLat || this._trackPointer;
         const map = this._map;
 

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -14,7 +14,7 @@ type Point = {
     y: number
 };
 
-function createImage(image: *, {width, height}: Size, channels: number, data?: Uint8Array | Uint8ClampedArray) {
+function createImage<T: AlphaImage | RGBAImage>(image: T, {width, height}: Size, channels: number, data?: Uint8Array | Uint8ClampedArray): T {
     if (!data) {
         data = new Uint8Array(width * height * channels);
     } else if (data instanceof Uint8ClampedArray) {
@@ -28,12 +28,11 @@ function createImage(image: *, {width, height}: Size, channels: number, data?: U
     return image;
 }
 
-function resizeImage(image: *, {width, height}: Size, channels: number) {
+function resizeImage<T: AlphaImage | RGBAImage>(image: T, newImage: T, channels: number) {
+    const {width, height} = newImage;
     if (width === image.width && height === image.height) {
         return;
     }
-
-    const newImage = createImage({}, {width, height}, channels);
 
     copyImage(image, newImage, {x: 0, y: 0}, {x: 0, y: 0}, {
         width: Math.min(image.width, width),
@@ -45,7 +44,7 @@ function resizeImage(image: *, {width, height}: Size, channels: number) {
     image.data = newImage.data;
 }
 
-function copyImage(srcImg: *, dstImg: *, srcPt: Point, dstPt: Point, size: Size, channels: number) {
+function copyImage<T: RGBAImage | AlphaImage>(srcImg: T | ImageData, dstImg: T, srcPt: Point, dstPt: Point, size: Size, channels: number): T {
     if (size.width === 0 || size.height === 0) {
         return dstImg;
     }
@@ -89,7 +88,7 @@ export class AlphaImage {
     }
 
     resize(size: Size) {
-        resizeImage(this, size, 1);
+        resizeImage(this, new AlphaImage(size), 1);
     }
 
     clone() {
@@ -116,7 +115,7 @@ export class RGBAImage {
     }
 
     resize(size: Size) {
-        resizeImage(this, size, 4);
+        resizeImage(this, new RGBAImage(size), 4);
     }
 
     replace(data: Uint8Array | Uint8ClampedArray, copy?: boolean) {

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -129,6 +129,7 @@ class StructArray {
     }
 
     static deserialize(input: SerializedStructArray) {
+        // $FlowFixMe not-an-object - newer Flow doesn't understand this pattern, silence for now
         const structArray = Object.create(this.prototype);
         structArray.arrayBuffer = input.arrayBuffer;
         structArray.length = input.length;

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -14,7 +14,7 @@ const MIN_TIME_UNTIL_EXPIRY = 1000 * 60 * 7; // 7 minutes. Skip caching tiles wi
 export type ResponseOptions = {
     status: number,
     statusText: string,
-    headers: window.Headers
+    headers: Headers
 };
 
 // We're using a global shared cache object. Normally, requesting ad-hoc Cache objects is fine, but
@@ -72,7 +72,9 @@ export function cachePut(request: Request, response: Response, requestTime: numb
         options.headers.set('Expires', new Date(requestTime + cacheControl['max-age'] * 1000).toUTCString());
     }
 
-    const timeUntilExpiry = new Date(options.headers.get('Expires')).getTime() - requestTime;
+    const expires = options.headers.get('Expires');
+    if (!expires) return;
+    const timeUntilExpiry = new Date(expires).getTime() - requestTime;
     if (timeUntilExpiry < MIN_TIME_UNTIL_EXPIRY) return;
 
     prepareBody(response, body => {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -480,7 +480,7 @@ export {deepEqual};
  */
 export function clone<T>(input: T): T {
     if (Array.isArray(input)) {
-        return input.map(clone);
+        return ((input.map(clone): any): T);
     } else if (typeof input === 'object' && input) {
         return ((mapObject(input, clone): any): T);
     } else {

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -9,7 +9,6 @@ import CompoundExpression from '../style-spec/expression/compound_expression.js'
 import expressions from '../style-spec/expression/definitions/index.js';
 import ResolvedImage from '../style-spec/expression/types/resolved_image.js';
 import window from './window.js';
-const {ImageData, ImageBitmap} = window;
 
 import type {Transferable} from '../types/transferable.js';
 
@@ -72,7 +71,7 @@ register('Object', Object);
 
 type SerializedGrid = { buffer: ArrayBuffer };
 
-Grid.serialize = function serialize(grid: Grid, transferables?: Array<Transferable>): SerializedGrid {
+(Grid: any).serialize = function serialize(grid: Grid, transferables?: Array<Transferable>): SerializedGrid {
     const buffer = grid.toArrayBuffer();
     if (transferables) {
         transferables.push(buffer);
@@ -80,7 +79,7 @@ Grid.serialize = function serialize(grid: Grid, transferables?: Array<Transferab
     return {buffer};
 };
 
-Grid.deserialize = function deserialize(serialized: SerializedGrid): Grid {
+(Grid: any).deserialize = function deserialize(serialized: SerializedGrid): Grid {
     return new Grid(serialized.buffer);
 };
 register('Grid', Grid);
@@ -106,8 +105,8 @@ function isArrayBuffer(val: any): boolean {
 }
 
 function isImageBitmap(val: any): boolean {
-    return ImageBitmap &&
-        val instanceof ImageBitmap;
+    return window.ImageBitmap &&
+        val instanceof window.ImageBitmap;
 }
 
 /**
@@ -142,7 +141,7 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
         if (transferables) {
             transferables.push(((input: any): ArrayBuffer));
         }
-        return input;
+        return (input: any);
     }
 
     if (ArrayBuffer.isView(input)) {
@@ -153,7 +152,7 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
         return view;
     }
 
-    if (input instanceof ImageData) {
+    if (input instanceof window.ImageData) {
         if (transferables) {
             transferables.push(input.data.buffer);
         }
@@ -231,7 +230,7 @@ export function deserialize(input: Serialized): mixed {
         isArrayBuffer(input) ||
         isImageBitmap(input) ||
         ArrayBuffer.isView(input) ||
-        input instanceof ImageData) {
+        input instanceof window.ImageData) {
         return input;
     }
 

--- a/test/unit/source/raster_dem_tile_worker_source.test.js
+++ b/test/unit/source/raster_dem_tile_worker_source.test.js
@@ -2,6 +2,7 @@ import {test} from '../../util/test.js';
 import RasterDEMTileWorkerSource from '../../../src/source/raster_dem_tile_worker_source.js';
 import StyleLayerIndex from '../../../src/style/style_layer_index.js';
 import DEMData from '../../../src/data/dem_data.js';
+import {RGBAImage} from '../../../src/util/image.js';
 
 test('loadTile', (t) => {
     t.test('loads DEM tile', (t) => {
@@ -10,7 +11,7 @@ test('loadTile', (t) => {
         source.loadTile({
             source: 'source',
             uid: 0,
-            rawImageData: {data: new Uint8ClampedArray(256), height: 8, width: 8},
+            rawImageData: new RGBAImage({height: 8, width: 8}, new Uint8ClampedArray(256)),
             dim: 256
         }, (err, data) => {
             if (err) t.fail();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.131.0:
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.131.0.tgz#d4228b6070afdf3b2a76acdee77a7f3f8e8f5133"
-  integrity sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==
+flow-bin@0.132.0:
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
+  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.136.0:
-  version "0.136.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.136.0.tgz#2c1be64496d791ea3160047ce22968ef166835f1"
-  integrity sha512-Z0sycQDyWXiNsGAhOBUrvHPzz7Q4g38BT57+YzZGffbaBmWRNC6MGZb+R6XTzeWb30bZin5V21nPQZezJzm9cQ==
+flow-bin@0.142.0:
+  version "0.142.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.142.0.tgz#b46b69de1123cf7c5a50917402968e07291df054"
+  integrity sha512-YgiapK/wrJjcgSgOWfoncbZ4vZrZWdHs+p7V9duI9zo4ehW2nM/VRrpSaWoZ+CWu3t+duGyAvupJvC6MM2l07w==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.134.0:
-  version "0.134.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.134.0.tgz#e98e5724f6ed5a1265cf904bbb5e4c096ea3a026"
-  integrity sha512-j5aCugO3jmwDsUKc+7KReArgnL6aVjHLo6DlozKhxKYN+TaP8BY+mintPSISjSQtKZFJyvoNAc1oXA79X5WjIA==
+flow-bin@0.136.0:
+  version "0.136.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.136.0.tgz#2c1be64496d791ea3160047ce22968ef166835f1"
+  integrity sha512-Z0sycQDyWXiNsGAhOBUrvHPzz7Q4g38BT57+YzZGffbaBmWRNC6MGZb+R6XTzeWb30bZin5V21nPQZezJzm9cQ==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@0.132.0:
-  version "0.132.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
-  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
+flow-bin@0.134.0:
+  version "0.134.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.134.0.tgz#e98e5724f6ed5a1265cf904bbb5e4c096ea3a026"
+  integrity sha512-j5aCugO3jmwDsUKc+7KReArgnL6aVjHLo6DlozKhxKYN+TaP8BY+mintPSISjSQtKZFJyvoNAc1oXA79X5WjIA==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
Continuing #11426. This PR upgrades Flow to v0.132.0, a version which forbids using implicit `any` as a type, which previously led to incorrectly typed or untyped code that Flow ignored. Similar to #11400 but extends to all other libraries we import. Then further upgrades to v0.142.0, the last version that supports `types_first = false`.

In particular, adds types for `@mapbox/grid-index` and `@mapbox/tiny-sdf` (previously untyped and assumed `Object` = `any`), and makes sure `Point` type is used explicitly where it's referenced (for some reason Flow didn't complain when it didn't). Also note that I had to disable a few errors with `any` or `$FlowFixMe` in places where proper typing is very difficult — I would leave fixing this for later when we're on the latest Flow version.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
