### PR TITLE
Fix map.getProjection() returns explicity set globe and simplifying Transform.clone()

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -135,7 +135,7 @@ class Transform {
     _nearZ: number;
     _farZ: number;
 
-    constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void, projection?: ?ProjectionSpecificatio, bounds: ?LngLatBounds) {
+    constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void, projection?: ?ProjectionSpecification, bounds: ?LngLatBounds) {
         this.tileSize = 512; // constant
 
         this._renderWorldCopies = renderWorldCopies === undefined ? true : renderWorldCopies;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -135,7 +135,7 @@ class Transform {
     _nearZ: number;
     _farZ: number;
 
-    constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void) {
+    constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void, projection?: ?ProjectionSpecificatio, bounds: ?LngLatBounds) {
         this.tileSize = 512; // constant
 
         this._renderWorldCopies = renderWorldCopies === undefined ? true : renderWorldCopies;
@@ -145,8 +145,8 @@ class Transform {
         this._minPitch = (minPitch === undefined || minPitch === null) ? 0 : minPitch;
         this._maxPitch = (maxPitch === undefined || maxPitch === null) ? 60 : maxPitch;
 
-        this.setProjection();
-        this.setMaxBounds();
+        this.setProjection(projection);
+        this.setMaxBounds(bounds);
 
         this.width = 0;
         this.height = 0;
@@ -174,12 +174,10 @@ class Transform {
     }
 
     clone(): Transform {
-        const clone = new Transform(this._minZoom, this._maxZoom, this._minPitch, this.maxPitch, this._renderWorldCopies);
-        clone.setProjection(this.getProjection());
+        const clone = new Transform(this._minZoom, this._maxZoom, this._minPitch, this.maxPitch, this._renderWorldCopies, this.getProjection());
         clone._elevation = this._elevation;
         clone._centerAltitude = this._centerAltitude;
         clone.tileSize = this.tileSize;
-        clone.setMaxBounds(this.getMaxBounds());
         clone.width = this.width;
         clone.height = this.height;
         clone.cameraElevationReference = this.cameraElevationReference;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -371,9 +371,9 @@ class Style extends Evented {
             }
         }
 
-        this.dispatcher.broadcast('setProjection', this.map.transform.projectionOptions);
-
         if (!projectionChanged) return;
+
+        this.dispatcher.broadcast('setProjection', this.map.transform.projectionOptions);
 
         const globeChanged = (projection.name === 'globe' || prevProjection.name === 'globe') && !this.map._transitionFromGlobe;
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1025,7 +1025,11 @@ class Map extends Camera {
      * const projection = map.getProjection();
      */
     getProjection() {
-        return this.transform.getProjection();
+        const proj = this.transform.getProjection();
+        if (this._transitionFromGlobe) {
+            proj.name = "globe";
+        }
+        return proj;
     }
 
     /**

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1556,6 +1556,32 @@ test('Map', (t) => {
             t.deepEqual(map.getProjection(), options);
             t.end();
         });
+
+        t.test('returns Albers projection at high zoom', (t) => {
+            const map = createMap(t, {projection: 'albers'});
+            map.setZoom(12);
+            map.once('render', () => {
+                t.deepEqual(map.getProjection(), {
+                    name: 'albers',
+                    center: [-96, 37.5],
+                    parallels: [29.5, 45.5]
+                });
+                t.end();
+            });
+        });
+
+        t.test('returns globe projection at high zoom', (t) => {
+            const map = createMap(t, {projection: 'globe'});
+            map.setZoom(12);
+            map.once('render', () => {
+                t.deepEqual(map.getProjection(), {
+                    name: 'globe',
+                    center: [0, 0],
+                });
+                t.end();
+            });
+
+        });
         t.end();
     });
 


### PR DESCRIPTION
As of the issue draft [here](https://github.com/orgs/mapbox/projects/677/views/10):

> When doing `map.setProjection('globe')`, `map.getProjection()` should always return `'globe'` independently of whether the map has transitioned to mercator.
> 
> This behavior would be consistent with the way other projections work.

The single-source of truth for most projections is `map._runtimeProjection` as described [here](https://github.com/mapbox/mapbox-gl-js/pull/11204). However, this is not the case with Globe view, which overrides this variable at zoom levels that switch to Mercator and keeps track of the original projection with the `this._transitionFromGlobe`. This PR checks this variable to alter the return of `map.getProjection()'



## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Changed map.getProjection to return globe even when fully zoomed in.</changelog>`
