### PR TITLE
Do not update camera zoom when DEM data isn't available yet

### DIFF
--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -29,6 +29,30 @@ export type ElevationQueryOptions = {
  * Provides access to elevation data from raster-dem source cache.
  */
 export class Elevation {
+
+    /**
+     * Helper that checks whether DEM data is available at a given mercator coordinate.
+     * @param {MercatorCoordinate} point Mercator coordinate of the point to check against.
+     * @returns {number} `true` indicating whether the data is available at `point`, and `false` otherwise.
+     */
+    isDataAvailableAtPoint(point: MercatorCoordinate) {
+        const sourceCache = this._source();
+        if (!sourceCache || point.y < 0.0 || point.y > 1.0) {
+            return false;
+        }
+
+        const cache: SourceCache = sourceCache;
+        const z = cache.getSource().maxzoom;
+        const tiles = 1 << z;
+        const wrap = Math.floor(point.x);
+        const px = point.x - wrap;
+        const x = Math.floor(px * tiles);
+        const y = Math.floor(point.y * tiles);
+        const demTile = this.findDEMTileFor(new OverscaledTileID(z, wrap, z, x, y));
+
+        return demTile && demTile.dem;
+    }
+
     /**
      * Helper around `getAtPoint` that guarantees that a numeric value is returned.
      * @param {MercatorCoordinate} point Mercator coordinate of the point.

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1521,7 +1521,7 @@ class Camera extends Evented {
 
             const newCenter = k === 1 ? center : tr.unproject(from.add(delta.mult(u(s))).mult(scale));
             tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, pointAtOffset);
-            tr._updateCenterElevation();
+            tr._updateCameraOnTerrain();
 
             if (!options.preloadOnly) {
                 this._fireMoveEvents(eventData);

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -748,7 +748,7 @@ test('transform', (t) => {
         transform.zoom = zoom;
 
         t.false(transform._centerAltitudeValid);
-        t.equal(transform._cameraZoom, transformBefore._cameraZoom);
+        t.equal(transform._seaLevelZoom, transformBefore._seaLevelZoom);
 
         t.end();
     });
@@ -762,7 +762,7 @@ test('transform', (t) => {
         t.equal(transform.elevation.getAtPointOrZero(new MercatorCoordinate(1.0, 0.5)), 250);
 
         t.equal(transform.zoom, 16);
-        t.equal(transform._cameraZoom, 16);
+        t.equal(transform._seaLevelZoom, 16);
 
         // zoom should remain unchanged
         transform.cameraElevationReference = "ground";
@@ -775,9 +775,9 @@ test('transform', (t) => {
         // zoom should change so that the altitude remains constant
         transform.cameraElevationReference = "sea";
         transform.center = new LngLat(180, 0);
-        t.equal(transform._cameraZoom, 16);
+        t.equal(transform._seaLevelZoom, 16);
 
-        const altitudeZ = transform.cameraToCenterDistance / (Math.pow(2.0, transform._cameraZoom) * transform.tileSize);
+        const altitudeZ = transform.cameraToCenterDistance / (Math.pow(2.0, transform._seaLevelZoom) * transform.tileSize);
         const heightZ = transform.cameraToCenterDistance / (Math.pow(2.0, transform.zoom) * transform.tileSize);
         const elevationZ = mercatorZfromAltitude(250, 0);
         t.equal(fixedNum(elevationZ + heightZ), fixedNum(altitudeZ));
@@ -792,20 +792,20 @@ test('transform', (t) => {
         transform.zoom = 16;
 
         transform.elevation = createConstantElevation(0);
-        t.equal(transform.zoom, transform._cameraZoom);
+        t.equal(transform.zoom, transform._seaLevelZoom);
 
         // Camera zoom should change so that the standard zoom value describes distance between the camera and the terrain
         transform.elevation = createConstantElevation(10000);
-        t.equal(fixedNum(transform._cameraZoom), 11.1449615644);
+        t.equal(fixedNum(transform._seaLevelZoom), 11.1449615644);
 
         // Camera height over terrain should remain constant
-        const altitudeZ = transform.cameraToCenterDistance / (Math.pow(2.0, transform._cameraZoom) * transform.tileSize);
+        const altitudeZ = transform.cameraToCenterDistance / (Math.pow(2.0, transform._seaLevelZoom) * transform.tileSize);
         const heightZ = transform.cameraToCenterDistance / (Math.pow(2.0, transform.zoom) * transform.tileSize);
         const elevationZ = mercatorZfromAltitude(10000, 0);
         t.equal(elevationZ + heightZ, altitudeZ);
 
         transform.pitch = 32;
-        t.equal(fixedNum(transform._cameraZoom), 11.1449615644);
+        t.equal(fixedNum(transform._seaLevelZoom), 11.1449615644);
         t.equal(transform.zoom, 16);
 
         t.end();


### PR DESCRIPTION
Make sure to not update camera zoom when the terrain DEM data isn't available at center point, which is the reference to calculate the camera zoom over terrain. This fixes the following issue that was reported by customer:

https://user-images.githubusercontent.com/9189867/150030713-87a69d65-6bc9-4c7c-9280-a8b7b2fc7075.mov

More description of the issue and a reproducible case is available here https://github.com/mapbox/gl-js-team/issues/341

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a potential issue with camera going under the terrain when the DEM data isn't available at center point.</changelog>`
