### PR TITLE
Fix a terrain+FF regression from the recent Flow PR

### DIFF
--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -38,7 +38,7 @@ export default class DEMData {
 
     // RGBAImage data has uniform 1px padding on all sides: square tile edge size defines stride
     // and dim is calculated as stride - 2.
-    constructor(uid: number, data: RGBAImage, encoding: DEMEncoding, borderReady: boolean = false, buildQuadTree: boolean = false) {
+    constructor(uid: number, data: ImageData, encoding: DEMEncoding, borderReady: boolean = false, buildQuadTree: boolean = false) {
         this.uid = uid;
         if (data.height !== data.width) throw new RangeError('DEM tiles must be square');
         if (encoding && encoding !== "mapbox" && encoding !== "terrarium") return warnOnce(

--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -1,7 +1,7 @@
 // @flow
 
 import DEMData from '../data/dem_data.js';
-import {RGBAImage} from '../util/image.js';
+import window from '../util/window.js';
 
 import type Actor from '../util/actor.js';
 import type {WorkerDEMTileParameters, WorkerDEMTileCallback} from './worker_source.js';
@@ -14,12 +14,13 @@ class RasterDEMTileWorkerSource {
     loadTile(params: WorkerDEMTileParameters, callback: WorkerDEMTileCallback) {
         const {uid, encoding, rawImageData, padding, buildQuadTree} = params;
         // Main thread will transfer ImageBitmap if offscreen decode with OffscreenCanvas is supported, else it will transfer an already decoded image.
-        const imagePixels = rawImageData instanceof RGBAImage ? rawImageData : this.getImageData(rawImageData, padding);
+        const imagePixels = window.ImageBitmap && rawImageData instanceof window.ImageBitmap ? this.getImageData(rawImageData, padding) : rawImageData;
+        // $FlowFixMe Flow struggles to refine ImageBitmap type, likely due to the JSDom shim
         const dem = new DEMData(uid, imagePixels, encoding, padding < 1, buildQuadTree);
         callback(null, dem);
     }
 
-    getImageData(imgBitmap: ImageBitmap, padding: number): RGBAImage {
+    getImageData(imgBitmap: ImageBitmap, padding: number): ImageData {
         // Lazily initialize OffscreenCanvas
         if (!this.offscreenCanvas || !this.offscreenCanvasContext) {
             // Dem tiles are typically 256x256
@@ -34,7 +35,7 @@ class RasterDEMTileWorkerSource {
         // Insert or remove defined padding around the image to allow backfilling for neighboring data.
         const imgData = this.offscreenCanvasContext.getImageData(-padding, -padding, imgBitmap.width + 2 * padding, imgBitmap.height + 2 * padding);
         this.offscreenCanvasContext.clearRect(0, 0, this.offscreenCanvas.width, this.offscreenCanvas.height);
-        return new RGBAImage({width: imgData.width, height: imgData.height}, imgData.data);
+        return imgData;
     }
 }
 

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {RequestParameters} from '../util/ajax.js';
-import type {RGBAImage, AlphaImage} from '../util/image.js';
+import type {AlphaImage} from '../util/image.js';
 import type {GlyphPositions} from '../render/glyph_atlas.js';
 import type ImageAtlas from '../render/image_atlas.js';
 import type LineAtlas from '../render/line_atlas.js';
@@ -43,7 +43,7 @@ export type WorkerTileParameters = RequestedTileParameters & {
 
 export type WorkerDEMTileParameters = TileParameters & {
     coord: { z: number, x: number, y: number, w: number },
-    rawImageData: RGBAImage | ImageBitmap,
+    rawImageData: ImageData | ImageBitmap,
     encoding: "mapbox" | "terrarium",
     padding: number,
     buildQuadTree?: boolean

--- a/test/unit/source/raster_dem_tile_worker_source.test.js
+++ b/test/unit/source/raster_dem_tile_worker_source.test.js
@@ -2,7 +2,6 @@ import {test} from '../../util/test.js';
 import RasterDEMTileWorkerSource from '../../../src/source/raster_dem_tile_worker_source.js';
 import StyleLayerIndex from '../../../src/style/style_layer_index.js';
 import DEMData from '../../../src/data/dem_data.js';
-import {RGBAImage} from '../../../src/util/image.js';
 
 test('loadTile', (t) => {
     t.test('loads DEM tile', (t) => {
@@ -11,7 +10,7 @@ test('loadTile', (t) => {
         source.loadTile({
             source: 'source',
             uid: 0,
-            rawImageData: new RGBAImage({height: 8, width: 8}, new Uint8ClampedArray(256)),
+            rawImageData: {data: new Uint8ClampedArray(256), width: 8, height: 8},
             dim: 256
         }, (err, data) => {
             if (err) t.fail();


### PR DESCRIPTION
Fixes a regression from #11456. Thanks @SnailBones for catching this! Raster DEM Worker parameters were incorrectly typed but Flow ignored it so we haven't caught this. A good example of the reason why I'm pushing for #11426 and improving type coverage.