### PR TITLE
[Flow] Type exports for data/*

### DIFF
--- a/src/data/bounds_attributes.js
+++ b/src/data/bounds_attributes.js
@@ -1,7 +1,9 @@
 // @flow
 import {createLayout} from '../util/struct_array.js';
 
-export default createLayout([
+import type {StructArrayLayout} from '../util/struct_array.js';
+
+export default (createLayout([
     {name: 'a_pos', type: 'Int16', components: 2},
     {name: 'a_texture_pos', type: 'Int16', components: 2}
-]);
+]): StructArrayLayout);

--- a/src/data/bucket/circle_attributes.js
+++ b/src/data/bucket/circle_attributes.js
@@ -1,11 +1,13 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-export const circleAttributes = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+export const circleAttributes: StructArrayLayout = createLayout([
     {name: 'a_pos', components: 2, type: 'Int16'}
 ], 4);
 
-export const circleGlobeAttributesExt = createLayout([
+export const circleGlobeAttributesExt: StructArrayLayout = createLayout([
     {name: 'a_pos_3', components: 3, type: 'Int16'},
     {name: 'a_pos_normal_3', components: 3, type: 'Int16'},
     {name: 'a_scale', components: 1, type: 'Float32'},

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -155,11 +155,11 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }
 
-    isEmpty() {
+    isEmpty(): boolean {
         return this.layoutVertexArray.length === 0;
     }
 
-    uploadPending() {
+    uploadPending(): boolean {
         return !this.uploaded || this.programConfigurations.needsUpload;
     }
 

--- a/src/data/bucket/dash_attributes.js
+++ b/src/data/bucket/dash_attributes.js
@@ -1,7 +1,9 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-const dashAttributes = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+const dashAttributes: StructArrayLayout = createLayout([
     {name: 'a_dash_to', components: 4, type: 'Uint16'}, // [x, y, width, unused]
     {name: 'a_dash_from', components: 4, type: 'Uint16'}
 ]);

--- a/src/data/bucket/fill_attributes.js
+++ b/src/data/bucket/fill_attributes.js
@@ -1,7 +1,9 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-const layout = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+const layout: StructArrayLayout = createLayout([
     {name: 'a_pos', components: 2, type: 'Int16'}
 ], 4);
 

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -140,7 +140,7 @@ class FillBucket implements Bucket {
         }
     }
 
-    isEmpty() {
+    isEmpty(): boolean {
         return this.layoutVertexArray.length === 0;
     }
 

--- a/src/data/bucket/fill_extrusion_attributes.js
+++ b/src/data/bucket/fill_extrusion_attributes.js
@@ -1,11 +1,13 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-export const fillExtrusionAttributes = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+export const fillExtrusionAttributes: StructArrayLayout = createLayout([
     {name: 'a_pos_normal_ed', components: 4, type: 'Int16'}
 ]);
 
-export const centroidAttributes = createLayout([
+export const centroidAttributes: StructArrayLayout = createLayout([
     {name: 'a_centroid_pos',  components: 2, type: 'Uint16'}
 ]);
 

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -266,11 +266,11 @@ class FillExtrusionBucket implements Bucket {
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }
 
-    isEmpty() {
+    isEmpty(): boolean {
         return this.layoutVertexArray.length === 0;
     }
 
-    uploadPending() {
+    uploadPending(): boolean {
         return !this.uploaded || this.programConfigurations.needsUpload;
     }
 

--- a/src/data/bucket/line_attributes.js
+++ b/src/data/bucket/line_attributes.js
@@ -1,7 +1,9 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-const lineLayoutAttributes = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+const lineLayoutAttributes: StructArrayLayout = createLayout([
     {name: 'a_pos_normal', components: 2, type: 'Int16'},
     {name: 'a_data', components: 4, type: 'Uint8'},
     {name: 'a_linesofar', components: 1, type: 'Float32'}

--- a/src/data/bucket/line_attributes_ext.js
+++ b/src/data/bucket/line_attributes_ext.js
@@ -1,7 +1,9 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-const lineLayoutAttributesExt = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+const lineLayoutAttributesExt: StructArrayLayout = createLayout([
     {name: 'a_packed', components: 3, type: 'Float32'}
 ]);
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -196,7 +196,7 @@ class LineBucket implements Bucket {
         }
     }
 
-    addConstantDashes(lineAtlas: LineAtlas) {
+    addConstantDashes(lineAtlas: LineAtlas): boolean {
         let hasFeatureDashes = false;
 
         for (const layer of this.layers) {
@@ -278,11 +278,11 @@ class LineBucket implements Bucket {
         }
     }
 
-    isEmpty() {
+    isEmpty(): boolean {
         return this.layoutVertexArray.length === 0;
     }
 
-    uploadPending() {
+    uploadPending(): boolean {
         return !this.uploaded || this.programConfigurations.needsUpload;
     }
 

--- a/src/data/bucket/pattern_attributes.js
+++ b/src/data/bucket/pattern_attributes.js
@@ -1,7 +1,9 @@
 // @flow
 import {createLayout} from '../../util/struct_array.js';
 
-const patternAttributes = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+const patternAttributes: StructArrayLayout = createLayout([
     // [tl.x, tl.y, br.x, br.y]
     {name: 'a_pattern_to', components: 4, type: 'Uint16'},
     {name: 'a_pattern_from', components: 4, type: 'Uint16'},

--- a/src/data/bucket/pattern_bucket_features.js
+++ b/src/data/bucket/pattern_bucket_features.js
@@ -13,7 +13,7 @@ type PatternStyleLayers =
     Array<FillStyleLayer> |
     Array<FillExtrusionStyleLayer>;
 
-export function hasPattern(type: string, layers: PatternStyleLayers, options: PopulateParameters) {
+export function hasPattern(type: string, layers: PatternStyleLayers, options: PopulateParameters): boolean {
     const patterns = options.patternDependencies;
     let hasPattern = false;
 
@@ -34,7 +34,7 @@ export function hasPattern(type: string, layers: PatternStyleLayers, options: Po
     return hasPattern;
 }
 
-export function addPatternDependencies(type: string, layers: PatternStyleLayers, patternFeature: BucketFeature, zoom: number, options: PopulateParameters) {
+export function addPatternDependencies(type: string, layers: PatternStyleLayers, patternFeature: BucketFeature, zoom: number, options: PopulateParameters): BucketFeature {
     const patterns = options.patternDependencies;
     for (const layer of layers) {
         const patternProperty = layer.paint.get(`${type}-pattern`);

--- a/src/data/bucket/symbol_attributes.js
+++ b/src/data/bucket/symbol_attributes.js
@@ -1,33 +1,34 @@
 // @flow
-
 import {createLayout} from '../../util/struct_array.js';
 
-export const symbolLayoutAttributes = createLayout([
+import type {StructArrayLayout} from '../../util/struct_array.js';
+
+export const symbolLayoutAttributes: StructArrayLayout = createLayout([
     {name: 'a_pos_offset',   components: 4, type: 'Int16'},
     {name: 'a_tex_size',     components: 4, type: 'Uint16'},
     {name: 'a_pixeloffset',  components: 4, type: 'Int16'},
     {name: 'a_z_tile_anchor', components: 4, type: 'Int16'}
 ], 4);
 
-export const dynamicLayoutAttributes = createLayout([
+export const dynamicLayoutAttributes: StructArrayLayout = createLayout([
     {name: 'a_projected_pos', components: 3, type: 'Float32'}
 ], 4);
 
-export const placementOpacityAttributes = createLayout([
+export const placementOpacityAttributes: StructArrayLayout = createLayout([
     {name: 'a_fade_opacity', components: 1, type: 'Uint32'}
 ], 4);
 
-export const collisionVertexAttributes = createLayout([
+export const collisionVertexAttributes: StructArrayLayout = createLayout([
     {name: 'a_placed', components: 2, type: 'Uint8'},
     {name: 'a_shift', components: 2, type: 'Float32'},
 ]);
 
-export const collisionVertexAttributesExt = createLayout([
+export const collisionVertexAttributesExt: StructArrayLayout = createLayout([
     {name: 'a_size_scale', components: 1, type: 'Float32'},
     {name: 'a_padding', components: 2, type: 'Float32'},
 ]);
 
-export const collisionBox = createLayout([
+export const collisionBox: StructArrayLayout = createLayout([
     // the box is centered around the anchor point
     {type: 'Int16', name: 'projectedAnchorX'},
     {type: 'Int16', name: 'projectedAnchorY'},
@@ -52,23 +53,23 @@ export const collisionBox = createLayout([
     {type: 'Uint16', name: 'bucketIndex'},
 ]);
 
-export const collisionBoxLayout = createLayout([ // used to render collision boxes for debugging purposes
+export const collisionBoxLayout: StructArrayLayout = createLayout([ // used to render collision boxes for debugging purposes
     {name: 'a_pos',             components: 3, type: 'Int16'},
     {name: 'a_anchor_pos',      components: 2, type: 'Int16'},
     {name: 'a_extrude',         components: 2, type: 'Int16'}
 ], 4);
 
-export const collisionCircleLayout = createLayout([ // used to render collision circles for debugging purposes
+export const collisionCircleLayout: StructArrayLayout = createLayout([ // used to render collision circles for debugging purposes
     {name: 'a_pos_2f',     components: 2, type: 'Float32'},
     {name: 'a_radius',     components: 1, type: 'Float32'},
     {name: 'a_flags',      components: 2, type: 'Int16'}
 ], 4);
 
-export const quadTriangle = createLayout([
+export const quadTriangle: StructArrayLayout = createLayout([
     {name: 'triangle', components: 3, type: 'Uint16'},
 ]);
 
-export const placement = createLayout([
+export const placement: StructArrayLayout = createLayout([
     {type: 'Int16', name: 'projectedAnchorX'},
     {type: 'Int16', name: 'projectedAnchorY'},
     {type: 'Int16', name: 'projectedAnchorZ'},
@@ -92,7 +93,7 @@ export const placement = createLayout([
     {type: 'Uint8', name: 'flipState'}
 ]);
 
-export const symbolInstance = createLayout([
+export const symbolInstance: StructArrayLayout = createLayout([
     {type: 'Int16', name: 'projectedAnchorX'},
     {type: 'Int16', name: 'projectedAnchorY'},
     {type: 'Int16', name: 'projectedAnchorZ'},
@@ -124,11 +125,11 @@ export const symbolInstance = createLayout([
     {type: 'Float32', name: 'collisionCircleDiameter'},
 ]);
 
-export const glyphOffset = createLayout([
+export const glyphOffset: StructArrayLayout = createLayout([
     {type: 'Float32', name: 'offsetX'}
 ]);
 
-export const lineVertex = createLayout([
+export const lineVertex: StructArrayLayout = createLayout([
     {type: 'Int16', name: 'x'},
     {type: 'Int16', name: 'y'},
     {type: 'Int16', name: 'tileUnitDistanceFromAnchor'}

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -192,7 +192,7 @@ export class SymbolBuffers {
         this.placedSymbolArray = new PlacedSymbolArray();
     }
 
-    isEmpty() {
+    isEmpty(): boolean {
         return this.layoutVertexArray.length === 0 &&
             this.indexArray.length === 0 &&
             this.dynamicLayoutVertexArray.length === 0 &&
@@ -564,13 +564,13 @@ class SymbolBucket implements Bucket {
         this.icon.programConfigurations.updatePaintArrays(states, vtLayer, this.layers, availableImages, imagePositions);
     }
 
-    isEmpty() {
+    isEmpty(): boolean {
         // When the bucket encounters only rtl-text but the plugin isn't loaded, no symbol instances will be created.
         // In order for the bucket to be serialized, and not discarded as an empty bucket both checks are necessary.
         return this.symbolInstances.length === 0 && !this.hasRTLText;
     }
 
-    uploadPending() {
+    uploadPending(): boolean {
         return !this.uploaded || this.text.programConfigurations.needsUpload || this.icon.programConfigurations.needsUpload;
     }
 
@@ -598,7 +598,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    addToLineVertexArray(anchor: Anchor, line: any) {
+    addToLineVertexArray(anchor: Anchor, line: any): {| lineLength: number, lineStartIndex: number |} {
         const lineStartIndex = this.lineVertexArray.length;
         const segment = anchor.segment;
         if (segment !== undefined) {
@@ -778,7 +778,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    getSymbolInstanceTextSize(textSize: any, instance: SymbolInstance, zoom: number, boxIndex: number) {
+    getSymbolInstanceTextSize(textSize: any, instance: SymbolInstance, zoom: number, boxIndex: number): number {
         const symbolIndex = instance.rightJustifiedTextSymbolIndex >= 0 ?
             instance.rightJustifiedTextSymbolIndex : instance.centerJustifiedTextSymbolIndex >= 0 ?
                 instance.centerJustifiedTextSymbolIndex : instance.leftJustifiedTextSymbolIndex >= 0 ?
@@ -791,7 +791,7 @@ class SymbolBucket implements Bucket {
         return this.tilePixelRatio * featureSize;
     }
 
-    getSymbolInstanceIconSize(iconSize: any, zoom: number, index: number) {
+    getSymbolInstanceIconSize(iconSize: any, zoom: number, index: number): number {
         const symbol: any = this.icon.placedSymbolArray.get(index);
         const featureSize = symbolSize.evaluateSizeForFeature(this.iconSizeData, iconSize, symbol);
 
@@ -906,23 +906,23 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    hasTextData() {
+    hasTextData(): boolean {
         return this.text.segments.get().length > 0;
     }
 
-    hasIconData() {
+    hasIconData(): boolean {
         return this.icon.segments.get().length > 0;
     }
 
-    hasDebugData() {
+    hasDebugData(): CollisionBuffers {
         return this.textCollisionBox && this.iconCollisionBox;
     }
 
-    hasTextCollisionBoxData() {
+    hasTextCollisionBoxData(): boolean {
         return this.hasDebugData() && this.textCollisionBox.segments.get().length > 0;
     }
 
-    hasIconCollisionBoxData() {
+    hasIconCollisionBoxData(): boolean {
         return this.hasDebugData() && this.iconCollisionBox.segments.get().length > 0;
     }
 
@@ -936,7 +936,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    getSortedSymbolIndexes(angle: number) {
+    getSortedSymbolIndexes(angle: number): Array<number> {
         if (this.sortedAngle === angle && this.symbolInstanceIndexes !== undefined) {
             return this.symbolInstanceIndexes;
         }

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -107,6 +107,11 @@ export type SortKeyRange = {
     symbolInstanceEnd: number
 };
 
+type LineVertexRange = {|
+    lineLength: number,
+    lineStartIndex: number
+|};
+
 // Opacity arrays are frequently updated but don't contain a lot of information, so we pack them
 // tight. Each Uint32 is actually four duplicate Uint8s for the four corners of a glyph
 // 7 bits are for the current opacity, and the lowest bit is the target opacity
@@ -598,7 +603,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    addToLineVertexArray(anchor: Anchor, line: any): {| lineLength: number, lineStartIndex: number |} {
+    addToLineVertexArray(anchor: Anchor, line: any): LineVertexRange {
         const lineStartIndex = this.lineVertexArray.length;
         const segment = anchor.segment;
         if (segment !== undefined) {

--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -38,7 +38,7 @@ export default class DEMData {
 
     // RGBAImage data has uniform 1px padding on all sides: square tile edge size defines stride
     // and dim is calculated as stride - 2.
-    constructor(uid: number, data: ImageData, encoding: DEMEncoding, borderReady: boolean = false, buildQuadTree: boolean = false) {
+    constructor(uid: number, data: ImageData, encoding: DEMEncoding, borderReady: boolean = false, buildQuadTree: boolean = false): void {
         this.uid = uid;
         if (data.height !== data.width) throw new RangeError('DEM tiles must be square');
         if (encoding && encoding !== "mapbox" && encoding !== "terrarium") return warnOnce(
@@ -80,7 +80,7 @@ export default class DEMData {
         this._tree = new DemMinMaxQuadTree(this);
     }
 
-    get(x: number, y: number, clampToEdge: boolean = false) {
+    get(x: number, y: number, clampToEdge: boolean = false): number {
         if (clampToEdge) {
             x = clamp(x, -1, this.dim);
             y = clamp(y, -1, this.dim);
@@ -98,18 +98,18 @@ export default class DEMData {
         return unpackVectors[this.encoding];
     }
 
-    _idx(x: number, y: number) {
+    _idx(x: number, y: number): number {
         if (x < -1 || x >= this.dim + 1 ||  y < -1 || y >= this.dim + 1) throw new RangeError('out of range source coordinates for DEM data');
         return (y + 1) * this.stride + (x + 1);
     }
 
-    _unpackMapbox(r: number, g: number, b: number) {
+    _unpackMapbox(r: number, g: number, b: number): number {
         // unpacking formula for mapbox.terrain-rgb:
         // https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb
         return ((r * 256 * 256 + g * 256.0 + b) / 10.0 - 10000.0);
     }
 
-    _unpackTerrarium(r: number, g: number, b: number) {
+    _unpackTerrarium(r: number, g: number, b: number): number {
         // unpacking formula for mapzen terrarium:
         // https://aws.amazon.com/public-datasets/terrain/
         return ((r * 256 + g + b / 256) - 32768.0);
@@ -127,7 +127,7 @@ export default class DEMData {
         return color;
     }
 
-    getPixels() {
+    getPixels(): RGBAImage {
         return new RGBAImage({width: this.stride, height: this.stride}, this.pixels);
     }
 

--- a/src/data/dem_tree.js
+++ b/src/data/dem_tree.js
@@ -307,7 +307,7 @@ export default class DemMinMaxQuadTree {
         return null;
     }
 
-    _addNode(min: number, max: number, leaf: number) {
+    _addNode(min: number, max: number, leaf: number): number {
         this.minimums.push(min);
         this.maximums.push(max);
         this.leaves.push(leaf);

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -41,6 +41,8 @@ type QueryParameters = {
     }
 }
 
+type QueryResult = {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>};
+
 type FeatureIndices = {
     bucketIndex: number,
     sourceLayerIndex: number,
@@ -114,7 +116,7 @@ class FeatureIndex {
     }
 
     // Finds non-symbol features in this tile at a particular position.
-    query(args: QueryParameters, styleLayers: {[_: string]: StyleLayer}, serializedLayers: {[_: string]: Object}, sourceFeatureState: SourceFeatureState): {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
+    query(args: QueryParameters, styleLayers: {[_: string]: StyleLayer}, serializedLayers: {[_: string]: Object}, sourceFeatureState: SourceFeatureState): QueryResult {
         this.loadVTLayers();
         const params = args.params || {},
             filter = featureFilter(params.filter);
@@ -167,7 +169,7 @@ class FeatureIndex {
     }
 
     loadMatchingFeature(
-        result: {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>},
+        result: QueryResult,
         featureIndexData: FeatureIndices,
         filter: FeatureFilter,
         filterLayerIDs: Array<string>,
@@ -244,7 +246,7 @@ class FeatureIndex {
                          filterSpec: FilterSpecification,
                          filterLayerIDs: Array<string>,
                          availableImages: Array<string>,
-                         styleLayers: {[_: string]: StyleLayer}) {
+                         styleLayers: {[_: string]: StyleLayer}): QueryResult {
         const result = {};
         this.loadVTLayers();
 
@@ -286,7 +288,7 @@ class FeatureIndex {
         return feature;
     }
 
-    hasLayer(id: string) {
+    hasLayer(id: string): boolean {
         for (const layerIDs of this.bucketLayerIDs) {
             for (const layerID of layerIDs) {
                 if (id === layerID) return true;

--- a/src/data/pos_attributes.js
+++ b/src/data/pos_attributes.js
@@ -1,6 +1,8 @@
 // @flow
 import {createLayout} from '../util/struct_array.js';
 
-export default createLayout([
+import type {StructArrayLayout} from '../util/struct_array.js';
+
+export default (createLayout([
     {name: 'a_pos', type: 'Int16', components: 2}
-]);
+]): StructArrayLayout);

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -628,7 +628,7 @@ export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
         }
     }
 
-    get(layerId: string) {
+    get(layerId: string): ProgramConfiguration {
         return this.programConfigurations[layerId];
     }
 

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -40,7 +40,7 @@ class SegmentVector {
         return segment;
     }
 
-    get() {
+    get(): Array<Segment> {
         return this.segments;
     }
 


### PR DESCRIPTION
A part of #11426. Adds missing export types for files in `src/data/*` apart from `array_types.js` which is in #11470.