### PR TITLE
Remove unused code in terrain.js and fix lint config

### DIFF
--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -54,7 +54,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     for (const tileID of tileIDs) {
         const unwrappedTileID = tileID.toUnwrapped();
         const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(unwrappedTileID);
-        painter.prepareDrawTile(tileID);
+        painter.prepareDrawTile();
 
         const tile = sourceCache ? sourceCache.getTile(tileID) :
             backgroundTiles ? backgroundTiles[tileID.key] : new Tile(tileID, tileSize, transform.zoom, painter);

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -80,7 +80,7 @@ function drawFillTiles(painter, sourceCache, layer, coords, depthMode, colorMode
 
         const bucket: ?FillBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
-        painter.prepareDrawTile(coord);
+        painter.prepareDrawTile();
 
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const program = painter.useProgram(programName, programConfiguration);

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -54,7 +54,7 @@ function renderHillshade(painter, coord, tile, layer, depthMode, stencilMode, co
     const gl = context.gl;
     const fbo = tile.fbo;
     if (!fbo) return;
-    painter.prepareDrawTile(coord);
+    painter.prepareDrawTile();
 
     const program = painter.useProgram('hillshade');
 

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -56,7 +56,7 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
 
         const bucket: ?LineBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
-        painter.prepareDrawTile(coord);
+        painter.prepareDrawTile();
 
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const program = painter.useProgram(programId, programConfiguration, ((definesValues: any): DynamicDefinesType[]));

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -58,7 +58,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
 
         const parentTile = sourceCache.findLoadedParent(coord, 0);
         const fade = rasterFade(tile, parentTile, sourceCache, painter.transform, rasterFadeDuration);
-        if (painter.terrain) painter.terrain.prepareDrawTile(coord);
+        if (painter.terrain) painter.terrain.prepareDrawTile();
 
         let parentScaleBy, parentTL;
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -890,9 +890,9 @@ class Painter {
         }
     }
 
-    prepareDrawTile(tileID: OverscaledTileID) {
+    prepareDrawTile() {
         if (this.terrain) {
-            this.terrain.prepareDrawTile(tileID);
+            this.terrain.prepareDrawTile();
         }
     }
 

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1419,7 +1419,7 @@ export class Terrain extends Elevation {
     /*
      * Bookkeeping if something gets rendered to the tile.
      */
-    prepareDrawTile(coord: OverscaledTileID) { // eslint-disable-line no-unused-vars
+    prepareDrawTile() {
         this.renderedToTile = true;
     }
 

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -118,8 +118,7 @@ class ProxySourceCache extends SourceCache {
     }
 
     // Override for transient nature of cover here: don't cache and retain.
-    /* eslint-disable no-unused-vars */
-    update(transform: Transform, tileSize?: number, updateForTerrain?: boolean) {
+    update(transform: Transform, tileSize?: number, updateForTerrain?: boolean) { // eslint-disable-line no-unused-vars
         if (transform.freezeTileCoverage) { return; }
         this.transform = transform;
         const idealTileIDs = transform.coveringTiles({
@@ -598,7 +597,6 @@ export class Terrain extends Elevation {
 
         const tr = this.painter.transform;
         const projection = tr.projection;
-        const tileTransform = projection.createTileTransform(tr, tr.worldSize);
 
         const id = tile.tileID.canonical;
         uniforms['u_tile_tl_up'] = (projection.upVector(id, 0, 0): any);
@@ -1104,7 +1102,6 @@ export class Terrain extends Elevation {
         // more need: in such case, if there is no overlap, stencilling is disabled.
         if (proxiedCoords.length <= 1) { this._overlapStencilType = false; return; }
 
-        const fb = fbo.fb;
         let stencilRange;
         if (layer.isTileClipped()) {
             stencilRange = proxiedCoords.length;
@@ -1422,7 +1419,7 @@ export class Terrain extends Elevation {
     /*
      * Bookkeeping if something gets rendered to the tile.
      */
-    prepareDrawTile(coord: OverscaledTileID) {
+    prepareDrawTile(coord: OverscaledTileID) { // eslint-disable-line no-unused-vars
         this.renderedToTile = true;
     }
 


### PR DESCRIPTION
`terrain.js` had a `/* eslint-disable no-unused-vars */` line which was probably intended to disable the rule in one specific line, but instead disabled it for the rest of the file (cc @astojilj). Due to this, we failed to notice some unused code — in particular, `projection.createTileTransform(...)` inside `setupElevationDraw` which served no purpose, but in case of enabled Globe view caused redundant and expensive globe matrix calculation. So this PR should speed up the globe view a little.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
