### PR TITLE
Use named exports for DOM functions for better tree shaking

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 import {bindAll} from '../../util/util.js';
 import config from '../../util/config.js';
 

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 
 import {bindAll, warnOnce} from '../../util/util.js';
 import window from '../../util/window.js';

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Event, Evented} from '../../util/evented.js';
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 import window from '../../util/window.js';
 import {extend, bindAll, warnOnce} from '../../util/util.js';
 import assert from 'assert';

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 
 import {bindAll} from '../../util/util.js';
 

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 import {extend, bindAll} from '../../util/util.js';
 import {MouseRotateHandler, MousePitchHandler} from '../handler/mouse.js';
 import window from '../../util/window.js';

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 import {extend, bindAll} from '../../util/util.js';
 
 import type Map from '../map.js';

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -2,7 +2,7 @@
 
 import {Event} from '../util/evented.js';
 
-import DOM from '../util/dom.js';
+import * as DOM from '../util/dom.js';
 import Point from '@mapbox/point-geometry';
 import {extend} from '../util/util.js';
 

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 
 import {Event} from '../../util/evented.js';
 

--- a/src/ui/handler/mouse.js
+++ b/src/ui/handler/mouse.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 import type Point from '@mapbox/point-geometry';
 
 const LEFT_BUTTON = 0;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -1,7 +1,7 @@
 // @flow
 
 import assert from 'assert';
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 
 import {ease as _ease, bindAll, bezier} from '../../util/util.js';
 import browser from '../../util/browser.js';

--- a/src/ui/handler/touch_pan.js
+++ b/src/ui/handler/touch_pan.js
@@ -4,7 +4,7 @@ import Point from '@mapbox/point-geometry';
 import type Map from '../map.js';
 import {indexTouches} from './handler_util.js';
 import {bindAll} from '../../util/util.js';
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 
 export default class TouchPanHandler {
 

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Point from '@mapbox/point-geometry';
-import DOM from '../../util/dom.js';
+import * as DOM from '../../util/dom.js';
 import type Map from '../map.js';
 
 class TwoTouchHandler {

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Event} from '../util/evented.js';
-import DOM from '../util/dom.js';
+import * as DOM from '../util/dom.js';
 import type Map from './map.js';
 import HandlerInertia from './handler_inertia.js';
 import {MapEventHandler, BlockableMapEventHandler} from './handler/map_event.js';

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -4,7 +4,7 @@ import {version} from '../../package.json';
 import {asyncAll, extend, bindAll, warnOnce, uniqueId} from '../util/util.js';
 import browser from '../util/browser.js';
 import window from '../util/window.js';
-import DOM from '../util/dom.js';
+import * as DOM from '../util/dom.js';
 import {getImage, getJSON, ResourceType} from '../util/ajax.js';
 import {RequestManager, getMapSessionAPI, postMapLoadEvent, AUTH_ERR_MSG, storeAuthState, removeAuthState} from '../util/mapbox.js';
 import Style from '../style/style.js';

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -1,6 +1,6 @@
 // @flow
 
-import DOM from '../util/dom.js';
+import * as DOM from '../util/dom.js';
 import window from '../util/window.js';
 import LngLat from '../geo/lng_lat.js';
 import Point from '@mapbox/point-geometry';

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -3,7 +3,7 @@
 import {extend, bindAll} from '../util/util.js';
 import {Event, Evented} from '../util/evented.js';
 import {MapMouseEvent} from '../ui/events.js';
-import DOM from '../util/dom.js';
+import * as DOM from '../util/dom.js';
 import LngLat from '../geo/lng_lat.js';
 import Point from '@mapbox/point-geometry';
 import window from '../util/window.js';

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -5,62 +5,59 @@ import Point from '@mapbox/point-geometry';
 import window from './window.js';
 import assert from 'assert';
 
-const DOM = {};
-export default DOM;
-
-DOM.create = function (tagName: string, className: ?string, container?: HTMLElement) {
+export function create(tagName: string, className: ?string, container?: HTMLElement) {
     const el = window.document.createElement(tagName);
     if (className !== undefined) el.className = className;
     if (container) container.appendChild(el);
     return el;
-};
+}
 
-DOM.createSVG = function (tagName: string, attributes: {[string]: string | number}, container?: HTMLElement) {
+export function createSVG(tagName: string, attributes: {[string]: string | number}, container?: HTMLElement) {
     const el = window.document.createElementNS('http://www.w3.org/2000/svg', tagName);
     for (const name of Object.keys(attributes)) {
         el.setAttributeNS(null, name, attributes[name]);
     }
     if (container) container.appendChild(el);
     return el;
-};
+}
 
 const docStyle = window.document && window.document.documentElement.style;
 const selectProp = docStyle && docStyle.userSelect !== undefined ? 'userSelect' : 'WebkitUserSelect';
 let userSelect;
 
-DOM.disableDrag = function () {
+export function disableDrag() {
     if (docStyle && selectProp) {
         userSelect = docStyle[selectProp];
         docStyle[selectProp] = 'none';
     }
-};
+}
 
-DOM.enableDrag = function () {
+export function enableDrag() {
     if (docStyle && selectProp) {
         docStyle[selectProp] = userSelect;
     }
-};
+}
 
 // Suppress the next click, but only if it's immediate.
-const suppressClick: MouseEventListener = function (e) {
+function suppressClickListener(e) {
     e.preventDefault();
     e.stopPropagation();
-    window.removeEventListener('click', suppressClick, true);
-};
+    window.removeEventListener('click', suppressClickListener, true);
+}
 
-DOM.suppressClick = function() {
-    window.addEventListener('click', suppressClick, true);
+export function suppressClick() {
+    window.addEventListener('click', suppressClickListener, true);
     window.setTimeout(() => {
-        window.removeEventListener('click', suppressClick, true);
+        window.removeEventListener('click', suppressClickListener, true);
     }, 0);
-};
+}
 
-DOM.mousePos = function (el: HTMLElement, e: MouseEvent | WheelEvent) {
+export function mousePos(el: HTMLElement, e: MouseEvent | WheelEvent) {
     const rect = el.getBoundingClientRect();
     return getScaledPoint(el, rect, e);
-};
+}
 
-DOM.touchPos = function (el: HTMLElement, touches: TouchList) {
+export function touchPos(el: HTMLElement, touches: TouchList) {
     const rect = el.getBoundingClientRect(),
         points = [];
 
@@ -68,9 +65,9 @@ DOM.touchPos = function (el: HTMLElement, touches: TouchList) {
         points.push(getScaledPoint(el, rect, touches[i]));
     }
     return points;
-};
+}
 
-DOM.mouseButton = function (e: MouseEvent) {
+export function mouseButton(e: MouseEvent) {
     assert(e.type === 'mousedown' || e.type === 'mouseup');
     if (typeof window.InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey &&
         window.navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
@@ -80,7 +77,7 @@ DOM.mouseButton = function (e: MouseEvent) {
         return 0;
     }
     return e.button;
-};
+}
 
 function getScaledPoint(el: HTMLElement, rect: ClientRect, e: MouseEvent | WheelEvent | Touch) {
     // Until we get support for pointer events (https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent)

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -1,7 +1,7 @@
 import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t, clickTolerance) {

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -1,7 +1,7 @@
 import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t) {

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -1,7 +1,7 @@
 import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t, clickTolerance, dragPan) {

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -2,7 +2,7 @@ import {test} from '../../../util/test.js';
 import {extend} from '../../../../src/util/util.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 import browser from '../../../../src/util/browser.js';
 

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -1,6 +1,6 @@
 import {test} from '../../../util/test.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import window from '../../../../src/util/window.js';
 import simulate from '../../../util/simulate_interaction.js';
 import {extend} from '../../../../src/util/util.js';

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -1,7 +1,7 @@
 import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t) {

--- a/test/unit/ui/handler/mouse_rotate.test.js
+++ b/test/unit/ui/handler/mouse_rotate.test.js
@@ -2,7 +2,7 @@ import {test} from '../../../util/test.js';
 import {extend} from '../../../../src/util/util.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 import browser from '../../../../src/util/browser.js';
 

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -2,7 +2,7 @@ import {test} from '../../../util/test.js';
 import browser from '../../../../src/util/browser.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 import {equalWithPrecision} from '../../../util/index.js';
 import sinon from 'sinon';

--- a/test/unit/ui/handler/touch_pan.test.js
+++ b/test/unit/ui/handler/touch_pan.test.js
@@ -1,7 +1,7 @@
 import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMapWithCooperativeGestures(t) {

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -2,7 +2,7 @@ import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
 import Marker from '../../../../src/ui/marker.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t) {

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -2,7 +2,7 @@ import {test} from '../../../util/test.js';
 import browser from '../../../../src/util/browser.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t) {

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -1,7 +1,7 @@
 import {test} from '../../../util/test.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 import browser from '../../../../src/util/browser.js';
 

--- a/test/unit/ui/map/isZooming.test.js
+++ b/test/unit/ui/map/isZooming.test.js
@@ -2,7 +2,7 @@ import {test} from '../../../util/test.js';
 import browser from '../../../../src/util/browser.js';
 import window from '../../../../src/util/window.js';
 import Map from '../../../../src/ui/map.js';
-import DOM from '../../../../src/util/dom.js';
+import * as DOM from '../../../../src/util/dom.js';
 import simulate from '../../../util/simulate_interaction.js';
 
 function createMap(t) {


### PR DESCRIPTION
Save a few bytes for the bundle by using named exports for DOM methods. It's also cleaner this way.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
