### PR TITLE
Fix fallback conditional for filter validation

### DIFF
--- a/src/style-spec/validate/validate_expression.js
+++ b/src/style-spec/validate/validate_expression.js
@@ -52,8 +52,11 @@ export function disallowedFilterParameters(e: Expression, options: any): Array<V
         'pitch',
         'distance-from-center'
     ]);
-    for (const param of options.valueSpec.expression.parameters) {
-        disallowedParameters.delete(param);
+
+    if (options.valueSpec && options.valueSpec.expression) {
+        for (const param of options.valueSpec.expression.parameters) {
+            disallowedParameters.delete(param);
+        }
     }
 
     if (disallowedParameters.size === 0) {

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -13,7 +13,7 @@ export default function validateFilter(options) {
         return validateExpression(extend({}, options, {
             expressionContext: 'filter',
             // We default to a layerType of `fill` because that points to a non-dynamic filter definition within the style-spec.
-            valueSpec: options.styleSpec[`filter_${layerType || 'fill'}`]
+            valueSpec: options.styleSpec[`filter_${layerType}`] || options.styleSpec[`filter_fill`]
         }));
     } else {
         return validateNonExpressionFilter(options);

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -13,7 +13,7 @@ export default function validateFilter(options) {
         return validateExpression(extend({}, options, {
             expressionContext: 'filter',
             // We default to a layerType of `fill` because that points to a non-dynamic filter definition within the style-spec.
-            valueSpec: options.styleSpec[`filter_${layerType}`] || options.styleSpec[`filter_fill`]
+            valueSpec: options.styleSpec[`filter_${layerType || 'fill'}`]
         }));
     } else {
         return validateNonExpressionFilter(options);

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -1,5 +1,6 @@
 import {test} from '../../util/test.js';
 import {createPropertyExpression} from '../../../src/style-spec/expression/index.js';
+import validateExpression from '../../../src/style-spec/validate/validate_expression.js';
 import definitions from '../../../src/style-spec/expression/definitions/index.js';
 import v8 from '../../../src/style-spec/reference/v8.json';
 
@@ -34,6 +35,20 @@ test('createPropertyExpression', (t) => {
         t.equal(result, 'error');
         t.equal(value.length, 1);
         t.equal(value[0].message, '"interpolate" expressions cannot be used with this property');
+        t.end();
+    });
+
+    t.end();
+});
+
+test('validateExpression', (t) => {
+    //see https://github.com/mapbox/mapbox-gl-js/issues/11457
+    test('ensure lack of valueSpec does not cause uncaught error', (t) => {
+        const result = validateExpression({
+            value: ['get', 'x'],
+            expressionContext: 'filter'
+        });
+        t.equal(result.length, 0);
         t.end();
     });
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/11457 by fixing the conditional statement that allows for a fallback statement if `filter_${layerType}` is undefined
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a bug that prevented some filters from being validated properly</changelog>`
