### PR TITLE
[Flow] Add missing types to LngLat & LngLatBounds

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -54,7 +54,7 @@ class LngLat {
      * const wrapped = ll.wrap();
      * console.log(wrapped.lng); // = -73.9749
      */
-    wrap() {
+    wrap(): LngLat {
         return new LngLat(wrap(this.lng, -180, 180), this.lat);
     }
 
@@ -66,7 +66,7 @@ class LngLat {
      * const ll = new mapboxgl.LngLat(-73.9749, 40.7736);
      * ll.toArray(); // = [-73.9749, 40.7736]
      */
-    toArray() {
+    toArray(): [number, number] {
         return [this.lng, this.lat];
     }
 
@@ -78,7 +78,7 @@ class LngLat {
      * const ll = new mapboxgl.LngLat(-73.9749, 40.7736);
      * ll.toString(); // = "LngLat(-73.9749, 40.7736)"
      */
-    toString() {
+    toString(): string {
         return `LngLat(${this.lng}, ${this.lat})`;
     }
 
@@ -93,7 +93,7 @@ class LngLat {
      * const losAngeles = new mapboxgl.LngLat(-118.2437, 34.0522);
      * newYork.distanceTo(losAngeles); // = 3935751.690893987, "true distance" using a non-spherical approximation is ~3966km
      */
-    distanceTo(lngLat: LngLat) {
+    distanceTo(lngLat: LngLat): number {
         const rad = Math.PI / 180;
         const lat1 = this.lat * rad;
         const lat2 = lngLat.lat * rad;
@@ -112,7 +112,7 @@ class LngLat {
      * const ll = new mapboxgl.LngLat(-73.9749, 40.7736);
      * ll.toBounds(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
      */
-    toBounds(radius?: number = 0) {
+    toBounds(radius?: number = 0): LngLatBounds {
         const earthCircumferenceInMetersAtEquator = 40075017;
         const latAccuracy = 360 * radius / earthCircumferenceInMetersAtEquator,
             lngAccuracy = latAccuracy / Math.cos((Math.PI / 180) * this.lat);

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -49,7 +49,7 @@ class LngLatBounds {
      * const llb = new mapboxgl.LngLatBounds(sw, ne);
      * llb.setNorthEast([-73.9397, 42.8002]);
      */
-    setNorthEast(ne: LngLatLike) {
+    setNorthEast(ne: LngLatLike): this {
         this._ne = ne instanceof LngLat ? new LngLat(ne.lng, ne.lat) : LngLat.convert(ne);
         return this;
     }
@@ -65,7 +65,7 @@ class LngLatBounds {
      * const llb = new mapboxgl.LngLatBounds(sw, ne);
      * llb.setSouthWest([-73.9876, 40.2661]);
      */
-    setSouthWest(sw: LngLatLike) {
+    setSouthWest(sw: LngLatLike): this {
         this._sw = sw instanceof LngLat ? new LngLat(sw.lng, sw.lat) : LngLat.convert(sw);
         return this;
     }
@@ -81,7 +81,7 @@ class LngLatBounds {
      * const llb = new mapboxgl.LngLatBounds(sw, ne);
      * llb.extend([-72.9876, 42.2661]);
      */
-    extend(obj: LngLatLike | LngLatBoundsLike) {
+    extend(obj: LngLatLike | LngLatBoundsLike): this {
         const sw = this._sw,
             ne = this._ne;
         let sw2, ne2;
@@ -224,7 +224,7 @@ class LngLatBounds {
      * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toArray(); // = [[-73.9876, 40.7661], [-73.9397, 40.8002]]
      */
-    toArray() {
+    toArray(): [[number, number], [number, number]] {
         return [this._sw.toArray(), this._ne.toArray()];
     }
 
@@ -237,7 +237,7 @@ class LngLatBounds {
      * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toString(); // = "LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))"
      */
-    toString() {
+    toString(): string {
         return `LngLatBounds(${this._sw.toString()}, ${this._ne.toString()})`;
     }
 
@@ -252,7 +252,7 @@ class LngLatBounds {
      * llb.setSouthWest([-73.9397, 40.8002]);
      * llb.isEmpty(); // false
      */
-    isEmpty() {
+    isEmpty(): boolean {
         return !(this._sw && this._ne);
     }
 
@@ -271,7 +271,7 @@ class LngLatBounds {
     *
     * console.log(llb.contains(ll)); // = true
     */
-    contains(lnglat: LngLatLike) {
+    contains(lnglat: LngLatLike): boolean {
         const {lng, lat} = LngLat.convert(lnglat);
 
         const containsLatitude = this._sw.lat <= lat && lat <= this._ne.lat;


### PR DESCRIPTION
A part of #11426. Adds missing export types to `LngLat` and `LngLatBounds` classes.