### PR TITLE
[Flow] Improve types in `vectortile_to_geojson.js`

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -228,7 +228,7 @@ class FeatureIndex {
             }
 
             const geojsonFeature = new GeoJSONFeature(feature, this.z, this.x, this.y, id);
-            (geojsonFeature: any).layer = serializedLayer;
+            geojsonFeature.layer = serializedLayer;
             let layerResult = result[layerID];
             if (layerResult === undefined) {
                 layerResult = result[layerID] = [];

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -442,7 +442,7 @@ class Tile {
             }
             const id = featureIndex.getId(feature, sourceLayer);
             const geojsonFeature = new GeoJSONFeature(feature, z, x, y, id);
-            (geojsonFeature: any).tile = coord;
+            geojsonFeature.tile = coord;
             result.push(geojsonFeature);
         }
     }

--- a/src/util/vectortile_to_geojson.js
+++ b/src/util/vectortile_to_geojson.js
@@ -2,23 +2,25 @@
 import type {GeoJSONGeometry, GeoJSONFeature} from '@mapbox/geojson-types';
 
 // we augment GeoJSON with custom properties in query*Features results
-type QueryFeature = GeoJSONFeature & {
-    tile?: mixed,
-    layer?: mixed
-};
+type QueryFeature = GeoJSONFeature & {[key: string]: mixed};
+
+const customProps = ['tile', 'layer', 'source', 'sourceLayer', 'state'];
 
 class Feature {
     type: 'Feature';
     _geometry: ?GeoJSONGeometry;
     properties: {};
     id: number | string | void;
-    layer: ?mixed;
-    tile: ?mixed;
+    _vectorTileFeature: VectorTileFeature;
     _x: number;
     _y: number;
     _z: number;
 
-    _vectorTileFeature: VectorTileFeature;
+    tile: ?mixed;
+    layer: ?mixed;
+    source: ?mixed;
+    sourceLayer: ?mixed;
+    state: ?mixed;
 
     constructor(vectorTileFeature: VectorTileFeature, z: number, x: number, y: number, id: string | number | void) {
         this.type = 'Feature';
@@ -50,8 +52,10 @@ class Feature {
             properties: this.properties
         };
         if (this.id !== undefined) json.id = this.id;
-        if (this.tile !== undefined) json.tile = this.tile;
-        if (this.layer !== undefined) json.layer = this.layer;
+        for (const key of customProps) {
+            // Flow doesn't support indexed access for classes https://github.com/facebook/flow/issues/1323
+            if ((this: any)[key] !== undefined) json[key] = (this: any)[key];
+        }
         return json;
     }
 }


### PR DESCRIPTION
A part of #11426. Improves types in `vectortile_to_geojson.js`, getting rid of some `any` and make it ready for type-first mode. Also makes the list of properties we augment queried GeoJSON results with explicit so that we can type-check it, making the code less fragile.