### PR TITLE
[Flow] Add missing types for controls & hash

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -4,7 +4,7 @@ import * as DOM from '../../util/dom.js';
 import {bindAll} from '../../util/util.js';
 import config from '../../util/config.js';
 
-import type Map from '../map.js';
+import type Map, {ControlPosition} from '../map.js';
 
 type Options = {
     compact?: boolean,
@@ -47,11 +47,11 @@ class AttributionControl {
         ], this);
     }
 
-    getDefaultPosition() {
+    getDefaultPosition(): ControlPosition {
         return 'bottom-right';
     }
 
-    onAdd(map: Map) {
+    onAdd(map: Map): HTMLElement {
         const compact = this.options && this.options.compact;
 
         this._map = map;

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -52,7 +52,7 @@ class FullscreenControl {
         }
     }
 
-    onAdd(map: Map) {
+    onAdd(map: Map): HTMLElement {
         this._map = map;
         if (!this._container) this._container = this._map.getContainer();
         this._controlContainer = DOM.create('div', `mapboxgl-ctrl mapboxgl-ctrl-group`);
@@ -71,7 +71,7 @@ class FullscreenControl {
         window.document.removeEventListener(this._fullscreenchange, this._changeIcon);
     }
 
-    _checkFullscreenSupport() {
+    _checkFullscreenSupport(): boolean {
         return !!(
             window.document.fullscreenEnabled ||
             (window.document: any).webkitFullscreenEnabled
@@ -93,11 +93,11 @@ class FullscreenControl {
         if (this._fullscreenButton.firstElementChild) this._fullscreenButton.firstElementChild.setAttribute('title', title);
     }
 
-    _getTitle() {
+    _getTitle(): string {
         return this._map._getUIString(this._isFullscreen() ? 'FullscreenControl.Exit' : 'FullscreenControl.Enter');
     }
 
-    _isFullscreen() {
+    _isFullscreen(): boolean {
         return this._fullscreen;
     }
 

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -1,10 +1,9 @@
 // @flow
 
 import * as DOM from '../../util/dom.js';
-
 import {bindAll} from '../../util/util.js';
 
-import type Map from '../map.js';
+import type Map, {ControlPosition} from '../map.js';
 
 /**
  * A `LogoControl` is a control that adds the Mapbox watermark
@@ -21,11 +20,10 @@ class LogoControl {
     _container: HTMLElement;
 
     constructor() {
-        bindAll(['_updateLogo'], this);
-        bindAll(['_updateCompact'], this);
+        bindAll(['_updateLogo', '_updateCompact'], this);
     }
 
-    onAdd(map: Map) {
+    onAdd(map: Map): HTMLElement {
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl');
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
@@ -52,7 +50,7 @@ class LogoControl {
         this._map.off('resize', this._updateCompact);
     }
 
-    getDefaultPosition() {
+    getDefaultPosition(): ControlPosition {
         return 'bottom-left';
     }
 
@@ -62,7 +60,7 @@ class LogoControl {
         }
     }
 
-    _logoRequired() {
+    _logoRequired(): boolean {
         if (!this._map.style) return true;
         const sourceCaches = this._map.style._sourceCaches;
         if (Object.entries(sourceCaches).length === 0) return true;

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -112,7 +112,7 @@ class NavigationControl {
         });
     }
 
-    onAdd(map: Map) {
+    onAdd(map: Map): HTMLElement {
         this._map = map;
         if (this.options.showZoom) {
             this._setButtonTitle(this._zoomInButton, 'ZoomIn');
@@ -150,7 +150,7 @@ class NavigationControl {
         this._map = undefined;
     }
 
-    _createButton(className: string, fn: () => mixed) {
+    _createButton(className: string, fn: () => mixed): HTMLButtonElement {
         const a = DOM.create('button', className, this._container);
         a.type = 'button';
         a.addEventListener('click', fn);

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -3,7 +3,7 @@
 import * as DOM from '../../util/dom.js';
 import {extend, bindAll} from '../../util/util.js';
 
-import type Map from '../map.js';
+import type Map, {ControlPosition} from '../map.js';
 
 type Unit = 'imperial' | 'metric' | 'nautical';
 
@@ -48,7 +48,7 @@ class ScaleControl {
         ], this);
     }
 
-    getDefaultPosition() {
+    getDefaultPosition(): ControlPosition {
         return 'bottom-left';
     }
 
@@ -56,7 +56,7 @@ class ScaleControl {
         updateScale(this._map, this._container, this.options);
     }
 
-    onAdd(map: Map) {
+    onAdd(map: Map): HTMLElement {
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-scale', map.getContainer());
 

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -35,7 +35,7 @@ class Hash {
      * @param {Object} map
      * @returns {Hash} `this`
      */
-    addTo(map: Map) {
+    addTo(map: Map): this {
         this._map = map;
         window.addEventListener('hashchange', this._onHashChange, false);
         map.on('moveend', this._updateHash);
@@ -47,7 +47,7 @@ class Hash {
      *
      * @returns {Popup} `this`
      */
-    remove() {
+    remove(): this {
         if (!this._map) return this;
 
         this._map.off('moveend', this._updateHash);
@@ -58,9 +58,9 @@ class Hash {
         return this;
     }
 
-    getHashString(mapFeedback?: boolean) {
+    getHashString(mapFeedback?: boolean): string {
         const map = this._map;
-        if (!map) return;
+        if (!map) return '';
         const center = map.getCenter(),
             zoom = Math.round(map.getZoom() * 100) / 100,
             // derived from equation: 512px * 2^z / 360 / 10^d < 0.5px
@@ -102,7 +102,7 @@ class Hash {
         return `#${hash}`;
     }
 
-    _getCurrentHash() {
+    _getCurrentHash(): Array<string> {
         // Get the current hash from location, stripped from its number sign
         const hash = window.location.hash.replace('#', '');
         if (this._hashName) {
@@ -120,9 +120,9 @@ class Hash {
         return hash.split('/');
     }
 
-    _onHashChange() {
+    _onHashChange(): boolean {
         const map = this._map;
-        if (!map) return;
+        if (!map) return false;
         const loc = this._getCurrentHash();
         if (loc.length >= 3 && !loc.some(v => isNaN(v))) {
             const bearing = map.dragRotate.isEnabled() && map.touchZoomRotate.isEnabled() ? +(loc[3] || 0) : map.getBearing();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -68,7 +68,7 @@ import type {
 } from '../style-spec/types.js';
 import type {ElevationQueryOptions} from '../terrain/elevation.js';
 
-type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+export type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 /* eslint-disable no-use-before-define */
 type IControl = {
     onAdd(map: Map): HTMLElement;


### PR DESCRIPTION
A part of #11426. Adds missing export types for control and hash classes, with a minor cleanup of return types in a few spots.