### PR TITLE
[Flow] Add missing types for line atlas and sprite positions

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -6,7 +6,7 @@ import type {TypedStyleLayer} from '../style/style_layer/typed_style_layer.js';
 import type FeatureIndex from './feature_index.js';
 import type Context from '../gl/context.js';
 import type {FeatureStates} from '../source/source_state.js';
-import type {ImagePosition} from '../render/image_atlas.js';
+import type {SpritePositions} from '../util/image.js';
 import type LineAtlas from '../render/line_atlas.js';
 import type {CanonicalTileID} from '../source/tile_id.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
@@ -81,7 +81,7 @@ export interface Bucket {
     +stateDependentLayers: Array<any>;
     +stateDependentLayerIds: Array<string>;
     populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform): void;
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}): void;
+    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions): void;
     isEmpty(): boolean;
 
     upload(context: Context): void;

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -27,7 +27,7 @@ import type IndexBuffer from '../../gl/index_buffer.js';
 import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureStates} from '../../source/source_state.js';
-import type {ImagePosition} from '../../render/image_atlas.js';
+import type {SpritePositions} from '../../util/image.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
 import type {Projection} from '../../geo/projection/index.js';
 import type {Vec3} from 'gl-matrix';
@@ -150,7 +150,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
         }
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -30,7 +30,7 @@ import type IndexBuffer from '../../gl/index_buffer.js';
 import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureStates} from '../../source/source_state.js';
-import type {ImagePosition} from '../../render/image_atlas.js';
+import type {SpritePositions} from '../../util/image.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
 class FillBucket implements Bucket {
@@ -129,12 +129,12 @@ class FillBucket implements Bucket {
         }
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }
 
-    addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>) {
+    addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: SpritePositions, availableImages: Array<string>) {
         for (const feature of this.patternFeatures) {
             this.addFeature(feature, feature.geometry, feature.index, canonical, imagePositions, availableImages);
         }
@@ -167,7 +167,7 @@ class FillBucket implements Bucket {
         this.segments2.destroy();
     }
 
-    addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string> = []) {
+    addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: SpritePositions, availableImages: Array<string> = []) {
         for (const polygon of classifyRings(geometry, EARCUT_MAX_RINGS)) {
             let numVertices = 0;
             for (const ring of polygon) {

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -35,7 +35,7 @@ import type Context from '../../gl/context.js';
 import type IndexBuffer from '../../gl/index_buffer.js';
 import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {FeatureStates} from '../../source/source_state.js';
-import type {ImagePosition} from '../../render/image_atlas.js';
+import type {SpritePositions} from '../../util/image.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
 const FACTOR = Math.pow(2, 13);
@@ -253,7 +253,7 @@ class FillExtrusionBucket implements Bucket {
         this.sortBorders();
     }
 
-    addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>) {
+    addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: SpritePositions, availableImages: Array<string>) {
         for (const feature of this.features) {
             const {geometry} = feature;
             this.addFeature(feature, geometry, feature.index, canonical, imagePositions, availableImages);
@@ -261,7 +261,7 @@ class FillExtrusionBucket implements Bucket {
         this.sortBorders();
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }
@@ -302,7 +302,7 @@ class FillExtrusionBucket implements Bucket {
         this.segments.destroy();
     }
 
-    addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>) {
+    addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: SpritePositions, availableImages: Array<string>) {
         const metadata = this.enableTerrain ? new PartMetadata() : null;
 
         for (const polygon of classifyRings(geometry, EARCUT_MAX_RINGS)) {

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -27,13 +27,12 @@ import type {
 import type LineStyleLayer from '../../style/style_layer/line_style_layer.js';
 import type Point from '@mapbox/point-geometry';
 import type {Segment} from '../segment.js';
-import {RGBAImage} from '../../util/image.js';
+import type {RGBAImage, SpritePositions} from '../../util/image.js';
 import type Context from '../../gl/context.js';
 import type Texture from '../../render/texture.js';
 import type IndexBuffer from '../../gl/index_buffer.js';
 import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {FeatureStates} from '../../source/source_state.js';
-import type {ImagePosition} from '../../render/image_atlas.js';
 import type LineAtlas from '../../render/line_atlas.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
@@ -267,12 +266,12 @@ class LineBucket implements Bucket {
 
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }
 
-    addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>) {
+    addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: SpritePositions, availableImages: Array<string>) {
         for (const feature of this.patternFeatures) {
             this.addFeature(feature, feature.geometry, feature.index, canonical, imagePositions, availableImages);
         }
@@ -314,7 +313,7 @@ class LineBucket implements Bucket {
         }
     }
 
-    addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>) {
+    addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: SpritePositions, availableImages: Array<string>) {
         const layout = this.layers[0].layout;
         const join = layout.get('line-join').evaluate(feature, {});
         const cap = layout.get('line-cap').evaluate(feature, {});

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -60,7 +60,6 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {SymbolQuad} from '../../symbol/quads.js';
 import type {SizeData} from '../../symbol/symbol_size.js';
 import type {FeatureStates} from '../../source/source_state.js';
-import type {ImagePosition} from '../../render/image_atlas.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
 export type SingleCollisionBox = {
     x1: number;
@@ -77,6 +76,7 @@ export type SingleCollisionBox = {
     tileID?: OverscaledTileID;
 };
 import type {Mat4} from 'gl-matrix';
+import type {SpritePositions} from '../../util/image.js';
 
 export type CollisionArrays = {
     textBox?: SingleCollisionBox;
@@ -563,7 +563,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.text.programConfigurations.updatePaintArrays(states, vtLayer, this.layers, availableImages, imagePositions);
         this.icon.programConfigurations.updatePaintArrays(states, vtLayer, this.layers, availableImages, imagePositions);

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -25,7 +25,7 @@ import type {TypedStyleLayer} from '../style/style_layer/typed_style_layer.js';
 import type {CrossfadeParameters} from '../style/evaluation_parameters.js';
 import type {StructArray, StructArrayMember} from '../util/struct_array.js';
 import type VertexBuffer from '../gl/vertex_buffer.js';
-import type {ImagePosition} from '../render/image_atlas.js';
+import type {SpritePosition, SpritePositions} from '../util/image.js';
 import type {
     Feature,
     FeatureState,
@@ -80,8 +80,8 @@ function packColor(color: Color): [number, number] {
  */
 
 interface AttributeBinder {
-    populatePaintArray(length: number, feature: Feature, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection): void;
-    updatePaintArray(start: number, length: number, feature: Feature, featureState: FeatureState, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}): void;
+    populatePaintArray(length: number, feature: Feature, imagePositions: SpritePositions, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection): void;
+    updatePaintArray(start: number, length: number, feature: Feature, featureState: FeatureState, availableImages: Array<string>, imagePositions: SpritePositions): void;
     upload(Context): void;
     destroy(): void;
 }
@@ -125,13 +125,13 @@ class CrossFadedConstantBinder implements UniformBinder {
         this.uniformNames = names.map(name => `u_${name}`);
         this.patternFrom = null;
         this.patternTo = null;
-        this.pixelRatioFrom = 1.0;
-        this.pixelRatioTo = 1.0;
+        this.pixelRatioFrom = 1;
+        this.pixelRatioTo = 1;
     }
 
-    setConstantPatternPositions(posTo: ImagePosition, posFrom: ImagePosition) {
-        this.pixelRatioFrom = posFrom.pixelRatio;
-        this.pixelRatioTo = posTo.pixelRatio;
+    setConstantPatternPositions(posTo: SpritePosition, posFrom: SpritePosition) {
+        this.pixelRatioFrom = posFrom.pixelRatio || 1;
+        this.pixelRatioTo = posTo.pixelRatio || 1;
         this.patternFrom = posFrom.tl.concat(posFrom.br);
         this.patternTo = posTo.tl.concat(posTo.br);
     }
@@ -174,7 +174,7 @@ class SourceExpressionBinder implements AttributeBinder {
         this.paintVertexArray = new PaintVertexArray();
     }
 
-    populatePaintArray(newLength: number, feature: Feature, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection) {
+    populatePaintArray(newLength: number, feature: Feature, imagePositions: SpritePositions, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection) {
         const start = this.paintVertexArray.length;
         assert(Array.isArray(availableImages));
         const value = this.expression.evaluate(new EvaluationParameters(0), feature, {}, canonical, availableImages, formattedSection);
@@ -246,7 +246,7 @@ class CompositeExpressionBinder implements AttributeBinder, UniformBinder {
         this.paintVertexArray = new PaintVertexArray();
     }
 
-    populatePaintArray(newLength: number, feature: Feature, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection) {
+    populatePaintArray(newLength: number, feature: Feature, imagePositions: SpritePositions, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection) {
         const min = this.expression.evaluate(new EvaluationParameters(this.zoom), feature, {}, canonical, availableImages, formattedSection);
         const max = this.expression.evaluate(new EvaluationParameters(this.zoom + 1), feature, {}, canonical, availableImages, formattedSection);
         const start = this.paintVertexArray.length;
@@ -331,14 +331,14 @@ class CrossFadedCompositeBinder implements AttributeBinder {
         this.zoomOutPaintVertexArray = new PaintVertexArray();
     }
 
-    populatePaintArray(length: number, feature: Feature, imagePositions: {[_: string]: ImagePosition}) {
+    populatePaintArray(length: number, feature: Feature, imagePositions: SpritePositions) {
         const start = this.zoomInPaintVertexArray.length;
         this.zoomInPaintVertexArray.resize(length);
         this.zoomOutPaintVertexArray.resize(length);
         this._setPaintValues(start, length, feature.patterns && feature.patterns[this.layerId], imagePositions);
     }
 
-    updatePaintArray(start: number, end: number, feature: Feature, featureState: FeatureState, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    updatePaintArray(start: number, end: number, feature: Feature, featureState: FeatureState, availableImages: Array<string>, imagePositions: SpritePositions) {
         this._setPaintValues(start, end, feature.patterns && feature.patterns[this.layerId], imagePositions);
     }
 
@@ -456,14 +456,14 @@ export default class ProgramConfiguration {
         return binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder ? binder.maxValue : 0;
     }
 
-    populatePaintArrays(newLength: number, feature: Feature, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection) {
+    populatePaintArrays(newLength: number, feature: Feature, imagePositions: SpritePositions, availableImages: Array<string>, canonical?: CanonicalTileID, formattedSection?: FormattedSection) {
         for (const property in this.binders) {
             const binder = this.binders[property];
             if (binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder || binder instanceof CrossFadedCompositeBinder)
                 (binder: AttributeBinder).populatePaintArray(newLength, feature, imagePositions, availableImages, canonical, formattedSection);
         }
     }
-    setConstantPatternPositions(posTo: ImagePosition, posFrom: ImagePosition) {
+    setConstantPatternPositions(posTo: SpritePosition, posFrom: SpritePosition) {
         for (const property in this.binders) {
             const binder = this.binders[property];
             if (binder instanceof CrossFadedConstantBinder)
@@ -471,7 +471,7 @@ export default class ProgramConfiguration {
         }
     }
 
-    updatePaintArrays(featureStates: FeatureStates, featureMap: FeaturePositionMap, vtLayer: VectorTileLayer, layer: TypedStyleLayer, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}): boolean {
+    updatePaintArrays(featureStates: FeatureStates, featureMap: FeaturePositionMap, vtLayer: VectorTileLayer, layer: TypedStyleLayer, availableImages: Array<string>, imagePositions: SpritePositions): boolean {
         let dirty: boolean = false;
         for (const id in featureStates) {
             const positions = featureMap.getPositions(id);
@@ -609,7 +609,7 @@ export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
         this._bufferOffset = 0;
     }
 
-    populatePaintArrays(length: number, feature: Feature, index: number, imagePositions: {[_: string]: ImagePosition}, availableImages: Array<string>, canonical: CanonicalTileID, formattedSection?: FormattedSection) {
+    populatePaintArrays(length: number, feature: Feature, index: number, imagePositions: SpritePositions, availableImages: Array<string>, canonical: CanonicalTileID, formattedSection?: FormattedSection) {
         for (const key in this.programConfigurations) {
             this.programConfigurations[key].populatePaintArrays(length, feature, imagePositions, availableImages, canonical, formattedSection);
         }
@@ -622,7 +622,7 @@ export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
         this.needsUpload = true;
     }
 
-    updatePaintArrays(featureStates: FeatureStates, vtLayer: VectorTileLayer, layers: $ReadOnlyArray<TypedStyleLayer>, availableImages: Array<string>, imagePositions: {[_: string]: ImagePosition}) {
+    updatePaintArrays(featureStates: FeatureStates, vtLayer: VectorTileLayer, layers: $ReadOnlyArray<TypedStyleLayer>, availableImages: Array<string>, imagePositions: SpritePositions) {
         for (const layer of layers) {
             this.needsUpload = this.programConfigurations[layer.id].updatePaintArrays(featureStates, this._featureMap, vtLayer, layer, availableImages, imagePositions) || this.needsUpload;
         }

--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -7,6 +7,7 @@ import potpack from 'potpack';
 import type {StyleImage} from '../style/style_image.js';
 import type ImageManager from './image_manager.js';
 import type Texture from './texture.js';
+import type {SpritePosition} from '../util/image.js';
 
 const IMAGE_PADDING: number = 1;
 export {IMAGE_PADDING};
@@ -18,7 +19,7 @@ type Rect = {
     h: number
 };
 
-export class ImagePosition {
+export class ImagePosition implements SpritePosition {
     paddedRect: Rect;
     pixelRatio: number;
     version: number;

--- a/src/render/image_manager.js
+++ b/src/render/image_manager.js
@@ -14,6 +14,7 @@ import type {StyleImage} from '../style/style_image.js';
 import type Context from '../gl/context.js';
 import type {Bin} from 'potpack';
 import type {Callback} from '../types/callback.js';
+import type {Size} from '../util/image.js';
 
 type Pattern = {
     bin: Bin,
@@ -62,7 +63,7 @@ class ImageManager extends Evented {
         this.dirty = true;
     }
 
-    isLoaded() {
+    isLoaded(): boolean {
         return this.loaded;
     }
 
@@ -92,7 +93,7 @@ class ImageManager extends Evented {
         }
     }
 
-    _validate(id: string, image: StyleImage) {
+    _validate(id: string, image: StyleImage): boolean {
         let valid = true;
         if (!this._validateStretch(image.stretchX, image.data && image.data.width)) {
             this.fire(new ErrorEvent(new Error(`Image "${id}" has invalid "stretchX" value`)));
@@ -109,7 +110,7 @@ class ImageManager extends Evented {
         return valid;
     }
 
-    _validateStretch(stretch: ?Array<[number, number]> | void, size: number) {
+    _validateStretch(stretch: ?Array<[number, number]> | void, size: number): boolean {
         if (!stretch) return true;
         let last = 0;
         for (const part of stretch) {
@@ -119,7 +120,7 @@ class ImageManager extends Evented {
         return true;
     }
 
-    _validateContent(content: ?[number, number, number, number] | void, image: StyleImage) {
+    _validateContent(content: ?[number, number, number, number] | void, image: StyleImage): boolean {
         if (!content) return true;
         if (content.length !== 4) return false;
         if (content[0] < 0 || image.data.width < content[0]) return false;
@@ -206,7 +207,7 @@ class ImageManager extends Evented {
 
     // Pattern stuff
 
-    getPixelSize() {
+    getPixelSize(): Size {
         const {width, height} = this.atlasImage;
         return {width, height};
     }

--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -4,6 +4,15 @@ import {warnOnce, nextPowerOfTwo} from '../util/util.js';
 import {AlphaImage} from '../util/image.js';
 import {register} from '../util/web_worker_transfer.js';
 
+import type {SpritePosition, SpritePositions} from '../util/image.js';
+
+type DashRange = {|
+    isDash: boolean,
+    left: number,
+    right: number,
+    zeroLength: boolean
+|};
+
 /**
  * A LineAtlas lets us reuse rendered dashed lines
  * by writing many of them to a texture and then fetching their positions
@@ -18,7 +27,7 @@ class LineAtlas {
     height: number;
     nextRow: number;
     image: AlphaImage;
-    positions: {[_: string]: any};
+    positions: SpritePositions;
     uploaded: boolean;
 
     constructor(width: number, height: number) {
@@ -38,7 +47,7 @@ class LineAtlas {
      * @returns {Object} position of dash texture in { y, height, width }
      * @private
      */
-    getDash(dasharray: Array<number>, lineCap: string) {
+    getDash(dasharray: Array<number>, lineCap: string): SpritePosition {
         const key = this.getKey(dasharray, lineCap);
         return this.positions[key];
     }
@@ -53,7 +62,7 @@ class LineAtlas {
         return dasharray.join(',') + lineCap;
     }
 
-    getDashRanges(dasharray: Array<number>, lineAtlasWidth: number, stretch: number) {
+    getDashRanges(dasharray: Array<number>, lineAtlasWidth: number, stretch: number): Array<DashRange> {
         // If dasharray has an odd length, both the first and last parts
         // are dashes and should be joined seamlessly.
         const oddDashArray = dasharray.length % 2 === 1;
@@ -81,7 +90,7 @@ class LineAtlas {
         return ranges;
     }
 
-    addRoundDash(ranges: Object, stretch: number, n: number) {
+    addRoundDash(ranges: Array<DashRange>, stretch: number, n: number) {
         const halfStretch = stretch / 2;
 
         for (let y = -n; y <= n; y++) {
@@ -111,7 +120,7 @@ class LineAtlas {
         }
     }
 
-    addRegularDash(ranges: Object, capLength: number) {
+    addRegularDash(ranges: Array<DashRange>, capLength: number) {
 
         // Collapse any zero-length range
         // Collapse neighbouring same-type parts into a single part
@@ -153,7 +162,7 @@ class LineAtlas {
         }
     }
 
-    addDash(dasharray: Array<number>, lineCap: string) {
+    addDash(dasharray: Array<number>, lineCap: string): null | SpritePosition {
         const key = this.getKey(dasharray, lineCap);
         if (this.positions[key]) return this.positions[key];
 

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -107,7 +107,7 @@ class Texture {
         }
     }
 
-    isSizePowerOfTwo() {
+    isSizePowerOfTwo(): boolean {
         return this.size[0] === this.size[1] && (Math.log(this.size[0]) / Math.LN2) % 1 === 0;
     }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -35,7 +35,7 @@ import type StyleLayer from '../style/style_layer.js';
 import type {WorkerTileResult} from './worker_source.js';
 import type Actor from '../util/actor.js';
 import type DEMData from '../data/dem_data.js';
-import type {AlphaImage} from '../util/image.js';
+import type {AlphaImage, SpritePositions} from '../util/image.js';
 import type ImageAtlas from '../render/image_atlas.js';
 import type LineAtlas from '../render/line_atlas.js';
 import type ImageManager from '../render/image_manager.js';
@@ -536,7 +536,9 @@ class Tile {
             const sourceLayerStates = states[sourceLayerId];
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
-            bucket.update(sourceLayerStates, sourceLayer, availableImages, (this.imageAtlas && this.imageAtlas.patternPositions) || {});
+            // $FlowFixMe[incompatible-type] Flow can't interpret ImagePosition as SpritePosition for some reason here
+            const imagePositions: SpritePositions = (this.imageAtlas && this.imageAtlas.patternPositions) || {};
+            bucket.update(sourceLayerStates, sourceLayer, availableImages, imagePositions);
             if (bucket instanceof LineBucket || bucket instanceof FillBucket) {
                 const sourceCache = painter.style._getSourceCache(bucket.layers[0].source);
                 if (painter._terrain && painter._terrain.enabled && sourceCache && bucket.programConfigurations.needsUpload) {

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -25,6 +25,7 @@ import type StyleLayer from '../style/style_layer.js';
 import type StyleLayerIndex from '../style/style_layer_index.js';
 import type {StyleImage} from '../style/style_image.js';
 import type {StyleGlyph} from '../style/style_glyph.js';
+import type {SpritePositions} from '../util/image.js';
 import type {
     WorkerTileParameters,
     WorkerTileCallback,
@@ -249,7 +250,9 @@ class WorkerTile {
                          bucket instanceof FillBucket ||
                          bucket instanceof FillExtrusionBucket)) {
                         recalculateLayers(bucket.layers, this.zoom, availableImages);
-                        bucket.addFeatures(options, this.tileID.canonical, imageAtlas.patternPositions, availableImages);
+                        // $FlowFixMe[incompatible-type] Flow can't interpret ImagePosition as SpritePosition for some reason here
+                        const imagePositions: SpritePositions = imageAtlas.patternPositions;
+                        bucket.addFeatures(options, this.tileID.canonical, imagePositions, availableImages);
                     }
                 }
 

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -9,6 +9,13 @@ export type Size = {
     height: number
 };
 
+export interface SpritePosition {
+    +tl: [number, number],
+    +br: [number, number],
+    +pixelRatio?: number
+}
+export type SpritePositions = {[_: string]: SpritePosition};
+
 type Point = {
     x: number,
     y: number


### PR DESCRIPTION
A part of #11426. Adds proper types to `LineAtlas`, removing `any`. This required a pretty extensive refactor because throughout the code, sprite positions for either dashes or icons/patterns where typed as `ImagePosition` (which only applies to the latter), but Flow ignored the mismatch because `LineAtlas` implicitly typed dashes as `any`. Now the code uses a much narrower `SpritePosition` interface, which is a small subset of `ImagePosition` (the latter with its extended functions/properties is still used in symbol layout).