### PR TITLE
[Flow] Add missing export types to source/*

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -235,7 +235,6 @@ class FeatureIndex {
                 layerResult = result[layerID] = [];
             }
 
-            // $FlowFixMe[incompatible-call] - Flow can't assing non-nullable type to nullable
             layerResult.push({featureIndex, feature: geojsonFeature, intersectionZ});
         }
     }

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -22,6 +22,7 @@ import {FeatureIndexArray} from './array_types.js';
 import {DEMSampler} from '../terrain/elevation.js';
 
 import type StyleLayer from '../style/style_layer.js';
+import type {QueryFeature} from '../util/vectortile_to_geojson.js';
 import type {FeatureFilter} from '../style-spec/feature_filter/index.js';
 import type Transform from '../geo/transform.js';
 import type {FilterSpecification, PromoteIdSpecification} from '../style-spec/types.js';
@@ -41,7 +42,7 @@ type QueryParameters = {
     }
 }
 
-export type QueryResult = {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>};
+export type QueryResult = {[_: string]: Array<{ featureIndex: number, feature: QueryFeature }>};
 
 type FeatureIndices = {
     bucketIndex: number,
@@ -233,6 +234,8 @@ class FeatureIndex {
             if (layerResult === undefined) {
                 layerResult = result[layerID] = [];
             }
+
+            // $FlowFixMe[incompatible-call] - Flow can't assing non-nullable type to nullable
             layerResult.push({featureIndex, feature: geojsonFeature, intersectionZ});
         }
     }

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -41,7 +41,7 @@ type QueryParameters = {
     }
 }
 
-type QueryResult = {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>};
+export type QueryResult = {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>};
 
 type FeatureIndices = {
     bucketIndex: number,

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -64,15 +64,13 @@ export function queryRenderedFeatures(sourceCache: SourceCache,
             const feature = featureWrapper.feature;
             const layer = feature.layer;
 
-            if (layer && layer.type !== 'background' && layer.type !== 'sky') {
-                // $FlowFixMe[incompatible-call] - integration tests are failing when skipping calls with the undefined feature.id
-                const state = sourceCache.getFeatureState(layer['source-layer'], feature.id);
-                feature.source = layer.source;
-                if (layer['source-layer']) {
-                    feature.sourceLayer = layer['source-layer'];
-                }
-                feature.state = state;
+            if (!layer || layer.type === 'background' || layer.type === 'sky') return;
+
+            feature.source = layer.source;
+            if (layer['source-layer']) {
+                feature.sourceLayer = layer['source-layer'];
             }
+            feature.state = feature.id !== undefined ? sourceCache.getFeatureState(layer['source-layer'], feature.id) : {};
         });
     }
     return result;

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -69,13 +69,9 @@ export function queryRenderedFeatures(sourceCache: SourceCache,
                 layer: LayerSpecification;
             } = (featureWrapper.feature: any);
 
-            // background and sky layers don't have a source
-            if (!feature.id || feature.layer.type === 'background' || feature.layer.type === 'sky') {
-                return;
-            }
-
+            // $FlowFixMe prop-missing
             const state = sourceCache.getFeatureState(feature.layer['source-layer'], feature.id);
-            // $FlowFixMe prop-missing - Flow can't infer the absense of source and source-layer after the getFeatureState call
+            // $FlowFixMe prop-missing
             feature.source = feature.layer.source;
             // $FlowFixMe prop-missing
             if (feature.layer['source-layer']) {

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -42,9 +42,9 @@ function sendPluginStateToWorker() {
     evented.fire(new Event('pluginStateChange', {pluginStatus, pluginURL}));
 }
 
-export const evented = new Evented();
+export const evented: Evented = new Evented();
 
-export const getRTLTextPluginStatus = function () {
+export const getRTLTextPluginStatus = function (): string {
     return pluginStatus;
 };
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -17,6 +17,7 @@ import type Style from '../style/style.js';
 import type Transform from '../geo/transform.js';
 import type {TileState} from './tile.js';
 import type {Callback} from '../types/callback.js';
+import type {FeatureStates} from './source_state.js';
 import type {QueryGeometry, TilespaceQueryGeometry} from '../style/query_geometry.js';
 
 /**
@@ -202,7 +203,7 @@ class SourceCache extends Evented {
         return false;
     }
 
-    _isIdRenderable(id: number, symbolLayer?: boolean) {
+    _isIdRenderable(id: number, symbolLayer?: boolean): boolean {
         return this._tiles[id] && this._tiles[id].hasData() &&
             !this._coveredTiles[id] && (symbolLayer || !this._tiles[id].holdingForFade());
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -12,6 +12,7 @@ import assert from 'assert';
 import SourceFeatureState from './source_state.js';
 
 import type {Source} from './source.js';
+import type {SourceSpecification} from '../style-spec/types.js';
 import type {default as MapboxMap} from '../ui/map.js';
 import type Style from '../style/style.js';
 import type Transform from '../geo/transform.js';
@@ -153,7 +154,7 @@ class SourceCache extends Evented {
             return this._source.abortTile(tile, () => {});
     }
 
-    serialize() {
+    serialize(): SourceSpecification {
         return this._source.serialize();
     }
 
@@ -195,7 +196,7 @@ class SourceCache extends Evented {
         return renderables.map(tile => tile.tileID).sort(compareTileId).map(id => id.key);
     }
 
-    hasRenderableParent(tileID: OverscaledTileID) {
+    hasRenderableParent(tileID: OverscaledTileID): boolean {
         const parentTile = this.findLoadedParent(tileID, 0);
         if (parentTile) {
             return this._isIdRenderable(parentTile.tileID.key);
@@ -331,10 +332,10 @@ class SourceCache extends Evented {
      * @private
      */
     _retainLoadedChildren(
-        idealTiles: {[_: any]: OverscaledTileID},
+        idealTiles: {[number | string]: OverscaledTileID},
         zoom: number,
         maxCoveringZoom: number,
-        retain: {[_: any]: OverscaledTileID}
+        retain: {[number | string]: OverscaledTileID}
     ) {
         for (const id in this._tiles) {
             let tile = this._tiles[id];
@@ -873,7 +874,7 @@ class SourceCache extends Evented {
         return coords;
     }
 
-    hasTransition() {
+    hasTransition(): boolean {
         if (this._source.hasTransition()) {
             return true;
         }
@@ -912,7 +913,7 @@ class SourceCache extends Evented {
      * Get the entire state object for a feature
      * @private
      */
-    getFeatureState(sourceLayer?: string, featureId: number | string) {
+    getFeatureState(sourceLayer?: string, featureId: number | string): FeatureStates {
         sourceLayer = sourceLayer || '_geojsonTileLayer';
         return this._state.getState(sourceLayer, featureId);
     }
@@ -1000,7 +1001,7 @@ function compareTileId(a: OverscaledTileID, b: OverscaledTileID): number {
     return a.overscaledZ - b.overscaledZ || bWrap - aWrap || b.canonical.y - a.canonical.y || b.canonical.x - a.canonical.x;
 }
 
-function isRasterType(type) {
+function isRasterType(type): boolean {
     return type === 'raster' || type === 'image' || type === 'video';
 }
 

--- a/src/source/source_state.js
+++ b/src/source/source_state.js
@@ -82,7 +82,7 @@ class SourceFeatureState {
         }
     }
 
-    getState(sourceLayer: string, featureId: number | string) {
+    getState(sourceLayer: string, featureId: number | string): FeatureStates {
         const feature = String(featureId);
         const base = this.state[sourceLayer] || {};
         const changes = this.stateChanges[sourceLayer] || {};

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -51,6 +51,7 @@ import type VertexBuffer from '../gl/vertex_buffer.js';
 import type IndexBuffer from '../gl/index_buffer.js';
 import type {Projection} from '../geo/projection/index.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
+import type {QueryResult} from '../data/feature_index.js';
 import type Painter from '../render/painter.js';
 
 export type TileState =
@@ -388,7 +389,7 @@ class Tile {
                           params: { filter: FilterSpecification, layers: Array<string>, availableImages: Array<string> },
                           transform: Transform,
                           pixelPosMatrix: Float32Array,
-                          visualizeQueryGeometry: boolean): {[_: string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
+                          visualizeQueryGeometry: boolean): QueryResult {
         Debug.run(() => {
             if (visualizeQueryGeometry) {
                 let geometryViz = this.queryGeometryDebugViz;

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -53,6 +53,7 @@ import type {Projection} from '../geo/projection/index.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
 import type {QueryResult} from '../data/feature_index.js';
 import type Painter from '../render/painter.js';
+import type {QueryFeature} from '../util/vectortile_to_geojson.js';
 
 export type TileState =
     | 'loading'   // Tile data is in the process of loading.
@@ -418,7 +419,7 @@ class Tile {
         }, layers, serializedLayers, sourceFeatureState);
     }
 
-    querySourceFeatures(result: Array<GeoJSONFeature>, params: any) {
+    querySourceFeatures(result: Array<QueryFeature>, params: any) {
         const featureIndex = this.latestFeatureIndex;
         if (!featureIndex || !featureIndex.rawTileData) return;
 
@@ -444,6 +445,8 @@ class Tile {
             const id = featureIndex.getId(feature, sourceLayer);
             const geojsonFeature = new GeoJSONFeature(feature, z, x, y, id);
             geojsonFeature.tile = coord;
+
+            // $FlowFixMe[incompatible-call] - Flow can't assing non-nullable type to nullable
             result.push(geojsonFeature);
         }
     }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -446,7 +446,6 @@ class Tile {
             const geojsonFeature = new GeoJSONFeature(feature, z, x, y, id);
             geojsonFeature.tile = coord;
 
-            // $FlowFixMe[incompatible-call] - Flow can't assing non-nullable type to nullable
             result.push(geojsonFeature);
         }
     }

--- a/src/source/tile_bounds.js
+++ b/src/source/tile_bounds.js
@@ -16,13 +16,13 @@ class TileBounds {
         this.maxzoom = maxzoom || 24;
     }
 
-    validateBounds(bounds: [number, number, number, number]) {
+    validateBounds(bounds: [number, number, number, number]): [number, number, number, number] {
         // make sure the bounds property contains valid longitude and latitudes
         if (!Array.isArray(bounds) || bounds.length !== 4) return [-180, -90, 180, 90];
         return [Math.max(-180, bounds[0]), Math.max(-90, bounds[1]), Math.min(180, bounds[2]), Math.min(90, bounds[3])];
     }
 
-    contains(tileID: CanonicalTileID) {
+    contains(tileID: CanonicalTileID): boolean {
         const worldSize = Math.pow(2, tileID.z);
         const level = {
             minX: Math.floor(mercatorXfromLng(this.bounds.getWest()) * worldSize),

--- a/src/util/vectortile_to_geojson.js
+++ b/src/util/vectortile_to_geojson.js
@@ -4,7 +4,7 @@ import type {GeoJSONGeometry, GeoJSONFeature} from '@mapbox/geojson-types';
 
 // we augment GeoJSON with custom properties in query*Features results
 export type QueryFeature = $ReadOnly<GeoJSONFeature> & {
-    layer: ?LayerSpecification;
+    layer?: ?LayerSpecification;
     [key: string]: mixed;
 };
 
@@ -52,7 +52,6 @@ class Feature {
     toJSON(): QueryFeature {
         const json: QueryFeature = {
             type: 'Feature',
-            layer: this.layer,
             geometry: this.geometry,
             properties: this.properties
         };

--- a/src/util/vectortile_to_geojson.js
+++ b/src/util/vectortile_to_geojson.js
@@ -3,7 +3,7 @@ import type {LayerSpecification} from '../style-spec/types.js';
 import type {GeoJSONGeometry, GeoJSONFeature} from '@mapbox/geojson-types';
 
 // we augment GeoJSON with custom properties in query*Features results
-export type QueryFeature = GeoJSONFeature & {
+export type QueryFeature = $ReadOnly<GeoJSONFeature> & {
     layer: ?LayerSpecification;
     [key: string]: mixed;
 };

--- a/src/util/vectortile_to_geojson.js
+++ b/src/util/vectortile_to_geojson.js
@@ -1,8 +1,12 @@
 // @flow
+import type {LayerSpecification} from '../style-spec/types.js';
 import type {GeoJSONGeometry, GeoJSONFeature} from '@mapbox/geojson-types';
 
 // we augment GeoJSON with custom properties in query*Features results
-type QueryFeature = GeoJSONFeature & {[key: string]: mixed};
+export type QueryFeature = GeoJSONFeature & {
+    layer: ?LayerSpecification;
+    [key: string]: mixed;
+};
 
 const customProps = ['tile', 'layer', 'source', 'sourceLayer', 'state'];
 
@@ -17,7 +21,7 @@ class Feature {
     _z: number;
 
     tile: ?mixed;
-    layer: ?mixed;
+    layer: ?LayerSpecification;
     source: ?mixed;
     sourceLayer: ?mixed;
     state: ?mixed;
@@ -48,6 +52,7 @@ class Feature {
     toJSON(): QueryFeature {
         const json: QueryFeature = {
             type: 'Feature',
+            layer: this.layer,
             geometry: this.geometry,
             properties: this.properties
         };


### PR DESCRIPTION
A part of #11426. Add more export types to a `source/*`