### PR TITLE
[Flow] Add missing export types to bench/*

### DIFF
--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -27,7 +27,7 @@ class ExpressionBenchmark extends Benchmark {
         this.style = style;
     }
 
-    setup() {
+    setup(): Promise<void> {
         return fetchStyle(this.style)
             .then(json => {
                 this.data = [];

--- a/bench/benchmarks/hillshade_load.js
+++ b/bench/benchmarks/hillshade_load.js
@@ -35,7 +35,7 @@ export default class HillshadeLoad extends Benchmark {
         };
     }
 
-    bench() {
+    bench(): Promise<void> {
         return createMap({
             width: 1024,
             height: 1024,

--- a/bench/benchmarks/layout.js
+++ b/bench/benchmarks/layout.js
@@ -40,7 +40,7 @@ export default class Layout extends Benchmark {
             .then(() => {});
     }
 
-    bench() {
+    bench(): Promise<void> {
         let promise = Promise.resolve();
         for (const tile of this.tiles) {
             promise = promise.then(() => {

--- a/bench/benchmarks/layout_dds.js
+++ b/bench/benchmarks/layout_dds.js
@@ -101,7 +101,7 @@ export default class LayoutDDS extends Benchmark {
             .then(() => {});
     }
 
-    bench() {
+    bench(): Promise<void> {
         let promise = Promise.resolve();
         for (const tile of this.tiles) {
             promise = promise.then(() => {

--- a/bench/benchmarks/symbol_layout.js
+++ b/bench/benchmarks/symbol_layout.js
@@ -27,7 +27,7 @@ export default class SymbolLayout extends Layout {
         });
     }
 
-    bench() {
+    bench(): Promise<void> {
         let promise = Promise.resolve();
         for (const tileResult of this.parsedTiles) {
             promise = promise.then(() => {

--- a/bench/lib/benchmark.js
+++ b/bench/lib/benchmark.js
@@ -57,7 +57,7 @@ class Benchmark {
             });
     }
 
-    _done() {
+    _done(): boolean {
         // 210 samples => 20 observations for regression
         return this._elapsed >= 500 && this._measurements.length > 210;
     }
@@ -76,7 +76,7 @@ class Benchmark {
         }
     }
 
-    _measureSync() {
+    _measureSync(): Promise<Array<Measurement>> {
         // Avoid Promise overhead for sync benchmarks.
         while (true) {
             const time = performance.now() - this._start;
@@ -87,13 +87,14 @@ class Benchmark {
                 this._measurements.push({time, iterations: this._iterationsPerMeasurement});
             }
             if (this._done()) {
-                return this._end();
+                break;
             }
             this._start = performance.now();
             for (let i = this._iterationsPerMeasurement; i > 0; --i) {
                 this.bench();
             }
         }
+        return this._end();
     }
 
     _measureAsync(): Promise<Array<Measurement>> {

--- a/bench/lib/tile_parser.js
+++ b/bench/lib/tile_parser.js
@@ -108,7 +108,7 @@ export default class TileParser {
         });
     }
 
-    fetchTile(tileID: OverscaledTileID) {
+    fetchTile(tileID: OverscaledTileID): Promise<{| buffer: ArrayBuffer, tileID: OverscaledTileID |}> {
         return fetch(this.style.map._requestManager.normalizeTileURL(tileID.canonical.url(this.tileJSON.tiles)))
             .then(response => response.arrayBuffer())
             .then(buffer => ({tileID, buffer}));


### PR DESCRIPTION
A part of #11426. Adds missing exports types to files under `bench/*`.