### PR TITLE
Improve globe performance by caching globe matrix

### DIFF
--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -1,6 +1,5 @@
 // @flow
 import {
-    MAX_MERCATOR_LATITUDE,
     lngFromMercatorX,
     latFromMercatorY,
     mercatorZfromAltitude,
@@ -8,9 +7,8 @@ import {
     mercatorYfromLat
 } from '../mercator_coordinate.js';
 import EXTENT from '../../data/extent.js';
-import {degToRad, smoothstep, clamp} from '../../util/util.js';
+import {degToRad, smoothstep} from '../../util/util.js';
 import {mat4, vec3} from 'gl-matrix';
-import Point from '@mapbox/point-geometry';
 import SegmentVector from '../../data/segment.js';
 import {members as globeLayoutAttributes, atmosphereLayout} from '../../terrain/globe_attributes.js';
 import {TriangleIndexArray, GlobeVertexArray, LineIndexArray} from '../../data/array_types.js';
@@ -151,36 +149,37 @@ export function globePixelsToTileUnits(zoom: number, id: CanonicalTileID): numbe
     return ecefPerPixel * normCoeff;
 }
 
-export function calculateGlobeMatrix(tr: Transform, worldSize: number, offset?: [number, number]): Float64Array {
-    const wsRadius = worldSize / (2.0 * Math.PI);
-    const scale = globeECEFUnitsToPixelScale(worldSize);
-
-    if (!offset) {
-        const lat = clamp(tr.center.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
-        const lng = tr.center.lng;
-
-        offset = [
-            mercatorXfromLng(lng) * worldSize,
-            mercatorYfromLat(lat) * worldSize
-        ];
-    }
-
+function calculateGlobePosMatrix(x, y, worldSize, lng, lat): Float64Array {
     // transform the globe from reference coordinate space to world space
-    const posMatrix = mat4.identity(new Float64Array(16));
-    mat4.translate(posMatrix, posMatrix, [offset[0], offset[1], -wsRadius]);
-    mat4.scale(posMatrix, posMatrix, [scale, scale, scale]);
-    mat4.rotateX(posMatrix, posMatrix, degToRad(-tr._center.lat));
-    mat4.rotateY(posMatrix, posMatrix, degToRad(-tr._center.lng));
+    const scale = globeECEFUnitsToPixelScale(worldSize);
+    const offset = [x, y, -worldSize / (2.0 * Math.PI)];
+    const m = mat4.identity(new Float64Array(16));
+    mat4.translate(m, m, offset);
+    mat4.scale(m, m, [scale, scale, scale]);
+    mat4.rotateX(m, m, degToRad(-lat));
+    mat4.rotateY(m, m, degToRad(-lng));
+    return m;
+}
 
-    return posMatrix;
+export function calculateGlobeMatrix(tr: Transform): Float64Array {
+    const {x, y} = tr.point;
+    const {lng, lat} = tr._center;
+    return calculateGlobePosMatrix(x, y, tr.worldSize, lng, lat);
+}
+
+export function calculateGlobeLabelMatrix(tr: Transform, id: CanonicalTileID): Float64Array {
+    const {lng, lat} = tr._center;
+    // Camera is moved closer towards the ground near poles as part of
+    // compesanting the reprojection. This has to be compensated for the
+    // map aligned label space. Whithout this logic map aligned symbols
+    // would appear larger than intended.
+    const m = calculateGlobePosMatrix(0, 0, tr.worldSize / tr._projectionScaler, lng, lat);
+    return mat4.multiply(m, m, globeDenormalizeECEF(globeTileBounds(id)));
 }
 
 export function calculateGlobeMercatorMatrix(tr: Transform): Float32Array {
     const worldSize = tr.worldSize;
-    const lat = clamp(tr.center.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
-    const point = new Point(
-        mercatorXfromLng(tr.center.lng) * worldSize,
-        mercatorYfromLat(lat) * worldSize);
+    const point = tr.point;
 
     const mercatorZ = mercatorZfromAltitude(1, tr.center.lat) * worldSize;
     const projectionScaler = mercatorZ / tr.pixelsPerMeter;

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -4,7 +4,7 @@ import MercatorCoordinate, {altitudeFromMercatorZ, lngFromMercatorX, latFromMerc
 import EXTENT from '../../data/extent.js';
 import {vec3} from 'gl-matrix';
 import {Aabb} from '../../util/primitives.js';
-import {globeTileBounds, calculateGlobeMatrix} from './globe_util.js';
+import {globeTileBounds} from './globe_util.js';
 import {UnwrappedTileID, CanonicalTileID} from '../../source/tile_id.js';
 import assert from 'assert';
 
@@ -104,14 +104,14 @@ export function tileAABB(tr: Transform, numTiles: number, z: number, x: number, 
         const mx = Number.MAX_VALUE;
         const cornerMax = [-mx, -mx, -mx];
         const cornerMin = [mx, mx, mx];
-        const globeMatrix = calculateGlobeMatrix(tr, numTiles);
-
         for (let i = 0; i < corners.length; i++) {
-            vec3.transformMat4(corners[i], corners[i], globeMatrix);
+            vec3.transformMat4(corners[i], corners[i], tr.globeMatrix);
             vec3.min(cornerMin, cornerMin, corners[i]);
             vec3.max(cornerMax, cornerMax, corners[i]);
         }
-
+        const scale = numTiles / tr.worldSize;
+        vec3.scale(cornerMin, cornerMin, scale);
+        vec3.scale(cornerMax, cornerMax, scale);
         return new Aabb(cornerMin, cornerMax);
     }
 

--- a/src/render/draw_globe_atmosphere.js
+++ b/src/render/draw_globe_atmosphere.js
@@ -4,7 +4,7 @@ import StencilMode from '../gl/stencil_mode.js';
 import DepthMode from '../gl/depth_mode.js';
 import ColorMode from '../gl/color_mode.js';
 import CullFaceMode from '../gl/cull_face_mode.js';
-import {calculateGlobeMatrix, globeToMercatorTransition} from './../geo/projection/globe_util.js';
+import {globeToMercatorTransition} from './../geo/projection/globe_util.js';
 import {atmosphereUniformValues} from '../terrain/globe_raster_program.js';
 import type Painter from './painter.js';
 import {vec3, mat4} from 'gl-matrix';
@@ -22,7 +22,7 @@ function drawGlobeAtmosphere(painter: Painter) {
     // Compute center and approximate radius of the globe on screen coordinates
     const viewMatrix = transform._camera.getWorldToCamera(transform.worldSize, 1.0);
     const viewToProj = transform._camera.getCameraToClipPerspective(transform._fov, transform.width / transform.height, transform._nearZ, transform._farZ);
-    const globeToView = mat4.mul([], viewMatrix, calculateGlobeMatrix(transform, transform.worldSize));
+    const globeToView = mat4.mul([], viewMatrix, transform.globeMatrix);
     const viewToScreen = mat4.mul([], transform.labelPlaneMatrix, viewToProj);
 
     const centerOnViewSpace = vec3.transformMat4([], [0, 0, 0], globeToView);

--- a/src/render/program/symbol_program.js
+++ b/src/render/program/symbol_program.js
@@ -14,7 +14,7 @@ import {OverscaledTileID} from '../../source/tile_id.js';
 import type Context from '../../gl/context.js';
 import type Painter from '../painter.js';
 import type {UniformValues, UniformLocations} from '../uniform_binding.js';
-import {globeECEFOrigin, calculateGlobeMatrix} from '../../geo/projection/globe_util.js';
+import {globeECEFOrigin} from '../../geo/projection/globe_util.js';
 
 export type SymbolIconUniformsType = {|
     'u_is_size_zoom_constant': Uniform1i,
@@ -216,14 +216,13 @@ const symbolIconUniformValues = (
     };
 
     if (transform.projection.name === 'globe') {
-        const tileMatrix = calculateGlobeMatrix(transform, transform.worldSize);
         values['u_tile_id'] = [coord.canonical.x, coord.canonical.y, 1 << coord.canonical.z];
         values['u_zoom_transition'] = zoomTransition;
         values['u_inv_rot_matrix'] = invMatrix;
         values['u_merc_center'] = mercatorCenter;
         values['u_camera_forward'] = ((transform._camera.forward(): any): [number, number, number]);
-        values['u_ecef_origin'] = globeECEFOrigin(tileMatrix, coord.toUnwrapped());
-        values['u_tile_matrix'] = Float32Array.from(tileMatrix);
+        values['u_ecef_origin'] = globeECEFOrigin(transform.globeMatrix, coord.toUnwrapped());
+        values['u_tile_matrix'] = Float32Array.from(transform.globeMatrix);
     }
 
     return values;

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -18,7 +18,7 @@ import type {Mat4, Vec4} from 'gl-matrix';
 
 import {WritingMode} from '../symbol/shaping.js';
 import {CanonicalTileID, OverscaledTileID} from '../source/tile_id.js';
-import {calculateGlobeMatrix, globeDenormalizeECEF, globeTileBounds} from '../geo/projection/globe_util.js';
+import {calculateGlobeLabelMatrix} from '../geo/projection/globe_util.js';
 export {updateLineLabels, hideGlyphs, getLabelPlaneMatrix, getGlCoordMatrix, project, projectVector, getPerspectiveRatio, placeFirstAndLastGlyph, placeGlyphAlongLine, xyTransformMat4};
 
 const FlipState = {
@@ -86,13 +86,7 @@ function getLabelPlaneMatrix(posMatrix: Float32Array,
     const m = mat4.create();
     if (pitchWithMap) {
         if (transform.projection.name === 'globe') {
-            // Camera is moved closer towards the ground near poles as part of
-            // compesanting the reprojection. This has to be compensated for the
-            // map aligned label space. Whithout this logic map aligned symbols
-            // would appear larger than intended.
-            const labelWorldSize = transform.worldSize / transform._projectionScaler;
-            const globeMatrix = calculateGlobeMatrix(transform, labelWorldSize, [0, 0]);
-            mat4.multiply(m, globeMatrix, globeDenormalizeECEF(globeTileBounds(tileID)));
+            mat4.multiply(m, m, calculateGlobeLabelMatrix(transform, tileID));
 
         } else {
             const s = mat2.invert([], pixelsToTileUnits);

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -16,7 +16,6 @@ import {OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import StencilMode from '../gl/stencil_mode.js';
 import ColorMode from '../gl/color_mode.js';
 import {
-    calculateGlobeMatrix,
     calculateGlobeMercatorMatrix,
     globeToMercatorTransition,
     globeMatrixForTile,
@@ -159,7 +158,6 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const depthMode = new DepthMode(gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
     vertexMorphing.update(now);
     const tr = painter.transform;
-    const globeMatrix = calculateGlobeMatrix(tr, tr.worldSize);
     const globeMercatorMatrix = calculateGlobeMercatorMatrix(tr);
     const mercatorCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
     const batches = showWireframe ? [false, true] : [false];
@@ -198,7 +196,7 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
                 extend(elevationOptions, {morphing: {srcDemTile: morph.from, dstDemTile: morph.to, phase: easeCubicInOut(morph.phase)}});
             }
 
-            const posMatrix = globeMatrixForTile(coord.canonical, globeMatrix);
+            const posMatrix = globeMatrixForTile(coord.canonical, tr.globeMatrix);
             const uniformValues = globeRasterUniformValues(
                 tr.projMatrix, posMatrix, globeMercatorMatrix,
                 globeToMercatorTransition(tr.zoom), mercatorCenter);


### PR DESCRIPTION
Depends on #11498 so uses it as the target branch. Closes #11392 by caching the globe matrix in transform and reusing it everywhere, eliminating a major source of jank when using the globe view. We can cache more matrices now, but this seems like a good start.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged @mpulkki-mapbox if this PR needs a native port (potentially)
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

