### PR TITLE
Simplify globe buffers code

### DIFF
--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -223,19 +223,18 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
                 const segment = sharedBuffers.poleSegments[z];
 
                 if (segment && (topCap || bottomCap)) {
-                    const poleMatrix = globePoleMatrixForTile(z, x, tr);
-                    const poleUniforms = globeRasterUniformValues(
-                        tr.projMatrix, poleMatrix, poleMatrix, 0.0, mercatorCenter);
+                    let poleMatrix = globePoleMatrixForTile(z, x, tr);
 
                     const drawPole = (program, vertexBuffer) => program.draw(
                         context, primitive, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
-                        poleUniforms, "globe_pole_raster", vertexBuffer, sharedBuffers.poleIndexBuffer, segment);
+                        globeRasterUniformValues(tr.projMatrix, poleMatrix, poleMatrix, 0.0, mercatorCenter),
+                        "globe_pole_raster", vertexBuffer, sharedBuffers.poleIndexBuffer, segment);
 
                     if (topCap) {
                         drawPole(program, sharedBuffers.poleNorthVertexBuffer);
                     }
                     if (bottomCap) {
-                        mat4.scale(poleMatrix, poleMatrix, [1, -1, 1]);
+                        poleMatrix = mat4.scale(mat4.create(), poleMatrix, [1, -1, 1]);
                         drawPole(program, sharedBuffers.poleSouthVertexBuffer);
                     }
                 }

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -8,13 +8,12 @@ import {Terrain} from './terrain.js';
 import Tile from '../source/tile.js';
 import assert from 'assert';
 import {easeCubicInOut} from '../util/util.js';
-import {mercatorXfromLng, mercatorYfromLat} from '../geo/mercator_coordinate.js';
 import type Painter from '../render/painter.js';
 import type SourceCache from '../source/source_cache.js';
-import type Program from '../render/program.js';
 import {OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import StencilMode from '../gl/stencil_mode.js';
 import ColorMode from '../gl/color_mode.js';
+import {mat4} from 'gl-matrix';
 import {
     calculateGlobeMatrix,
     calculateGlobeMercatorMatrix,
@@ -145,12 +144,10 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const setShaderMode = (mode, isWireframe) => {
         if (programMode === mode)
             return;
-        const defines = ([]: any);
+        const defines = [shaderDefines[mode], 'PROJECTION_GLOBE_VIEW'];
         if (isWireframe) {
             defines.push(shaderDefines[showWireframe]);
         }
-        defines.push(shaderDefines[mode]);
-        defines.push('PROJECTION_GLOBE_VIEW');
         program = painter.useProgram('globeRaster', null, defines);
         programMode = mode;
     };
@@ -161,7 +158,8 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const tr = painter.transform;
     const globeMatrix = calculateGlobeMatrix(tr, tr.worldSize);
     const globeMercatorMatrix = calculateGlobeMercatorMatrix(tr);
-    const mercatorCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
+    const {x, y} = tr.point;
+    const mercatorCenter = [x, y];
     const batches = showWireframe ? [false, true] : [false];
     const sharedBuffers = painter.globeSharedBuffers;
 
@@ -175,7 +173,6 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
 
         for (const coord of tileIDs) {
             const tile = sourceCache.getTile(coord);
-            const tiles = Math.pow(2, coord.canonical.z);
             const gridBuffer = globeVertexBufferForTileMesh(painter, tile, coord);
             const stencilMode = StencilMode.disabled;
 
@@ -220,25 +217,27 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
 
             if (!isWireframe && sharedBuffers) {
                 // Fill poles by extrapolating adjacent border tiles
-                const drawGlobePole = (program: Program<any>, isTopCap: boolean) => {
-                    const [poleBuffer, segment] = sharedBuffers.getPoleBuffersForTile(coord.canonical.z, isTopCap);
+                const {x, y, z} = coord.canonical;
+                const topCap = y === 0;
+                const bottomCap = y === (1 << z) - 1;
+                const segment = sharedBuffers.poleSegments[z];
 
-                    if (segment) {
-                        const poleMatrix = globePoleMatrixForTile(coord.canonical, isTopCap, tr);
-                        const poleUniforms = globeRasterUniformValues(
-                            tr.projMatrix, poleMatrix, poleMatrix, 0.0, mercatorCenter);
+                if (segment && (topCap || bottomCap)) {
+                    const poleMatrix = globePoleMatrixForTile(z, x, tr);
+                    const poleUniforms = globeRasterUniformValues(
+                        tr.projMatrix, poleMatrix, poleMatrix, 0.0, mercatorCenter);
 
-                        program.draw(context, primitive, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
-                            poleUniforms, "globe_pole_raster", poleBuffer, sharedBuffers.poleIndexBuffer, segment);
+                    const drawPole = (program, vertexBuffer) => program.draw(
+                        context, primitive, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
+                        poleUniforms, "globe_pole_raster", vertexBuffer, sharedBuffers.poleIndexBuffer, segment);
+
+                    if (topCap) {
+                        drawPole(program, sharedBuffers.poleNorthVertexBuffer);
                     }
-                };
-
-                if (coord.canonical.y === 0) {
-                    drawGlobePole(program, true);
-                }
-
-                if (coord.canonical.y === tiles - 1) {
-                    drawGlobePole(program, false);
+                    if (bottomCap) {
+                        mat4.scale(poleMatrix, poleMatrix, [1, -1, 1]);
+                        drawPole(program, sharedBuffers.poleSouthVertexBuffer);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR simplifies `GlobeSharedBuffers` implementation, reorganizing it to be less verbose and inlining methods where appropriate. Also contains an optimization for pole buffers generation where we iterate over south/north inside all the other loops (zooms and grid) so that we do those calculations once instead of twice.

In a follow-up commit, I optimized globe pole drawing so that it only needs to calculate the matrix once instead of twice.

Got -134 gzipped bundle bytes and -66 lines of code!

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
