### PR TITLE
Allow Safari to use the Image API to decode images to avoid a potential crash

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -7,6 +7,7 @@ import config from './config.js';
 import assert from 'assert';
 import {cacheGet, cachePut} from './tile_request_cache.js';
 import webpSupported from './webp_supported.js';
+import offscreenCanvasSupported from './offscreen_canvas_supported.js';
 
 import type {Callback} from '../types/callback.js';
 import type {Cancelable} from '../types/cancelable.js';
@@ -354,7 +355,7 @@ export const getImage = function(requestParameters: RequestParameters, callback:
         if (err) {
             callback(err);
         } else if (data) {
-            if (window.createImageBitmap) {
+            if (offscreenCanvasSupported()) {
                 arrayBufferToImageBitmap(data, (err, imgBitmap) => callback(err, imgBitmap, cacheControl, expires));
             } else {
                 arrayBufferToImage(data, (err, img) => callback(err, img, cacheControl, expires));

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -1,13 +1,12 @@
 // @flow
 
 import window from './window.js';
-import {extend, warnOnce, isWorker} from './util.js';
+import {extend, warnOnce, isWorker, isSafari} from './util.js';
 import {isMapboxHTTPURL, hasCacheDefeatingSku} from './mapbox.js';
 import config from './config.js';
 import assert from 'assert';
 import {cacheGet, cachePut} from './tile_request_cache.js';
 import webpSupported from './webp_supported.js';
-import offscreenCanvasSupported from './offscreen_canvas_supported.js';
 
 import type {Callback} from '../types/callback.js';
 import type {Cancelable} from '../types/cancelable.js';
@@ -355,7 +354,9 @@ export const getImage = function(requestParameters: RequestParameters, callback:
         if (err) {
             callback(err);
         } else if (data) {
-            if (offscreenCanvasSupported()) {
+            // force Safari to use the Image API to avoid a potential crash
+            // See https://github.com/mapbox/mapbox-gl-js/issues/11494
+            if (!isSafari(window) && window.createImageBitmap) {
                 arrayBufferToImageBitmap(data, (err, imgBitmap) => callback(err, imgBitmap, cacheControl, expires));
             } else {
                 arrayBufferToImage(data, (err, img) => callback(err, img, cacheControl, expires));


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - This reverts part of the change in https://github.com/mapbox/mapbox-gl-js/pull/10494 and only uses `window.createImageBitmap` to decode images when `offscreenCanvas` is supported. OffscreenCanvas is not supported by Safari which forces Safari to decode images using the Image API. Certain types of WebP images (raster-dem tiles over the ocean with small or no variation in them) cause Safari 15.2 and Safari 15.3 to crash when decoded with `createImageBitmap`. With the Image API, these images still fail to decode, but Safari properly handles the error so the failure is harmless.
    - The upside of this change is that we can continue requesting WebP images which are significantly smaller than PNG images but we avoid the Safari tab crashing.
    - The original bug for the Safari crash is https://github.com/mapbox/mapbox-gl-js/issues/11494
    - The `offscreenCanvasSupported()` check was first added in https://github.com/mapbox/mapbox-gl-js/pull/8845 as a progressive enhancement.
 - [x] manually test the debug page
    - Without this change, Safari 15.2/15.3 consistently crashes with certain tiles. With this change, Safari gracefully handles the bug by logging an error.
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Allow Safari to use the Image API to decode images to avoid a potential crash</changelog>`

This is a public style and location I used to manually test this.
```
var map = window.map = new mapboxgl.Map({
    container: 'map',
    zoom: 14.14,
    center: [-118.39997, 33.75873],
    style: 'mapbox://styles/ryanhamley/ckzhfiobs001i16kdrvuo8isv',
    hash: true
});

```