### PR TITLE
Simplify web worker registry to reduce bundle size

### DIFF
--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -36,7 +36,7 @@ class StructArrayLayout2i4 extends StructArray {
 }
 
 StructArrayLayout2i4.prototype.bytesPerElement = 4;
-register('StructArrayLayout2i4', StructArrayLayout2i4);
+register(StructArrayLayout2i4);
 
 /**
  * Implementation of the StructArray layout:
@@ -70,7 +70,7 @@ class StructArrayLayout4i8 extends StructArray {
 }
 
 StructArrayLayout4i8.prototype.bytesPerElement = 8;
-register('StructArrayLayout4i8', StructArrayLayout4i8);
+register(StructArrayLayout4i8);
 
 /**
  * Implementation of the StructArray layout:
@@ -113,7 +113,7 @@ class StructArrayLayout2i4ub1f12 extends StructArray {
 }
 
 StructArrayLayout2i4ub1f12.prototype.bytesPerElement = 12;
-register('StructArrayLayout2i4ub1f12', StructArrayLayout2i4ub1f12);
+register(StructArrayLayout2i4ub1f12);
 
 /**
  * Implementation of the StructArray layout:
@@ -146,7 +146,7 @@ class StructArrayLayout3f12 extends StructArray {
 }
 
 StructArrayLayout3f12.prototype.bytesPerElement = 12;
-register('StructArrayLayout3f12', StructArrayLayout3f12);
+register(StructArrayLayout3f12);
 
 /**
  * Implementation of the StructArray layout:
@@ -186,7 +186,7 @@ class StructArrayLayout10ui20 extends StructArray {
 }
 
 StructArrayLayout10ui20.prototype.bytesPerElement = 20;
-register('StructArrayLayout10ui20', StructArrayLayout10ui20);
+register(StructArrayLayout10ui20);
 
 /**
  * Implementation of the StructArray layout:
@@ -224,7 +224,7 @@ class StructArrayLayout8ui16 extends StructArray {
 }
 
 StructArrayLayout8ui16.prototype.bytesPerElement = 16;
-register('StructArrayLayout8ui16', StructArrayLayout8ui16);
+register(StructArrayLayout8ui16);
 
 /**
  * Implementation of the StructArray layout:
@@ -275,7 +275,7 @@ class StructArrayLayout4i4ui4i4i32 extends StructArray {
 }
 
 StructArrayLayout4i4ui4i4i32.prototype.bytesPerElement = 32;
-register('StructArrayLayout4i4ui4i4i32', StructArrayLayout4i4ui4i4i32);
+register(StructArrayLayout4i4ui4i4i32);
 
 /**
  * Implementation of the StructArray layout:
@@ -306,7 +306,7 @@ class StructArrayLayout1ul4 extends StructArray {
 }
 
 StructArrayLayout1ul4.prototype.bytesPerElement = 4;
-register('StructArrayLayout1ul4', StructArrayLayout1ul4);
+register(StructArrayLayout1ul4);
 
 /**
  * Implementation of the StructArray layout:
@@ -360,7 +360,7 @@ class StructArrayLayout5i4f1i1ul2ui40 extends StructArray {
 }
 
 StructArrayLayout5i4f1i1ul2ui40.prototype.bytesPerElement = 40;
-register('StructArrayLayout5i4f1i1ul2ui40', StructArrayLayout5i4f1i1ul2ui40);
+register(StructArrayLayout5i4f1i1ul2ui40);
 
 /**
  * Implementation of the StructArray layout:
@@ -399,7 +399,7 @@ class StructArrayLayout3i2i2i16 extends StructArray {
 }
 
 StructArrayLayout3i2i2i16.prototype.bytesPerElement = 16;
-register('StructArrayLayout3i2i2i16', StructArrayLayout3i2i2i16);
+register(StructArrayLayout3i2i2i16);
 
 /**
  * Implementation of the StructArray layout:
@@ -439,7 +439,7 @@ class StructArrayLayout2f1f2i16 extends StructArray {
 }
 
 StructArrayLayout2f1f2i16.prototype.bytesPerElement = 16;
-register('StructArrayLayout2f1f2i16', StructArrayLayout2f1f2i16);
+register(StructArrayLayout2f1f2i16);
 
 /**
  * Implementation of the StructArray layout:
@@ -475,7 +475,7 @@ class StructArrayLayout2ub2f12 extends StructArray {
 }
 
 StructArrayLayout2ub2f12.prototype.bytesPerElement = 12;
-register('StructArrayLayout2ub2f12', StructArrayLayout2ub2f12);
+register(StructArrayLayout2ub2f12);
 
 /**
  * Implementation of the StructArray layout:
@@ -508,7 +508,7 @@ class StructArrayLayout3ui6 extends StructArray {
 }
 
 StructArrayLayout3ui6.prototype.bytesPerElement = 6;
-register('StructArrayLayout3ui6', StructArrayLayout3ui6);
+register(StructArrayLayout3ui6);
 
 /**
  * Implementation of the StructArray layout:
@@ -576,7 +576,7 @@ class StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60 extends StructArray {
 }
 
 StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60.prototype.bytesPerElement = 60;
-register('StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60', StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60);
+register(StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60);
 
 /**
  * Implementation of the StructArray layout:
@@ -648,7 +648,7 @@ class StructArrayLayout3i2f6i15ui1ul3f76 extends StructArray {
 }
 
 StructArrayLayout3i2f6i15ui1ul3f76.prototype.bytesPerElement = 76;
-register('StructArrayLayout3i2f6i15ui1ul3f76', StructArrayLayout3i2f6i15ui1ul3f76);
+register(StructArrayLayout3i2f6i15ui1ul3f76);
 
 /**
  * Implementation of the StructArray layout:
@@ -679,7 +679,7 @@ class StructArrayLayout1f4 extends StructArray {
 }
 
 StructArrayLayout1f4.prototype.bytesPerElement = 4;
-register('StructArrayLayout1f4', StructArrayLayout1f4);
+register(StructArrayLayout1f4);
 
 /**
  * Implementation of the StructArray layout:
@@ -712,7 +712,7 @@ class StructArrayLayout3i6 extends StructArray {
 }
 
 StructArrayLayout3i6.prototype.bytesPerElement = 6;
-register('StructArrayLayout3i6', StructArrayLayout3i6);
+register(StructArrayLayout3i6);
 
 /**
  * Implementation of the StructArray layout:
@@ -749,7 +749,7 @@ class StructArrayLayout7f28 extends StructArray {
 }
 
 StructArrayLayout7f28.prototype.bytesPerElement = 28;
-register('StructArrayLayout7f28', StructArrayLayout7f28);
+register(StructArrayLayout7f28);
 
 /**
  * Implementation of the StructArray layout:
@@ -787,7 +787,7 @@ class StructArrayLayout1ul3ui12 extends StructArray {
 }
 
 StructArrayLayout1ul3ui12.prototype.bytesPerElement = 12;
-register('StructArrayLayout1ul3ui12', StructArrayLayout1ul3ui12);
+register(StructArrayLayout1ul3ui12);
 
 /**
  * Implementation of the StructArray layout:
@@ -819,7 +819,7 @@ class StructArrayLayout2ui4 extends StructArray {
 }
 
 StructArrayLayout2ui4.prototype.bytesPerElement = 4;
-register('StructArrayLayout2ui4', StructArrayLayout2ui4);
+register(StructArrayLayout2ui4);
 
 /**
  * Implementation of the StructArray layout:
@@ -850,7 +850,7 @@ class StructArrayLayout1ui2 extends StructArray {
 }
 
 StructArrayLayout1ui2.prototype.bytesPerElement = 2;
-register('StructArrayLayout1ui2', StructArrayLayout1ui2);
+register(StructArrayLayout1ui2);
 
 /**
  * Implementation of the StructArray layout:
@@ -882,7 +882,7 @@ class StructArrayLayout2f8 extends StructArray {
 }
 
 StructArrayLayout2f8.prototype.bytesPerElement = 8;
-register('StructArrayLayout2f8', StructArrayLayout2f8);
+register(StructArrayLayout2f8);
 
 /**
  * Implementation of the StructArray layout:
@@ -916,7 +916,7 @@ class StructArrayLayout4f16 extends StructArray {
 }
 
 StructArrayLayout4f16.prototype.bytesPerElement = 16;
-register('StructArrayLayout4f16', StructArrayLayout4f16);
+register(StructArrayLayout4f16);
 
 /**
  * Implementation of the StructArray layout:
@@ -957,7 +957,7 @@ class StructArrayLayout6i1f16 extends StructArray {
 }
 
 StructArrayLayout6i1f16.prototype.bytesPerElement = 16;
-register('StructArrayLayout6i1f16', StructArrayLayout6i1f16);
+register(StructArrayLayout6i1f16);
 
 class CollisionBoxStruct extends Struct {
     _structArray: CollisionBoxArray;
@@ -1008,7 +1008,7 @@ export class CollisionBoxArray extends StructArrayLayout5i4f1i1ul2ui40 {
     }
 }
 
-register('CollisionBoxArray', CollisionBoxArray);
+register(CollisionBoxArray);
 
 class PlacedSymbolStruct extends Struct {
     _structArray: PlacedSymbolArray;
@@ -1079,7 +1079,7 @@ export class PlacedSymbolArray extends StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1
     }
 }
 
-register('PlacedSymbolArray', PlacedSymbolArray);
+register(PlacedSymbolArray);
 
 class SymbolInstanceStruct extends Struct {
     _structArray: SymbolInstanceArray;
@@ -1165,7 +1165,7 @@ export class SymbolInstanceArray extends StructArrayLayout3i2f6i15ui1ul3f76 {
     }
 }
 
-register('SymbolInstanceArray', SymbolInstanceArray);
+register(SymbolInstanceArray);
 
 /**
  * @private
@@ -1174,7 +1174,7 @@ export class GlyphOffsetArray extends StructArrayLayout1f4 {
     getoffsetX(index: number): number { return this.float32[index * 1 + 0]; }
 }
 
-register('GlyphOffsetArray', GlyphOffsetArray);
+register(GlyphOffsetArray);
 
 /**
  * @private
@@ -1185,7 +1185,7 @@ export class SymbolLineVertexArray extends StructArrayLayout3i6 {
     gettileUnitDistanceFromAnchor(index: number): number { return this.int16[index * 3 + 2]; }
 }
 
-register('SymbolLineVertexArray', SymbolLineVertexArray);
+register(SymbolLineVertexArray);
 
 class FeatureIndexStruct extends Struct {
     _structArray: FeatureIndexArray;
@@ -1218,7 +1218,7 @@ export class FeatureIndexArray extends StructArrayLayout1ul3ui12 {
     }
 }
 
-register('FeatureIndexArray', FeatureIndexArray);
+register(FeatureIndexArray);
 
 class FillExtrusionCentroidStruct extends Struct {
     _structArray: FillExtrusionCentroidArray;
@@ -1247,7 +1247,7 @@ export class FillExtrusionCentroidArray extends StructArrayLayout2ui4 {
     }
 }
 
-register('FillExtrusionCentroidArray', FillExtrusionCentroidArray);
+register(FillExtrusionCentroidArray);
 
 class CircleGlobeExtStruct extends Struct {
     _structArray: CircleGlobeExtArray;
@@ -1286,7 +1286,7 @@ export class CircleGlobeExtArray extends StructArrayLayout6i1f16 {
     }
 }
 
-register('CircleGlobeExtArray', CircleGlobeExtArray);
+register(CircleGlobeExtArray);
 
 export {
     StructArrayLayout2i4,

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -240,6 +240,6 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
     }
 }
 
-register('CircleBucket', CircleBucket, {omit: ['layers']});
+register(CircleBucket, {omit: ['layers']});
 
 export default CircleBucket;

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -225,6 +225,6 @@ class FillBucket implements Bucket {
     }
 }
 
-register('FillBucket', FillBucket, {omit: ['layers', 'patternFeatures']});
+register(FillBucket, {omit: ['layers', 'patternFeatures']});
 
 export default FillBucket;

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -487,8 +487,8 @@ class FillExtrusionBucket implements Bucket {
     }
 }
 
-register('FillExtrusionBucket', FillExtrusionBucket, {omit: ['layers', 'features']});
-register('PartMetadata', PartMetadata);
+register(FillExtrusionBucket, {omit: ['layers', 'features']});
+register(PartMetadata);
 
 export default FillExtrusionBucket;
 

--- a/src/data/bucket/heatmap_bucket.js
+++ b/src/data/bucket/heatmap_bucket.js
@@ -12,6 +12,6 @@ class HeatmapBucket extends CircleBucket<HeatmapStyleLayer> {
     layers: Array<HeatmapStyleLayer>;
 }
 
-register('HeatmapBucket', HeatmapBucket, {omit: ['layers']});
+register(HeatmapBucket, {omit: ['layers']});
 
 export default HeatmapBucket;

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -657,6 +657,6 @@ class LineBucket implements Bucket {
     }
 }
 
-register('LineBucket', LineBucket, {omit: ['layers', 'patternFeatures']});
+register(LineBucket, {omit: ['layers', 'patternFeatures']});
 
 export default LineBucket;

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -234,7 +234,7 @@ export class SymbolBuffers {
     }
 }
 
-register('SymbolBuffers', SymbolBuffers);
+register(SymbolBuffers);
 
 class CollisionBuffers {
     layoutVertexArray: StructArray;
@@ -280,7 +280,7 @@ class CollisionBuffers {
     }
 }
 
-register('CollisionBuffers', CollisionBuffers);
+register(CollisionBuffers);
 
 /**
  * Unlike other buckets, which simply implement #addFeature with type-specific
@@ -1035,7 +1035,7 @@ class SymbolBucket implements Bucket {
     }
 }
 
-register('SymbolBucket', SymbolBucket, {
+register(SymbolBucket, {
     omit: ['layers', 'collisionBoxArray', 'features', 'compareText']
 });
 

--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -176,5 +176,5 @@ export default class DEMData {
     }
 }
 
-register('DEMData', DEMData);
-register('DemMinMaxQuadTree', DemMinMaxQuadTree, {omit: ['dem']});
+register(DEMData);
+register(DemMinMaxQuadTree, {omit: ['dem']});

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -311,11 +311,7 @@ class FeatureIndex {
     }
 }
 
-register(
-    'FeatureIndex',
-    FeatureIndex,
-    {omit: ['rawTileData', 'sourceLayerCoder']}
-);
+register(FeatureIndex, {omit: ['rawTileData', 'sourceLayerCoder']});
 
 export default FeatureIndex;
 

--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -126,4 +126,4 @@ function swap(arr, i, j) {
     arr[j] = tmp;
 }
 
-register('FeaturePositionMap', FeaturePositionMap);
+register(FeaturePositionMap);

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -704,10 +704,10 @@ function layoutType(property, type, binderType) {
     return (layoutException && layoutException[binderType]) || defaultLayouts[type][binderType];
 }
 
-register('ConstantBinder', ConstantBinder);
-register('CrossFadedConstantBinder', CrossFadedConstantBinder);
-register('SourceExpressionBinder', SourceExpressionBinder);
-register('CrossFadedCompositeBinder', CrossFadedCompositeBinder);
-register('CompositeExpressionBinder', CompositeExpressionBinder);
-register('ProgramConfiguration', ProgramConfiguration, {omit: ['_buffers']});
-register('ProgramConfigurationSet', ProgramConfigurationSet);
+register(ConstantBinder);
+register(CrossFadedConstantBinder);
+register(SourceExpressionBinder);
+register(CrossFadedCompositeBinder);
+register(CompositeExpressionBinder);
+register(ProgramConfiguration, {omit: ['_buffers']});
+register(ProgramConfigurationSet);

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -72,5 +72,5 @@ class SegmentVector {
  */
 SegmentVector.MAX_VERTEX_ARRAY_LENGTH = Math.pow(2, 16) - 1;
 
-register('SegmentVector', SegmentVector);
+register(SegmentVector);
 export default SegmentVector;

--- a/src/render/glyph_atlas.js
+++ b/src/render/glyph_atlas.js
@@ -76,4 +76,4 @@ export default class GlyphAtlas {
     }
 }
 
-register('GlyphAtlas', GlyphAtlas);
+register(GlyphAtlas);

--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -142,5 +142,5 @@ export default class ImageAtlas {
 
 }
 
-register('ImagePosition', ImagePosition);
-register('ImageAtlas', ImageAtlas);
+register(ImagePosition);
+register(ImageAtlas);

--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -215,6 +215,6 @@ class LineAtlas {
     }
 }
 
-register('LineAtlas', LineAtlas);
+register(LineAtlas);
 
 export default LineAtlas;

--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -14,8 +14,8 @@ class RasterDEMTileWorkerSource {
     loadTile(params: WorkerDEMTileParameters, callback: WorkerDEMTileCallback) {
         const {uid, encoding, rawImageData, padding, buildQuadTree} = params;
         // Main thread will transfer ImageBitmap if offscreen decode with OffscreenCanvas is supported, else it will transfer an already decoded image.
-        const imagePixels = window.ImageBitmap && rawImageData instanceof window.ImageBitmap ? this.getImageData(rawImageData, padding) : rawImageData;
-        // $FlowFixMe Flow struggles to refine ImageBitmap type, likely due to the JSDom shim
+        // Flow struggles to refine ImageBitmap type, likely due to the JSDom shim
+        const imagePixels = window.ImageBitmap && rawImageData instanceof window.ImageBitmap ? this.getImageData(rawImageData, padding) : ((rawImageData: any): ImageData);
         const dem = new DEMData(uid, imagePixels, encoding, padding < 1, buildQuadTree);
         callback(null, dem);
     }

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -191,5 +191,5 @@ function getQuadkey(z, x, y) {
     return quadkey;
 }
 
-register('CanonicalTileID', CanonicalTileID);
-register('OverscaledTileID', OverscaledTileID, {omit: ['projMatrix']});
+register(CanonicalTileID);
+register(OverscaledTileID, {omit: ['projMatrix']});

--- a/src/style/format_section_override.js
+++ b/src/style/format_section_override.js
@@ -54,4 +54,4 @@ export default class FormatSectionOverride<T> implements Expression {
     }
 }
 
-register('FormatSectionOverride', FormatSectionOverride, {omit: ['defaultValue']});
+register(FormatSectionOverride, {omit: ['defaultValue']});

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -755,8 +755,8 @@ export class Properties<Props: Object> {
     }
 }
 
-register('DataDrivenProperty', DataDrivenProperty);
-register('DataConstantProperty', DataConstantProperty);
-register('CrossFadedDataDrivenProperty', CrossFadedDataDrivenProperty);
-register('CrossFadedProperty', CrossFadedProperty);
-register('ColorRampProperty', ColorRampProperty);
+register(DataDrivenProperty);
+register(DataConstantProperty);
+register(CrossFadedDataDrivenProperty);
+register(CrossFadedProperty);
+register(ColorRampProperty);

--- a/src/symbol/anchor.js
+++ b/src/symbol/anchor.js
@@ -23,6 +23,6 @@ class Anchor extends Point {
     }
 }
 
-register('Anchor', Anchor);
+register(Anchor);
 
 export default Anchor;

--- a/src/symbol/opacity_state.js
+++ b/src/symbol/opacity_state.js
@@ -22,6 +22,6 @@ class OpacityState {
     }
 }
 
-register('OpacityState', OpacityState);
+register(OpacityState);
 
 export default OpacityState;

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -7,6 +7,7 @@ import config from './config.js';
 import assert from 'assert';
 import {cacheGet, cachePut} from './tile_request_cache.js';
 import webpSupported from './webp_supported.js';
+import {register} from './web_worker_transfer.js';
 
 import type {Callback} from '../types/callback.js';
 import type {Cancelable} from '../types/cancelable.js';
@@ -88,6 +89,7 @@ class AJAXError extends Error {
         return `${this.name}: ${this.message} (${this.status}): ${this.url}`;
     }
 }
+register(AJAXError);
 
 // Ensure that we're sending the correct referrer from blob URL worker bundles.
 // For files loaded from the local file system, `location.origin` will be set

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -7,7 +7,6 @@ import config from './config.js';
 import assert from 'assert';
 import {cacheGet, cachePut} from './tile_request_cache.js';
 import webpSupported from './webp_supported.js';
-import {register} from './web_worker_transfer.js';
 
 import type {Callback} from '../types/callback.js';
 import type {Cancelable} from '../types/cancelable.js';
@@ -73,7 +72,7 @@ export type RequestParameters = {
 
 export type ResponseCallback<T> = (error: ?Error, data: ?T, cacheControl: ?string, expires: ?string) => void;
 
-class AJAXError extends Error {
+export class AJAXError extends Error {
     status: number;
     url: string;
     constructor(message: string, status: number, url: string) {
@@ -89,7 +88,6 @@ class AJAXError extends Error {
         return `${this.name}: ${this.message} (${this.status}): ${this.url}`;
     }
 }
-register(AJAXError);
 
 // Ensure that we're sending the correct referrer from blob URL worker bundles.
 // For files loaded from the local file system, `location.origin` will be set

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -144,5 +144,5 @@ export class RGBAImage {
     }
 }
 
-register('AlphaImage', AlphaImage);
-register('RGBAImage', RGBAImage);
+register(AlphaImage);
+register(RGBAImage);

--- a/src/util/struct_array.js.ejs
+++ b/src/util/struct_array.js.ejs
@@ -99,4 +99,4 @@ if (useComponentGetters) {
 -%>
 }
 
-register('<%=StructArrayClass%>', <%=StructArrayClass%>);
+register(<%=StructArrayClass%>);

--- a/src/util/struct_array_layout.js.ejs
+++ b/src/util/struct_array_layout.js.ejs
@@ -95,4 +95,4 @@ for (const member of members) {
 }
 
 <%=StructArrayLayoutClass%>.prototype.bytesPerElement = <%= size %>;
-register('<%=StructArrayLayoutClass%>', <%=StructArrayLayoutClass%>);
+register(<%=StructArrayLayoutClass%>);

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -9,6 +9,7 @@ import CompoundExpression from '../style-spec/expression/compound_expression.js'
 import expressions from '../style-spec/expression/definitions/index.js';
 import ResolvedImage from '../style-spec/expression/types/resolved_image.js';
 import window from './window.js';
+import {AJAXError} from './ajax.js';
 
 import type {Transferable} from '../types/transferable.js';
 
@@ -80,6 +81,7 @@ register(Grid);
 
 register(Color);
 register(Error);
+register(AJAXError);
 register(ResolvedImage);
 
 register(StylePropertyFunction);

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -164,7 +164,7 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
         const klass = (input.constructor: any);
         const name = klass.name;
         if (!registry[name]) {
-            throw new Error(`can't serialize object of unregistered class`);
+            throw new Error(`can't serialize object of unregistered class ${name}`);
         }
 
         const properties: SerializedObject = klass.serialize ?

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -33,14 +33,12 @@ export type Serialized =
 type Registry = {
     [_: string]: {
         klass: Class<any>,
-        omit: $ReadOnlyArray<string>,
-        shallow: $ReadOnlyArray<string>
+        omit: $ReadOnlyArray<string>
     }
 };
 
 type RegisterOptions<T> = {
-    omit?: $ReadOnlyArray<$Keys<T>>,
-    shallow?: $ReadOnlyArray<$Keys<T>>
+    omit?: $ReadOnlyArray<$Keys<T>>
 }
 
 const registry: Registry = {};
@@ -50,24 +48,20 @@ const registry: Registry = {};
  *
  * @param options
  * @param options.omit List of properties to omit from serialization (e.g., cached/computed properties)
- * @param options.shallow List of properties that should be serialized by a simple shallow copy, rather than by a recursive call to serialize().
  *
  * @private
  */
-export function register<T: any>(name: string, klass: Class<T>, options: RegisterOptions<T> = {}) {
+export function register<T: any>(klass: Class<T>, options: RegisterOptions<T> = {}) {
+    const name = klass.name;
+    assert(name, 'Can\'t register a class without a name.');
     assert(!registry[name], `${name} is already registered.`);
-    (Object.defineProperty: any)(klass, '_classRegistryKey', {
-        value: name,
-        writeable: false
-    });
     registry[name] = {
         klass,
-        omit: options.omit || [],
-        shallow: options.shallow || []
+        omit: options.omit || []
     };
 }
 
-register('Object', Object);
+register(Object);
 
 type SerializedGrid = { buffer: ArrayBuffer };
 
@@ -82,21 +76,20 @@ type SerializedGrid = { buffer: ArrayBuffer };
 (Grid: any).deserialize = function deserialize(serialized: SerializedGrid): Grid {
     return new Grid(serialized.buffer);
 };
-register('Grid', Grid);
+register(Grid);
 
-register('Color', Color);
-register('Error', Error);
-register('ResolvedImage', ResolvedImage);
+register(Color);
+register(Error);
+register(ResolvedImage);
 
-register('StylePropertyFunction', StylePropertyFunction);
-register('StyleExpression', StyleExpression, {omit: ['_evaluator']});
+register(StylePropertyFunction);
+register(StyleExpression, {omit: ['_evaluator']});
 
-register('ZoomDependentExpression', ZoomDependentExpression);
-register('ZoomConstantExpression', ZoomConstantExpression);
-register('CompoundExpression', CompoundExpression, {omit: ['_evaluate']});
+register(ZoomDependentExpression);
+register(ZoomConstantExpression);
+register(CompoundExpression, {omit: ['_evaluate']});
 for (const name in expressions) {
-    if ((expressions[name]: any)._classRegistryKey) continue;
-    register(`Expression_${name}`, expressions[name]);
+    if (!registry[expressions[name].name]) register(expressions[name]);
 }
 
 function isArrayBuffer(val: any): boolean {
@@ -169,11 +162,10 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
 
     if (typeof input === 'object') {
         const klass = (input.constructor: any);
-        const name = klass._classRegistryKey;
-        if (!name) {
+        const name = klass.name;
+        if (!registry[name]) {
             throw new Error(`can't serialize object of unregistered class`);
         }
-        assert(registry[name]);
 
         const properties: SerializedObject = klass.serialize ?
             // (Temporary workaround) allow a class to provide static
@@ -191,9 +183,7 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
                 if (!(input: any).hasOwnProperty(key)) continue;
                 if (registry[name].omit.indexOf(key) >= 0) continue;
                 const property = (input: any)[key];
-                properties[key] = registry[name].shallow.indexOf(key) >= 0 ?
-                    property :
-                    serialize(property, transferables);
+                properties[key] = serialize(property, transferables);
             }
             if (input instanceof Error) {
                 properties.message = input.message;
@@ -255,7 +245,7 @@ export function deserialize(input: Serialized): mixed {
         for (const key of Object.keys(input)) {
             if (key === '$name') continue;
             const value = (input: SerializedObject)[key];
-            result[key] = registry[name].shallow.indexOf(key) >= 0 ? value : deserialize(value);
+            result[key] = deserialize(value);
         }
 
         return result;

--- a/test/unit/util/web_worker_transfer.test.js
+++ b/test/unit/util/web_worker_transfer.test.js
@@ -26,7 +26,7 @@ test('round trip', (t) => {
         }
     }
 
-    register('Foo', Foo, {omit: ['_cached']});
+    register(Foo, {omit: ['_cached']});
 
     const foo = new Foo(10);
     const transferables = [];
@@ -41,16 +41,6 @@ test('round trip', (t) => {
     t.assert(transferables[0] === foo.buffer);
     t.assert(bar._cached === undefined);
     t.assert(bar.squared() === 100);
-    t.end();
-});
-
-test('anonymous class', (t) => {
-    const Klass = (() => class {})();
-    t.assert(!Klass.name);
-    register('Anon', Klass);
-    const x = new Klass();
-    const deserialized = deserialize(serialize(x));
-    t.assert(deserialized instanceof Klass);
     t.end();
 });
 
@@ -74,7 +64,7 @@ test('custom serialization', (t) => {
         }
     }
 
-    register('Bar', Bar);
+    register(Bar);
 
     const bar = new Bar('a');
     t.assert(!bar._deserialized);


### PR DESCRIPTION
The web worker class registry `register` function previously accepted a class name, introduced in #5804. Since then, a lot has changed, including switch to ES / Rollup and dropping both IE11 & ES5 transpilation, so classes are now first-class citizen and we can rely on their `name` property. 

The class names we specified for `register` were strings scattered across the codebase that didn't get minified and no longer served any purpose. Getting rid of them (and having asserts to make sure classes have names and we register those that are transferred) lands us a free -566 bytes gzipped bundle reduction.

Note that I also removed `shallow` option which was unused since its introduction, and had to adjust Flow handling in one unrelated part of code (no idea why Flow started complaining where it was silent before, probably a bug).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

