### PR TITLE
Add missing export types to `dom.js` & `image.js`

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -57,7 +57,7 @@ class AttributionControl {
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-attrib');
         this._compactButton = DOM.create('button', 'mapboxgl-ctrl-attrib-button', this._container);
-        DOM.create('span', `mapboxgl-ctrl-icon`, this._compactButton).setAttribute('aria-hidden', true);
+        DOM.create('span', `mapboxgl-ctrl-icon`, this._compactButton).setAttribute('aria-hidden', 'true');
         this._compactButton.type = 'button';
         this._compactButton.addEventListener('click', this._toggleAttribution);
         this._setElementTitle(this._compactButton, 'ToggleAttribution');

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -80,7 +80,7 @@ class FullscreenControl {
 
     _setupUI() {
         const button = this._fullscreenButton = DOM.create('button', (`mapboxgl-ctrl-fullscreen`), this._controlContainer);
-        DOM.create('span', `mapboxgl-ctrl-icon`, button).setAttribute('aria-hidden', true);
+        DOM.create('span', `mapboxgl-ctrl-icon`, button).setAttribute('aria-hidden', 'true');
         button.type = 'button';
         this._updateTitle();
         this._fullscreenButton.addEventListener('click', this._onClickFullscreen);

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -411,7 +411,7 @@ class GeolocateControl extends Evented {
     _setupUI(supported: boolean) {
         this._container.addEventListener('contextmenu', (e: MouseEvent) => e.preventDefault());
         this._geolocateButton = DOM.create('button', `mapboxgl-ctrl-geolocate`, this._container);
-        DOM.create('span', `mapboxgl-ctrl-icon`, this._geolocateButton).setAttribute('aria-hidden', true);
+        DOM.create('span', `mapboxgl-ctrl-icon`, this._geolocateButton).setAttribute('aria-hidden', 'true');
 
         this._geolocateButton.type = 'button';
 

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -54,7 +54,7 @@ class NavigationControl {
         this.options = extend({}, defaultOptions, options);
 
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-group');
-        this._container.addEventListener('contextmenu', (e) => e.preventDefault());
+        this._container.addEventListener('contextmenu', (e: MouseEvent) => e.preventDefault());
 
         if (this.options.showZoom) {
             bindAll([
@@ -62,9 +62,9 @@ class NavigationControl {
                 '_updateZoomButtons'
             ], this);
             this._zoomInButton = this._createButton('mapboxgl-ctrl-zoom-in', (e) => { if (this._map) this._map.zoomIn({}, {originalEvent: e}); });
-            DOM.create('span', `mapboxgl-ctrl-icon`, this._zoomInButton).setAttribute('aria-hidden', true);
+            DOM.create('span', `mapboxgl-ctrl-icon`, this._zoomInButton).setAttribute('aria-hidden', 'true');
             this._zoomOutButton = this._createButton('mapboxgl-ctrl-zoom-out', (e) => { if (this._map) this._map.zoomOut({}, {originalEvent: e}); });
-            DOM.create('span', `mapboxgl-ctrl-icon`, this._zoomOutButton).setAttribute('aria-hidden', true);
+            DOM.create('span', `mapboxgl-ctrl-icon`, this._zoomOutButton).setAttribute('aria-hidden', 'true');
         }
         if (this.options.showCompass) {
             bindAll([
@@ -80,7 +80,7 @@ class NavigationControl {
                 }
             });
             this._compassIcon = DOM.create('span', 'mapboxgl-ctrl-icon', this._compass);
-            this._compassIcon.setAttribute('aria-hidden', true);
+            this._compassIcon.setAttribute('aria-hidden', 'true');
         }
     }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -589,15 +589,16 @@ export default class Popup extends Evented {
     _update(cursor?: Point) {
         const hasPosition = this._lngLat || this._trackPointer;
         const map = this._map;
+        const content = this._content;
 
-        if (!map || !hasPosition || !this._content) { return; }
+        if (!map || !hasPosition || !content) { return; }
 
         let container = this._container;
 
         if (!container) {
             container = this._container = DOM.create('div', 'mapboxgl-popup', map.getContainer());
             this._tip = DOM.create('div', 'mapboxgl-popup-tip', container);
-            container.appendChild(this._content);
+            container.appendChild(content);
         }
 
         if (this.options.maxWidth && container.style.maxWidth !== this.options.maxWidth) {

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -5,14 +5,15 @@ import Point from '@mapbox/point-geometry';
 import window from './window.js';
 import assert from 'assert';
 
-export function create(tagName: string, className: ?string, container?: HTMLElement) {
+// refine the return type based on tagName, e.g. 'button' -> HTMLButtonElement
+export function create<T: string>(tagName: T, className: ?string, container?: HTMLElement): $Call<typeof document.createElement, T> {
     const el = window.document.createElement(tagName);
     if (className !== undefined) el.className = className;
     if (container) container.appendChild(el);
     return el;
 }
 
-export function createSVG(tagName: string, attributes: {[string]: string | number}, container?: HTMLElement) {
+export function createSVG(tagName: string, attributes: {[string]: string | number}, container?: Element): Element {
     const el = window.document.createElementNS('http://www.w3.org/2000/svg', tagName);
     for (const name of Object.keys(attributes)) {
         el.setAttributeNS(null, name, attributes[name]);
@@ -52,12 +53,12 @@ export function suppressClick() {
     }, 0);
 }
 
-export function mousePos(el: HTMLElement, e: MouseEvent | WheelEvent) {
+export function mousePos(el: HTMLElement, e: MouseEvent | WheelEvent): Point {
     const rect = el.getBoundingClientRect();
     return getScaledPoint(el, rect, e);
 }
 
-export function touchPos(el: HTMLElement, touches: TouchList) {
+export function touchPos(el: HTMLElement, touches: TouchList): Array<Point> {
     const rect = el.getBoundingClientRect(),
         points = [];
 
@@ -67,7 +68,7 @@ export function touchPos(el: HTMLElement, touches: TouchList) {
     return points;
 }
 
-export function mouseButton(e: MouseEvent) {
+export function mouseButton(e: MouseEvent): number {
     assert(e.type === 'mousedown' || e.type === 'mouseup');
     if (typeof window.InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey &&
         window.navigator.platform.toUpperCase().indexOf('MAC') >= 0) {

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -98,7 +98,7 @@ export class AlphaImage {
         resizeImage(this, new AlphaImage(size), 1);
     }
 
-    clone() {
+    clone(): AlphaImage {
         return new AlphaImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }
 
@@ -135,7 +135,7 @@ export class RGBAImage {
         }
     }
 
-    clone() {
+    clone(): RGBAImage {
         return new RGBAImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }
 


### PR DESCRIPTION
A part of #11426. Adds missing export types to `dom.js` and `image.js`, and fixes new corresponding errors. One interesting bit here is how `DOM.create` is typed — using generics, `typeof` and `$Call` to refine the return type to a specific HTML element like `HTMLButtonElement`, `HTMLCanvasElement` etc. (using just `HTMLElement` produced a lot of errors due to element-specific attributes like `button.type`).