### PR TITLE
[Flow] Add missing export types to style-spec util

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -52,6 +52,7 @@
 [options]
 server.max_workers=4
 types_first=false
+merge_timeout=180
 
 [strict]
 nonstrict-import

--- a/src/style-spec/deref.js
+++ b/src/style-spec/deref.js
@@ -15,7 +15,7 @@ function deref(layer: LayerSpecification, parent: LayerSpecification): LayerSpec
 
     refProperties.forEach((k) => {
         if (k in parent) {
-            result[k] = parent[k];
+            result[k] = (parent: any)[k];
         }
     });
 

--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -5,8 +5,7 @@ import type {LayerSpecification} from './types.js';
 import refProperties from './util/ref_properties.js';
 
 function stringify(obj) {
-    const type = typeof obj;
-    if (type === 'number' || type === 'boolean' || type === 'string' || obj === undefined || obj === null)
+    if (typeof obj === 'number' || typeof obj === 'boolean' || typeof obj === 'string' || obj === undefined || obj === null)
         return JSON.stringify(obj);
 
     if (Array.isArray(obj)) {
@@ -17,11 +16,9 @@ function stringify(obj) {
         return `${str}]`;
     }
 
-    const keys = Object.keys(obj).sort();
-
     let str = '{';
-    for (let i = 0; i < keys.length; i++) {
-        str += `${JSON.stringify(keys[i])}:${stringify(obj[keys[i]])},`;
+    for (const key of Object.keys(obj).sort()) {
+        str += `${key}:${stringify((obj: any)[key])},`;
     }
     return `${str}}`;
 }
@@ -29,7 +26,7 @@ function stringify(obj) {
 function getKey(layer) {
     let key = '';
     for (const k of refProperties) {
-        key += `/${stringify(layer[k])}`;
+        key += `/${stringify((layer: any)[k])}`;
     }
     return key;
 }

--- a/src/style-spec/util/color_spaces.js
+++ b/src/style-spec/util/color_spaces.js
@@ -79,7 +79,7 @@ function labToRgb(labColor: LABColor): Color {
     );
 }
 
-function interpolateLab(from: LABColor, to: LABColor, t: number) {
+function interpolateLab(from: LABColor, to: LABColor, t: number): LABColor {
     return {
         l: interpolateNumber(from.l, to.l, t),
         a: interpolateNumber(from.a, to.a, t),
@@ -117,7 +117,7 @@ function interpolateHue(a: number, b: number, t: number) {
     return a + t * (d > 180 || d < -180 ? d - 360 * Math.round(d / 360) : d);
 }
 
-function interpolateHcl(from: HCLColor, to: HCLColor, t: number) {
+function interpolateHcl(from: HCLColor, to: HCLColor, t: number): HCLColor {
     return {
         h: interpolateHue(from.h, to.h, t),
         c: interpolateNumber(from.c, to.c, t),

--- a/src/style-spec/util/extend.js
+++ b/src/style-spec/util/extend.js
@@ -1,6 +1,6 @@
 // @flow
 
-export default function (output: any, ...inputs: Array<any>) {
+export default function (output: any, ...inputs: Array<any>): any {
     for (const input of inputs) {
         for (const k in input) {
             output[k] = input[k];

--- a/src/style-spec/util/interpolate.js
+++ b/src/style-spec/util/interpolate.js
@@ -2,11 +2,11 @@
 
 import Color from './color.js';
 
-export function number(a: number, b: number, t: number) {
+export function number(a: number, b: number, t: number): number {
     return (a * (1 - t)) + (b * t);
 }
 
-export function color(from: Color, to: Color, t: number) {
+export function color(from: Color, to: Color, t: number): Color {
     return new Color(
         number(from.r, to.r, t),
         number(from.g, to.g, t),

--- a/src/style-spec/util/ref_properties.js
+++ b/src/style-spec/util/ref_properties.js
@@ -1,2 +1,2 @@
-
+// @flow
 export default ['type', 'source', 'source-layer', 'minzoom', 'maxzoom', 'filter', 'layout'];

--- a/src/style-spec/util/unbundle_jsonlint.js
+++ b/src/style-spec/util/unbundle_jsonlint.js
@@ -1,7 +1,7 @@
 // @flow
 
 // Turn jsonlint-lines-primitives objects into primitive objects
-export function unbundle(value: mixed) {
+export function unbundle(value: mixed): mixed {
     if (value instanceof Number || value instanceof String || value instanceof Boolean) {
         return value.valueOf();
     } else {


### PR DESCRIPTION
A part of #11426. Adds missing export types to `style-spec/util/*`. Also adds a `merge_timeout` option to Flow config to temporarily fix flaky flow builds in recent days (until we switch to type-first mode).