### PR TITLE
WIP Globe edge antialiasing

### DIFF
--- a/src/shaders/globe_atmosphere.vertex.glsl
+++ b/src/shaders/globe_atmosphere.vertex.glsl
@@ -6,6 +6,8 @@ uniform vec3 u_frustum_tl;
 uniform vec3 u_frustum_tr;
 uniform vec3 u_frustum_br;
 uniform vec3 u_frustum_bl;
+uniform highp vec3 u_globe_pos;
+uniform highp float u_globe_radius;
 
 varying vec3 v_ray_dir;
 

--- a/src/shaders/globe_raster.fragment.glsl
+++ b/src/shaders/globe_raster.fragment.glsl
@@ -1,8 +1,34 @@
 uniform sampler2D u_image0;
 varying vec2 v_pos0;
 
+uniform vec3 u_frustum_tl;
+uniform vec3 u_frustum_tr;
+uniform vec3 u_frustum_br;
+uniform vec3 u_frustum_bl;
+uniform highp vec3 u_globe_pos;
+uniform highp float u_globe_radius;
+
+uniform vec2 u_viewport;
+
 void main() {
-    gl_FragColor = texture2D(u_image0, v_pos0);
+    vec2 uv = gl_FragCoord.xy / u_viewport;
+
+    vec3 ray_dir = mix(
+        mix(u_frustum_tl, u_frustum_tr, uv.x),
+        mix(u_frustum_bl, u_frustum_br, uv.x),
+        1.0 - uv.y);
+
+    vec3 dir = normalize(ray_dir);
+
+    vec3 closest_point = dot(u_globe_pos, dir) * dir;
+    float norm_dist_from_center = 1.0 - length(closest_point - u_globe_pos) / u_globe_radius;
+
+    const float antialias_distance_px = 4.0;
+    float antialias = smoothstep(0.0, antialias_distance_px / max(u_viewport.x, u_viewport.y), norm_dist_from_center);
+
+    vec4 raster = texture2D(u_image0, v_pos0);
+
+    gl_FragColor = vec4(raster.rgb * antialias, raster.a * antialias);
 #ifdef TERRAIN_WIREFRAME
     gl_FragColor = vec4(1.0, 0.0, 0.0, 0.8);
 #endif

--- a/src/terrain/globe_raster_program.js
+++ b/src/terrain/globe_raster_program.js
@@ -17,7 +17,14 @@ export type GlobeRasterUniformsType = {|
     'u_merc_matrix': UniformMatrix4f,
     'u_zoom_transition': Uniform1f,
     'u_merc_center': Uniform2f,
-    'u_image0': Uniform1i
+    'u_image0': Uniform1i,
+    'u_frustum_tl': Uniform3f,
+    'u_frustum_tr': Uniform3f,
+    'u_frustum_br': Uniform3f,
+    'u_frustum_bl': Uniform3f,
+    'u_globe_pos': Uniform3f,
+    'u_globe_radius': Uniform1f,
+    'u_viewport': Uniform2f,
 |};
 
 export type AtmosphereUniformsType = {|
@@ -39,7 +46,14 @@ const globeRasterUniforms = (context: Context, locations: UniformLocations): Glo
     'u_merc_matrix': new UniformMatrix4f(context, locations.u_merc_matrix),
     'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
     'u_merc_center': new Uniform2f(context, locations.u_merc_center),
-    'u_image0': new Uniform1i(context, locations.u_image0)
+    'u_image0': new Uniform1i(context, locations.u_image0),
+    'u_frustum_tl': new Uniform3f(context, locations.u_frustum_tl),
+    'u_frustum_tr': new Uniform3f(context, locations.u_frustum_tr),
+    'u_frustum_br': new Uniform3f(context, locations.u_frustum_br),
+    'u_frustum_bl': new Uniform3f(context, locations.u_frustum_bl),
+    'u_globe_pos': new Uniform3f(context, locations.u_globe_pos),
+    'u_globe_radius': new Uniform1f(context, locations.u_globe_radius),
+    'u_viewport': new Uniform2f(context, locations.u_viewport)
 });
 
 const atmosphereUniforms = (context: Context, locations: UniformLocations): AtmosphereUniformsType => ({
@@ -60,14 +74,28 @@ const globeRasterUniformValues = (
     globeMatrix: Float32Array,
     globeMercatorMatrix: Float32Array,
     zoomTransition: number,
-    mercCenter: [number, number]
+    mercCenter: [number, number],
+    frustumDirTl: [number, number, number],
+    frustumDirTr: [number, number, number],
+    frustumDirBr: [number, number, number],
+    frustumDirBl: [number, number, number],
+    globePosition: [number, number, number],
+    globeRadius: number,
+    viewport: [number, number]
 ): UniformValues<GlobeRasterUniformsType> => ({
     'u_proj_matrix': Float32Array.from(projMatrix),
     'u_globe_matrix': globeMatrix,
     'u_merc_matrix': globeMercatorMatrix,
     'u_zoom_transition': zoomTransition,
     'u_merc_center': mercCenter,
-    'u_image0': 0
+    'u_image0': 0,
+    'u_frustum_tl': frustumDirTl,
+    'u_frustum_tr': frustumDirTr,
+    'u_frustum_br': frustumDirBr,
+    'u_frustum_bl': frustumDirBl,
+    'u_globe_pos': globePosition,
+    'u_globe_radius': globeRadius,
+    'u_viewport': viewport,
 });
 
 const atmosphereUniformValues = (


### PR DESCRIPTION
A draft PR/PoC to introduce antialiasing at the edges of the globe geometry. Globe suffers a similar issue to https://github.com/mapbox/mapbox-gl-js/issues/11164, when not using aa from gl context. This can be resolved by slightly smoothing the edges of the globe with custom antialiasing by using the sphere of the view space globe sphere geometry as a small distance field.

**After / Before**

![Screenshot from 2022-02-17 11-43-17](https://user-images.githubusercontent.com/7061573/154559253-b9412ce3-6994-49c9-904d-d42de5bf827f.png)

![ezgif-7-f917ac4818](https://user-images.githubusercontent.com/7061573/154559280-616ea95e-e0f5-4fad-833a-db4081ccdf8d.gif)
