### PR TITLE
[Flow] Add missing export types to `src/style-spec/validate/*`

### DIFF
--- a/src/style-spec/.eslintrc
+++ b/src/style-spec/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": ["rollup.config.js", "test.js"],
+      "rules": {
+        "flowtype/require-valid-file-annotation": "off"
+      }
+    }
+  ]
+}

--- a/src/style-spec/bin/gl-style-composite.js
+++ b/src/style-spec/bin/gl-style-composite.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
+
+// @flow
 /* eslint-disable no-process-exit */
-/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
 
 import fs from 'fs';
 import minimist from 'minimist';
+
+/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
+/* $FlowFixMe[cannot-resolve-module] */
 import {format, composite} from '@mapbox/mapbox-gl-style-spec';
 
 const argv = minimist(process.argv.slice(2));
@@ -13,7 +17,7 @@ if (argv.help || argv.h || (!argv._.length && process.stdin.isTTY)) {
     process.exit(0);
 }
 
-console.log(format(composite(JSON.parse(fs.readFileSync(argv._[0])))));
+console.log(format(composite(JSON.parse(fs.readFileSync(argv._[0]).toString()))));
 
 function help() {
     console.log('usage:');

--- a/src/style-spec/bin/gl-style-format.js
+++ b/src/style-spec/bin/gl-style-format.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
+
+// @flow
 /* eslint-disable no-process-exit */
-/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
 
 import fs from 'fs';
 import minimist from 'minimist';
+
+/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
+/* $FlowFixMe[cannot-resolve-module] */
 import {format} from '@mapbox/mapbox-gl-style-spec';
 
 const argv = minimist(process.argv.slice(2));
@@ -13,7 +17,7 @@ if (argv.help || argv.h || (!argv._.length && process.stdin.isTTY)) {
     process.exit(0);
 }
 
-console.log(format(JSON.parse(fs.readFileSync(argv._[0])), argv.space));
+console.log(format(JSON.parse(fs.readFileSync(argv._[0]).toString()), argv.space));
 
 function help() {
     console.log('usage:');

--- a/src/style-spec/bin/gl-style-migrate.js
+++ b/src/style-spec/bin/gl-style-migrate.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
+
+// @flow
 /* eslint-disable no-process-exit */
-/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
 
 import fs from 'fs';
 import minimist from 'minimist';
+
+/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
+/* $FlowFixMe[cannot-resolve-module] */
 import {format, migrate} from '@mapbox/mapbox-gl-style-spec';
 
 const argv = minimist(process.argv.slice(2));
@@ -13,7 +17,7 @@ if (argv.help || argv.h || (!argv._.length && process.stdin.isTTY)) {
     process.exit(0);
 }
 
-console.log(format(migrate(JSON.parse(fs.readFileSync(argv._[0])))));
+console.log(format(migrate(JSON.parse(fs.readFileSync(argv._[0]).toString()))));
 
 function help() {
     console.log('usage:');

--- a/src/style-spec/bin/gl-style-validate.js
+++ b/src/style-spec/bin/gl-style-validate.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
+
+// @flow
 /* eslint-disable no-process-exit */
-/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
 
 import rw from 'rw';
 import minimist from 'minimist';
+
+/* eslint import/no-unresolved: [error, { ignore: ['^@mapbox/mapbox-gl-style-spec$'] }] */
+/* $FlowFixMe[cannot-resolve-module] */
 import {validate, validateMapboxApiSupported} from '@mapbox/mapbox-gl-style-spec';
 
 const argv = minimist(process.argv.slice(2), {

--- a/src/style-spec/reference/latest.js
+++ b/src/style-spec/reference/latest.js
@@ -1,3 +1,7 @@
+// @flow
 
 import spec from './v8.json';
+
+export type StyleReference = typeof spec;
+
 export default spec;

--- a/src/style-spec/validate/validate.js
+++ b/src/style-spec/validate/validate.js
@@ -1,3 +1,6 @@
+// @flow
+
+import latestStyleSpec from '../reference/latest.js';
 
 import extend from '../util/extend.js';
 import {unbundle, deepUnbundle} from '../util/unbundle_jsonlint.js';
@@ -22,6 +25,8 @@ import validateString from './validate_string.js';
 import validateFormatted from './validate_formatted.js';
 import validateImage from './validate_image.js';
 import validateProjection from './validate_projection.js';
+
+import type {StyleSpecification} from '../types.js';
 
 const VALIDATORS = {
     '*'() {
@@ -55,8 +60,15 @@ const VALIDATORS = {
 //   scalar value.
 // - valueSpec: current spec being evaluated. Tracks value.
 // - styleSpec: current full spec being evaluated.
+export type ValidationOptions = {
+    key: string;
+    value: any;
+    style: $Shape<StyleSpecification>;
+    valueSpec: any;
+    styleSpec: $Shape<typeof latestStyleSpec>;
+}
 
-export default function validate(options) {
+export default function validate(options: ValidationOptions) {
     const value = options.value;
     const valueSpec = options.valueSpec;
     const styleSpec = options.styleSpec;

--- a/src/style-spec/validate/validate.js
+++ b/src/style-spec/validate/validate.js
@@ -1,7 +1,5 @@
 // @flow
 
-import latestStyleSpec from '../reference/latest.js';
-
 import extend from '../util/extend.js';
 import {unbundle, deepUnbundle} from '../util/unbundle_jsonlint.js';
 import {isExpression} from '../expression/index.js';
@@ -26,6 +24,7 @@ import validateFormatted from './validate_formatted.js';
 import validateImage from './validate_image.js';
 import validateProjection from './validate_projection.js';
 
+import type {StyleReference} from '../reference/latest.js';
 import type {StyleSpecification} from '../types.js';
 
 const VALIDATORS = {
@@ -62,10 +61,10 @@ const VALIDATORS = {
 // - styleSpec: current full spec being evaluated.
 export type ValidationOptions = {
     key: string;
-    value: any;
+    value: Object;
+    valueSpec: Object;
     style: $Shape<StyleSpecification>;
-    valueSpec: any;
-    styleSpec: $Shape<typeof latestStyleSpec>;
+    styleSpec: StyleReference;
 }
 
 export default function validate(options: ValidationOptions) {

--- a/src/style-spec/validate/validate_array.js
+++ b/src/style-spec/validate/validate_array.js
@@ -1,9 +1,16 @@
+// @flow
 
 import getType from '../util/get_type.js';
 import validate from './validate.js';
 import ValidationError from '../error/validation_error.js';
 
-export default function validateArray(options) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    arrayElementValidator: Function;
+};
+
+export default function validateArray(options: Options): Array<ValidationError> {
     const array = options.value;
     const arraySpec = options.valueSpec;
     const style = options.style;
@@ -27,7 +34,8 @@ export default function validateArray(options) {
         "type": arraySpec.value,
         "values": arraySpec.values,
         "minimum": arraySpec.minimum,
-        "maximum": arraySpec.maximum
+        "maximum": arraySpec.maximum,
+        function: undefined
     };
 
     if (styleSpec.$version < 7) {

--- a/src/style-spec/validate/validate_boolean.js
+++ b/src/style-spec/validate/validate_boolean.js
@@ -1,8 +1,11 @@
+// @flow
 
 import getType from '../util/get_type.js';
 import ValidationError from '../error/validation_error.js';
 
-export default function validateBoolean(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateBoolean(options: ValidationOptions): Array<ValidationError> {
     const value = options.value;
     const key = options.key;
     const type = getType(value);

--- a/src/style-spec/validate/validate_color.js
+++ b/src/style-spec/validate/validate_color.js
@@ -1,9 +1,12 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import getType from '../util/get_type.js';
 import {parseCSSColor} from 'csscolorparser';
 
-export default function validateColor(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateColor(options: ValidationOptions): Array<ValidationError> {
     const key = options.key;
     const value = options.value;
     const type = getType(value);

--- a/src/style-spec/validate/validate_enum.js
+++ b/src/style-spec/validate/validate_enum.js
@@ -1,8 +1,11 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import {unbundle} from '../util/unbundle_jsonlint.js';
 
-export default function validateEnum(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateEnum(options: ValidationOptions): Array<ValidationError> {
     const key = options.key;
     const value = options.value;
     const valueSpec = options.valueSpec;

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -1,3 +1,4 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import validateExpression from './validate_expression.js';
@@ -7,7 +8,13 @@ import {unbundle, deepUnbundle} from '../util/unbundle_jsonlint.js';
 import extend from '../util/extend.js';
 import {isExpressionFilter} from '../feature_filter/index.js';
 
-export default function validateFilter(options) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    layerType: string;
+}
+
+export default function validateFilter(options: Options): Array<ValidationError> {
     if (isExpressionFilter(deepUnbundle(options.value))) {
         const layerType = deepUnbundle(options.layerType);
         return validateExpression(extend({}, options, {

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -17,16 +17,10 @@ type Options = ValidationOptions & {
 export default function validateFilter(options: Options): Array<ValidationError> {
     if (isExpressionFilter(deepUnbundle(options.value))) {
         const layerType = deepUnbundle(options.layerType);
-        if (typeof layerType !== 'string') {
-            const key = options.key;
-            const value = options.value;
-            return [new ValidationError(key, value, `layer type must be a string`)];
-        }
-
         return validateExpression(extend({}, options, {
             expressionContext: 'filter',
             // We default to a layerType of `fill` because that points to a non-dynamic filter definition within the style-spec.
-            valueSpec: options.styleSpec[`filter_${layerType || 'fill'}`]
+            valueSpec: options.styleSpec[`filter_${layerType ? String(layerType) : 'fill'}`]
         }));
     } else {
         return validateNonExpressionFilter(options);

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -17,6 +17,12 @@ type Options = ValidationOptions & {
 export default function validateFilter(options: Options): Array<ValidationError> {
     if (isExpressionFilter(deepUnbundle(options.value))) {
         const layerType = deepUnbundle(options.layerType);
+        if (typeof layerType !== 'string') {
+            const key = options.key;
+            const value = options.value;
+            return [new ValidationError(key, value, `layer type must be a string`)];
+        }
+
         return validateExpression(extend({}, options, {
             expressionContext: 'filter',
             // We default to a layerType of `fill` because that points to a non-dynamic filter definition within the style-spec.

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -16,11 +16,12 @@ type Options = ValidationOptions & {
 
 export default function validateFilter(options: Options): Array<ValidationError> {
     if (isExpressionFilter(deepUnbundle(options.value))) {
-        const layerType = deepUnbundle(options.layerType);
+        // We default to a layerType of `fill` because that points to a non-dynamic filter definition within the style-spec.
+        const layerType = options.layerType || 'fill';
+
         return validateExpression(extend({}, options, {
             expressionContext: 'filter',
-            // We default to a layerType of `fill` because that points to a non-dynamic filter definition within the style-spec.
-            valueSpec: options.styleSpec[`filter_${layerType ? String(layerType) : 'fill'}`]
+            valueSpec: options.styleSpec[`filter_${layerType}`]
         }));
     } else {
         return validateNonExpressionFilter(options);

--- a/src/style-spec/validate/validate_fog.js
+++ b/src/style-spec/validate/validate_fog.js
@@ -1,9 +1,12 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import validate from './validate.js';
 import getType from '../util/get_type.js';
 
-export default function validateFog(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateFog(options: ValidationOptions): Array<ValidationError> {
     const fog = options.value;
     const style = options.style;
     const styleSpec = options.styleSpec;

--- a/src/style-spec/validate/validate_formatted.js
+++ b/src/style-spec/validate/validate_formatted.js
@@ -1,8 +1,12 @@
 // @flow
+
+import ValidationError from '../error/validation_error.js';
 import validateExpression from './validate_expression.js';
 import validateString from './validate_string.js';
 
-export default function validateFormatted(options: any) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateFormatted(options: ValidationOptions): Array<ValidationError> {
     if (validateString(options).length === 0) {
         return [];
     }

--- a/src/style-spec/validate/validate_formatted.js
+++ b/src/style-spec/validate/validate_formatted.js
@@ -1,10 +1,10 @@
 // @flow
 
-import ValidationError from '../error/validation_error.js';
 import validateExpression from './validate_expression.js';
 import validateString from './validate_string.js';
 
 import type {ValidationOptions} from './validate.js';
+import type ValidationError from '../error/validation_error.js';
 
 export default function validateFormatted(options: ValidationOptions): Array<ValidationError> {
     if (validateString(options).length === 0) {

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -1,3 +1,4 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import getType from '../util/get_type.js';
@@ -13,7 +14,9 @@ import {
     supportsInterpolation
 } from '../util/properties.js';
 
-export default function validateFunction(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateFunction(options: ValidationOptions): any {
     const functionValueSpec = options.valueSpec;
     const functionType = unbundle(options.value.type);
     let stopKeyType;

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -119,7 +119,7 @@ export default function validateFunction(options: ValidationOptions): any {
 
             const nextStopDomainZoom = unbundle(value[0].zoom);
             if (typeof nextStopDomainZoom !== 'number') {
-                return [new ValidationError(key, value, 'stop zoom values must be numbers')];
+                return [new ValidationError(key, value[0].zoom, 'stop zoom values must be numbers')];
             }
 
             if (previousStopDomainZoom && previousStopDomainZoom > nextStopDomainZoom) {

--- a/src/style-spec/validate/validate_glyphs_url.js
+++ b/src/style-spec/validate/validate_glyphs_url.js
@@ -1,8 +1,11 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import validateString from './validate_string.js';
 
-export default function(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function(options: ValidationOptions): Array<ValidationError> {
     const value = options.value;
     const key = options.key;
 

--- a/src/style-spec/validate/validate_image.js
+++ b/src/style-spec/validate/validate_image.js
@@ -1,8 +1,12 @@
 // @flow
+
+import ValidationError from '../error/validation_error.js';
 import validateExpression from './validate_expression.js';
 import validateString from './validate_string.js';
 
-export default function validateImage(options: any) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateImage(options: ValidationOptions): Array<ValidationError> {
     if (validateString(options).length === 0) {
         return [];
     }

--- a/src/style-spec/validate/validate_image.js
+++ b/src/style-spec/validate/validate_image.js
@@ -1,10 +1,10 @@
 // @flow
 
-import ValidationError from '../error/validation_error.js';
 import validateExpression from './validate_expression.js';
 import validateString from './validate_string.js';
 
 import type {ValidationOptions} from './validate.js';
+import type ValidationError from '../error/validation_error.js';
 
 export default function validateImage(options: ValidationOptions): Array<ValidationError> {
     if (validateString(options).length === 0) {

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -1,3 +1,4 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import {unbundle} from '../util/unbundle_jsonlint.js';
@@ -8,7 +9,15 @@ import validateLayoutProperty from './validate_layout_property.js';
 import validateSpec from './validate.js';
 import extend from '../util/extend.js';
 
-export default function validateLayer(options) {
+import type {ValidationOptions} from './validate.js';
+import type {LayerSpecification} from '../types.js';
+
+type Options = ValidationOptions & {
+    value: LayerSpecification;
+    arrayIndex: number;
+}
+
+export default function validateLayer(options: Options): Array<ValidationError> {
     let errors = [];
 
     const layer = options.value;

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -36,6 +36,7 @@ export default function validateLayer(options: Options): Array<ValidationError> 
         for (let i = 0; i < options.arrayIndex; i++) {
             const otherLayer = style.layers[i];
             if (unbundle(otherLayer.id) === layerId) {
+                // $FlowFixMe[prop-missing] - id.__line__ is added dynamically during the readStyle step
                 errors.push(new ValidationError(key, layer.id, `duplicate layer id "${layer.id}", previously used at line ${otherLayer.id.__line__}`));
             }
         }
@@ -55,7 +56,8 @@ export default function validateLayer(options: Options): Array<ValidationError> 
         });
 
         if (!parent) {
-            errors.push(new ValidationError(key, layer.ref, `ref layer "${ref}" not found`));
+            if (typeof ref === 'string')
+                errors.push(new ValidationError(key, layer.ref, `ref layer "${ref}" not found`));
         } else if (parent.ref) {
             errors.push(new ValidationError(key, layer.ref, 'ref cannot reference another ref layer'));
         } else {
@@ -115,6 +117,7 @@ export default function validateLayer(options: Options): Array<ValidationError> 
                     layer,
                     key: options.key,
                     value: options.value,
+                    valueSpec: {},
                     style: options.style,
                     styleSpec: options.styleSpec,
                     objectElementValidators: {
@@ -129,6 +132,7 @@ export default function validateLayer(options: Options): Array<ValidationError> 
                     layer,
                     key: options.key,
                     value: options.value,
+                    valueSpec: {},
                     style: options.style,
                     styleSpec: options.styleSpec,
                     objectElementValidators: {

--- a/src/style-spec/validate/validate_layout_property.js
+++ b/src/style-spec/validate/validate_layout_property.js
@@ -1,6 +1,15 @@
+// @flow
 
+import ValidationError from '../error/validation_error.js';
 import validateProperty from './validate_property.js';
 
-export default function validateLayoutProperty(options) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    objectKey: string;
+    layerType: string;
+}
+
+export default function validateLayoutProperty(options: Options): Array<ValidationError> {
     return validateProperty(options, 'layout');
 }

--- a/src/style-spec/validate/validate_layout_property.js
+++ b/src/style-spec/validate/validate_layout_property.js
@@ -1,9 +1,9 @@
 // @flow
 
-import ValidationError from '../error/validation_error.js';
 import validateProperty from './validate_property.js';
 
 import type {ValidationOptions} from './validate.js';
+import type ValidationError from '../error/validation_error.js';
 
 type Options = ValidationOptions & {
     objectKey: string;

--- a/src/style-spec/validate/validate_layout_property.js
+++ b/src/style-spec/validate/validate_layout_property.js
@@ -2,14 +2,9 @@
 
 import validateProperty from './validate_property.js';
 
-import type {ValidationOptions} from './validate.js';
 import type ValidationError from '../error/validation_error.js';
+import type {PropertyValidationOptions} from './validate_property.js';
 
-type Options = ValidationOptions & {
-    objectKey: string;
-    layerType: string;
-}
-
-export default function validateLayoutProperty(options: Options): Array<ValidationError> {
+export default function validateLayoutProperty(options: PropertyValidationOptions): Array<ValidationError> {
     return validateProperty(options, 'layout');
 }

--- a/src/style-spec/validate/validate_light.js
+++ b/src/style-spec/validate/validate_light.js
@@ -1,9 +1,12 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import getType from '../util/get_type.js';
 import validate from './validate.js';
 
-export default function validateLight(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateLight(options: ValidationOptions): Array<ValidationError> {
     const light = options.value;
     const styleSpec = options.styleSpec;
     const lightSpec = styleSpec.light;

--- a/src/style-spec/validate/validate_number.js
+++ b/src/style-spec/validate/validate_number.js
@@ -1,8 +1,15 @@
+// @flow
 
 import getType from '../util/get_type.js';
 import ValidationError from '../error/validation_error.js';
 
-export default function validateNumber(options) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    arrayIndex: number;
+}
+
+export default function validateNumber(options: Options): Array<ValidationError> {
     const key = options.key;
     const value = options.value;
     const valueSpec = options.valueSpec;

--- a/src/style-spec/validate/validate_object.js
+++ b/src/style-spec/validate/validate_object.js
@@ -1,9 +1,17 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import getType from '../util/get_type.js';
 import validateSpec from './validate.js';
 
-export default function validateObject(options) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    valueSpec?: any;
+    objectElementValidators?: Function;
+}
+
+export default function validateObject(options: Options): Array<ValidationError> {
     const key = options.key;
     const object = options.value;
     const elementSpecs = options.valueSpec || {};

--- a/src/style-spec/validate/validate_object.js
+++ b/src/style-spec/validate/validate_object.js
@@ -7,9 +7,8 @@ import validateSpec from './validate.js';
 import type {ValidationOptions} from './validate.js';
 
 type Options = ValidationOptions & {
-    valueSpec?: any;
     objectElementValidators?: Function;
-}
+};
 
 export default function validateObject(options: Options): Array<ValidationError> {
     const key = options.key;
@@ -43,6 +42,8 @@ export default function validateObject(options: Options): Array<ValidationError>
             continue;
         }
 
+        if (!validateElement) continue;
+
         errors = errors.concat(validateElement({
             key: (key ? `${key}.` : key) + objectKey,
             value: object[objectKey],
@@ -51,6 +52,7 @@ export default function validateObject(options: Options): Array<ValidationError>
             styleSpec,
             object,
             objectKey
+        // $FlowFixMe[extra-arg]
         }, object));
     }
 

--- a/src/style-spec/validate/validate_object.js
+++ b/src/style-spec/validate/validate_object.js
@@ -37,12 +37,12 @@ export default function validateObject(options: Options): Array<ValidationError>
             validateElement = elementValidators['*'];
         } else if (elementSpecs['*']) {
             validateElement = validateSpec;
-        } else {
+        }
+
+        if (!validateElement) {
             errors.push(new ValidationError(key, object[objectKey], `unknown property "${objectKey}"`));
             continue;
         }
-
-        if (!validateElement) continue;
 
         errors = errors.concat(validateElement({
             key: (key ? `${key}.` : key) + objectKey,

--- a/src/style-spec/validate/validate_paint_property.js
+++ b/src/style-spec/validate/validate_paint_property.js
@@ -1,6 +1,15 @@
+// @flow
 
+import ValidationError from '../error/validation_error.js';
 import validateProperty from './validate_property.js';
 
-export default function validatePaintProperty(options) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    objectKey: string;
+    layerType: string;
+}
+
+export default function validatePaintProperty(options: Options): Array<ValidationError> {
     return validateProperty(options, 'paint');
 }

--- a/src/style-spec/validate/validate_paint_property.js
+++ b/src/style-spec/validate/validate_paint_property.js
@@ -1,9 +1,9 @@
 // @flow
 
-import ValidationError from '../error/validation_error.js';
 import validateProperty from './validate_property.js';
 
 import type {ValidationOptions} from './validate.js';
+import type ValidationError from '../error/validation_error.js';
 
 type Options = ValidationOptions & {
     objectKey: string;

--- a/src/style-spec/validate/validate_paint_property.js
+++ b/src/style-spec/validate/validate_paint_property.js
@@ -2,14 +2,9 @@
 
 import validateProperty from './validate_property.js';
 
-import type {ValidationOptions} from './validate.js';
 import type ValidationError from '../error/validation_error.js';
+import type {PropertyValidationOptions} from './validate_property.js';
 
-type Options = ValidationOptions & {
-    objectKey: string;
-    layerType: string;
-}
-
-export default function validatePaintProperty(options: Options): Array<ValidationError> {
+export default function validatePaintProperty(options: PropertyValidationOptions): Array<ValidationError> {
     return validateProperty(options, 'paint');
 }

--- a/src/style-spec/validate/validate_projection.js
+++ b/src/style-spec/validate/validate_projection.js
@@ -1,8 +1,12 @@
+// @flow
+
 import ValidationError from '../error/validation_error.js';
 import getType from '../util/get_type.js';
 import validate from './validate.js';
 
-export default function validateProjection(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateProjection(options: ValidationOptions): Array<ValidationError> {
     const projection = options.value;
     const styleSpec = options.styleSpec;
     const projectionSpec = styleSpec.projection;

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -1,3 +1,4 @@
+// @flow
 
 import validate from './validate.js';
 import ValidationError from '../error/validation_error.js';
@@ -6,7 +7,14 @@ import {isFunction} from '../function/index.js';
 import {unbundle, deepUnbundle} from '../util/unbundle_jsonlint.js';
 import {supportsPropertyExpression} from '../util/properties.js';
 
-export default function validateProperty(options, propertyType) {
+import type {ValidationOptions} from './validate.js';
+
+type Options = ValidationOptions & {
+    objectKey: string;
+    layerType: string;
+}
+
+export default function validateProperty(options: Options, propertyType: string): Array<ValidationError> {
     const key = options.key;
     const style = options.style;
     const styleSpec = options.styleSpec;

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -9,12 +9,12 @@ import {supportsPropertyExpression} from '../util/properties.js';
 
 import type {ValidationOptions} from './validate.js';
 
-type Options = ValidationOptions & {
+export type PropertyValidationOptions = ValidationOptions & {
     objectKey: string;
     layerType: string;
 }
 
-export default function validateProperty(options: Options, propertyType: string): Array<ValidationError> {
+export default function validateProperty(options: PropertyValidationOptions, propertyType: string): Array<ValidationError> {
     const key = options.key;
     const style = options.style;
     const styleSpec = options.styleSpec;

--- a/src/style-spec/validate/validate_source.js
+++ b/src/style-spec/validate/validate_source.js
@@ -1,3 +1,4 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import {unbundle} from '../util/unbundle_jsonlint.js';
@@ -7,11 +8,13 @@ import validateExpression from './validate_expression.js';
 import validateString from './validate_string.js';
 import getType from '../util/get_type.js';
 
+import type {ValidationOptions} from './validate.js';
+
 const objectElementValidators = {
     promoteId: validatePromoteId
 };
 
-export default function validateSource(options) {
+export default function validateSource(options: ValidationOptions): Array<ValidationError> {
     const value = options.value;
     const key = options.key;
     const styleSpec = options.styleSpec;

--- a/src/style-spec/validate/validate_string.js
+++ b/src/style-spec/validate/validate_string.js
@@ -1,8 +1,11 @@
+// @flow
 
 import getType from '../util/get_type.js';
 import ValidationError from '../error/validation_error.js';
 
-export default function validateString(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateString(options: $Shape<ValidationOptions>): Array<ValidationError> {
     const value = options.value;
     const key = options.key;
     const type = getType(value);

--- a/src/style-spec/validate/validate_terrain.js
+++ b/src/style-spec/validate/validate_terrain.js
@@ -1,10 +1,13 @@
+// @flow
 
 import ValidationError from '../error/validation_error.js';
 import validate from './validate.js';
 import getType from '../util/get_type.js';
 import {unbundle} from '../util/unbundle_jsonlint.js';
 
-export default function validateTerrain(options) {
+import type {ValidationOptions} from './validate.js';
+
+export default function validateTerrain(options: ValidationOptions): Array<ValidationError> {
     const terrain = options.value;
     const key = options.key;
     const style = options.style;

--- a/src/style-spec/validate/validate_terrain.js
+++ b/src/style-spec/validate/validate_terrain.js
@@ -55,7 +55,7 @@ export default function validateTerrain(options: ValidationOptions): Array<Valid
         if (!source) {
             errors.push(new ValidationError(key, terrain.source, `source "${terrain.source}" not found`));
         } else if (sourceType !== 'raster-dem') {
-            errors.push(new ValidationError(key, terrain.source, `terrain cannot be used with a source of type ${sourceType}, it only be used with a "raster-dem" source type`));
+            errors.push(new ValidationError(key, terrain.source, `terrain cannot be used with a source of type ${String(sourceType)}, it only be used with a "raster-dem" source type`));
         }
     }
 

--- a/src/style-spec/validate_style.min.js
+++ b/src/style-spec/validate_style.min.js
@@ -63,5 +63,5 @@ export const validatePaintProperty: Validator = opts => sortErrors(_validatePain
 export const validateLayoutProperty: Validator = opts => sortErrors(_validateLayoutProperty(opts));
 
 function sortErrors(errors) {
-    return errors.slice().sort((a, b) => a.line - b.line);
+    return errors.slice().sort((a, b) => a.line && b.line ? a.line - b.line : 0);
 }

--- a/test/unit/style-spec/fixture/functions.output-api-supported.json
+++ b/test/unit/style-spec/fixture/functions.output-api-supported.json
@@ -60,7 +60,7 @@
     "line": 263
   },
   {
-    "message": "layers[15].paint.fill-color.stops[0][0].zoom: number expected, string found",
+    "message": "layers[15].paint.fill-color.stops[0]: stop zoom values must be numbers",
     "line": 284
   },
   {

--- a/test/unit/style-spec/fixture/functions.output.json
+++ b/test/unit/style-spec/fixture/functions.output.json
@@ -60,7 +60,7 @@
     "line": 263
   },
   {
-    "message": "layers[15].paint.fill-color.stops[0][0].zoom: number expected, string found",
+    "message": "layers[15].paint.fill-color.stops[0]: stop zoom values must be numbers",
     "line": 284
   },
   {


### PR DESCRIPTION
A part of https://github.com/mapbox/mapbox-gl-js/issues/11426. Add more export types to the `src/style-spec/validate/*`