### PR TITLE
Prevent rays facing away from center to be counted as inside

### DIFF
--- a/src/shaders/globe_atmosphere.fragment.glsl
+++ b/src/shaders/globe_atmosphere.fragment.glsl
@@ -9,15 +9,15 @@ varying vec3 v_ray_dir;
 
 void main() {
     vec3 dir = normalize(v_ray_dir);
-    vec3 closestPoint = dot(u_globe_pos, dir) * dir;
-    float normDistFromCenter = length(closestPoint - u_globe_pos) / u_globe_radius;
+    vec3 closest_point = abs(dot(u_globe_pos, dir)) * dir;
+    float norm_dist_from_center = length(closest_point - u_globe_pos) / u_globe_radius;
 
-    if (normDistFromCenter < 1.0)
+    if (norm_dist_from_center < 1.0)
         discard;
 
     // exponential (sqrt) curve
     // [0.0, 1.0] == inside the globe, > 1.0 == outside of the globe
-    float t = clamp(1.0 - sqrt(normDistFromCenter - 1.0) / u_fadeout_range, 0.0, 1.0);
+    float t = clamp(1.0 - sqrt(norm_dist_from_center - 1.0) / u_fadeout_range, 0.0, 1.0);
 
     vec3 color = mix(u_start_color, u_end_color, 1.0 - t);
 


### PR DESCRIPTION
To unblock issue discovered in #11525.

This issue wasn't necessarily visible without an increased FOV or a higher zoom transition threshold. But the closest point in that shader may be incorrectly calculated for rays are pointing _away_ from the center globe point, leading to the logic of that shader considering rays inside the globe incorrectly. This PR fixes that issue by always making that distance forward facing.

Visualization of the value `t` describing the atmosphere gradient progress before and after:

https://user-images.githubusercontent.com/7061573/154772532-0b66dbea-df68-4632-92dc-898bf1dd4cf0.mp4

https://user-images.githubusercontent.com/7061573/154772540-346362d2-c91a-49c0-a3e0-f9a23f6a150e.mp4


