### PR TITLE
Rework globe controls

### DIFF
--- a/flow-typed/gl-matrix.js
+++ b/flow-typed/gl-matrix.js
@@ -38,6 +38,7 @@ declare module "gl-matrix" {
         div<T: Vec3>(T, Vec3, Vec3): T,
         min<T: Vec3>(T, Vec3, Vec3): T,
         max<T: Vec3>(T, Vec3, Vec3): T,
+        lerp<T: Vec3>(T, Vec3, Vec3, number): T,
         transformQuat<T: Vec3>(T, Vec3, Quat): T,
         transformMat3<T: Vec3>(T, Vec3, Mat3): T,
         transformMat4<T: Vec3>(T, Vec3, Mat4): T

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -3,7 +3,7 @@ import {mat4, vec3, vec4} from 'gl-matrix';
 import {Ray} from '../../util/primitives.js';
 import EXTENT from '../../data/extent.js';
 import LngLat from '../lng_lat.js';
-import {degToRad, radToDeg, getColumn, shortestAngle} from '../../util/util.js';
+import {degToRad, radToDeg, getColumn, shortestAngle, clamp} from '../../util/util.js';
 import MercatorCoordinate, {
     lngFromMercatorX,
     latFromMercatorY,
@@ -104,25 +104,42 @@ export default class Globe extends Mercator {
     }
 
     pointCoordinate(tr: Transform, x: number, y: number, _: number): MercatorCoordinate {
-        const point0 = [x, y, 0, 1];
+        const point0 = vec3.scale([], tr._camera.position, tr.worldSize);
         const point1 = [x, y, 1, 1];
 
-        vec4.transformMat4(point0, point0, tr.pixelMatrixInverse);
         vec4.transformMat4(point1, point1, tr.pixelMatrixInverse);
-
-        vec4.scale(point0, point0, 1 / point0[3]);
         vec4.scale(point1, point1, 1 / point1[3]);
 
         const p0p1 = vec3.sub([], point1, point0);
-        const direction = vec3.normalize([], p0p1);
+        const dir = vec3.normalize([], p0p1);
 
-        // Compute globe origo in world space
+        // Find closest point on the sphere to the ray. This is a bit more involving operation
+        // if the ray is not intersecting with the sphere. In this scenario we'll "clamp" the ray
+        // to the surface of the sphere, ie. find a tangent vector that originates from the camera position
         const m = tr.globeMatrix;
         const globeCenter = [m[12], m[13], m[14]];
+        const p0toCenter = vec3.sub([], globeCenter, point0);
+        const p0toCenterDist = vec3.length(p0toCenter);
+        const centerDir = vec3.normalize([], p0toCenter);
         const radius = tr.worldSize / (2.0 * Math.PI);
+        const cosAngle = vec3.dot(centerDir, dir);
+
+        const origoTangentAngle = Math.asin(radius / p0toCenterDist);
+        const origoDirAngle = Math.acos(cosAngle);
+
+        if (origoTangentAngle < origoDirAngle) {
+            // Find the tangent vector by interpolating between camera-to-globe and camera-to-click vectors.
+            // First we'll find a point P1 on the clicked ray that forms a right-angled triangle with the camera position
+            // and the center of the globe. Angle of the tanget vector is then used as the interpolation factor
+            const clampedP1 = [], origoToP1 = [];
+
+            vec3.scale(clampedP1, dir, p0toCenterDist / cosAngle);
+            vec3.normalize(origoToP1, vec3.sub(origoToP1, clampedP1, p0toCenter));
+            vec3.normalize(dir, vec3.add(dir, p0toCenter, vec3.scale(dir, origoToP1, Math.tan(origoTangentAngle) * p0toCenterDist)));
+        }
 
         const pointOnGlobe = [];
-        const ray = new Ray(point0, direction);
+        const ray = new Ray(point0, dir);
 
         ray.closestPointOnSphere(globeCenter, radius, pointOnGlobe);
 
@@ -142,7 +159,7 @@ export default class Globe extends Mercator {
         lng = tr.center.lng + shortestAngle(tr.center.lng, lng);
 
         const mx = mercatorXfromLng(lng);
-        const my = mercatorYfromLat(lat);
+        const my = clamp(mercatorYfromLat(lat), 0, 1);
 
         return new MercatorCoordinate(mx, my);
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1031,12 +1031,23 @@ class Transform {
     get point(): Point { return this.project(this.center); }
 
     setLocationAtPoint(lnglat: LngLat, point: Point) {
-        const a = this.pointCoordinate(point);
-        const b = this.pointCoordinate(this.centerPoint);
+        let x, y;
+        const centerPoint = this.centerPoint;
+
+        if (this.projection.name === 'globe') {
+            // Pixel coordinates are applied directly to the globe
+            const worldSize = this.worldSize;
+            x = (point.x - centerPoint.x) / worldSize;
+            y = (point.y - centerPoint.y) / worldSize;
+        } else {
+            const a = this.pointCoordinate(point);
+            const b = this.pointCoordinate(centerPoint);
+            x = a.x - b.x;
+            y = a.y - b.y;
+        }
+
         const loc = this.locationCoordinate(lnglat);
-        this.setLocation(new MercatorCoordinate(
-            loc.x - (a.x - b.x),
-            loc.y - (a.y - b.y)));
+        this.setLocation(new MercatorCoordinate(loc.x - x, loc.y - y));
     }
 
     setLocation(location: MercatorCoordinate) {

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -23,7 +23,7 @@ import window from '../util/window.js';
 import Point from '@mapbox/point-geometry';
 import assert from 'assert';
 import {vec3} from 'gl-matrix';
-import MercatorCoordinate from '../geo/mercator_coordinate.js';
+import MercatorCoordinate, {latFromMercatorY, mercatorZfromAltitude} from '../geo/mercator_coordinate.js';
 
 import type {Vec3} from 'gl-matrix';
 
@@ -524,11 +524,26 @@ class HandlerManager {
             assert(this._dragOrigin, '_dragOrigin should have been setup with a previous dragstart');
 
             const startPoint = tr.pointCoordinate(around);
-            const endPoint = tr.pointCoordinate(around.sub(panDelta));
+            if (tr.projection.name === 'globe') {
+                const startLat = latFromMercatorY(startPoint.y);
+                const centerLat = tr.center.lat;
 
-            if (startPoint && endPoint) {
-                panVec[0] = endPoint.x - startPoint.x;
-                panVec[1] = endPoint.y - startPoint.y;
+                // Compute pan vector directly in pixel coordinates for the globe.
+                // Rotate the globe a bit faster when dragging near poles to compensate
+                // different pixel-per-meter ratios (ie. pixel-to-physical-rotation is lower)
+                const scale = Math.min(mercatorZfromAltitude(1, startLat) / mercatorZfromAltitude(1, centerLat), 2);
+
+                panDelta = panDelta.rotate(-tr.angle);
+
+                panVec[0] = -panDelta.x / tr.worldSize * scale;
+                panVec[1] = -panDelta.y / tr.worldSize * scale;
+            } else {
+                const endPoint = tr.pointCoordinate(around.sub(panDelta));
+
+                if (startPoint && endPoint) {
+                    panVec[0] = endPoint.x - startPoint.x;
+                    panVec[1] = endPoint.y - startPoint.y;
+                }
             }
         }
 

--- a/test/unit/geo/projection/globe.test.js
+++ b/test/unit/geo/projection/globe.test.js
@@ -6,35 +6,50 @@ import {OverscaledTileID} from '../../../../src/source/tile_id.js';
 test('Globe', (t) => {
     t.test('pointCoordinate', (t) => {
         const tr = new Transform();
-        tr.resize(100, 100);
+        tr.resize(512, 512);
         tr.zoom = 0;
         tr.setProjection({name: 'globe'});
 
-        let point = tr.projection.pointCoordinate(tr, 50, 50);
+        // center
+        let point = tr.projection.pointCoordinate(tr, 256, 256);
         t.same(point.x.toFixed(2), 0.5);
         t.same(point.y.toFixed(2), 0.5);
 
-        point = tr.projection.pointCoordinate(tr, 0, 50);
-        t.same(point.x.toFixed(4), 0.3736);
+        // left, middle
+        point = tr.projection.pointCoordinate(tr, 0, 256);
+        t.same(point.x.toFixed(4), 0.2653);
         t.same(point.y.toFixed(4), 0.5);
 
-        point = tr.projection.pointCoordinate(tr, 50, 0);
+        // right, middle
+        point = tr.projection.pointCoordinate(tr, 512, 256);
+        t.same(point.x.toFixed(4), 0.7347);
+        t.same(point.y.toFixed(4), 0.5);
+
+        // clamp y
+        point = tr.projection.pointCoordinate(tr, 256, 512);
         t.same(point.x.toFixed(4), 0.5);
-        t.same(point.y.toFixed(4), 0.3577);
+        t.same(point.y.toFixed(4), 0.9830);
+
+        // Position should be always clamped to the surface of the globe sphere
+        for (let i = 0; i < 5; i++) {
+            point = tr.projection.pointCoordinate(tr, 512 + i * 50, 256);
+            t.same(point.x.toFixed(4), 0.7347);
+            t.same(point.y.toFixed(4), 0.5);
+        }
 
         tr.center = {lng: 180, lat: 0};
 
-        point = tr.projection.pointCoordinate(tr, 50, 50);
+        point = tr.projection.pointCoordinate(tr, 256, 256);
         t.same(point.x.toFixed(2), 1.0);
         t.same(point.y.toFixed(2), 0.5);
 
-        point = tr.projection.pointCoordinate(tr, 0, 50);
-        t.same(point.x.toFixed(4), 0.8736);
+        point = tr.projection.pointCoordinate(tr, 0, 256);
+        t.same(point.x.toFixed(4), 0.7653);
         t.same(point.y.toFixed(4), 0.5);
 
         // Expect x-coordinate not to wrap
-        point = tr.projection.pointCoordinate(tr, 100, 50);
-        t.same(point.x.toFixed(4), 1.1264);
+        point = tr.projection.pointCoordinate(tr, 512, 256);
+        t.same(point.x.toFixed(4), 1.2347);
         t.same(point.y.toFixed(4), 0.5);
 
         t.end();

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -985,6 +985,80 @@ test('camera', (t) => {
             camera.easeTo({center: [100, 0], zoom: 3.2, bearing: 90, duration: 1000});
         });
 
+        t.test('Globe', (t) => {
+            t.test('pans to specified location', (t) => {
+                const camera = createCamera();
+                camera.transform.zoom = 4;
+                camera.transform.setProjection({name: 'globe'});
+
+                camera.easeTo({center: [90, 10], duration:0});
+                t.deepEqual(camera.getCenter(), {lng: 90, lat: 10});
+
+                t.end();
+            });
+
+            t.test('rotate the globe once around its axis', (t) => {
+                const camera = createCamera();
+                const stub = t.stub(browser, 'now');
+                stub.callsFake(() => 0);
+
+                camera.transform.zoom = 4;
+                camera.transform.setProjection({name: 'globe'});
+
+                camera.easeTo({center: [360, 0], duration: 100, easing: e => e});
+
+                camera.simulateFrame();
+                t.deepEqual(camera.getCenter(), {lng: 0, lat: 0});
+
+                stub.callsFake(() => 25);
+                camera.simulateFrame();
+                t.deepEqual(camera.getCenter(), {lng: 90, lat: 0});
+
+                stub.callsFake(() => 50);
+                camera.simulateFrame();
+                t.deepEqual(camera.getCenter(), {lng: 180, lat: 0});
+
+                stub.callsFake(() => 75);
+                camera.simulateFrame();
+                t.deepEqual(camera.getCenter(), {lng: -90, lat: 0});
+
+                stub.callsFake(() => 100);
+                camera.simulateFrame();
+                t.deepEqual(camera.getCenter(), {lng: 0, lat: 0});
+
+                t.end();
+            });
+
+            t.test('pans with padding', (t) => {
+                const camera = createCamera();
+                camera.transform.setProjection({name: 'globe'});
+
+                camera.easeTo({center: [90, 0], duration:0, padding:{top: 100}});
+                t.deepEqual(camera.getCenter(), {lng: 90, lat: 0});
+                t.deepEqual(camera.getPadding(), {top:100, bottom:0, left:0, right:0});
+                t.end();
+            });
+
+            t.test('pans with specified offset and bearing', (t) => {
+                const camera = createCamera();
+                const stub = t.stub(browser, 'now');
+                stub.callsFake(() => 0);
+
+                camera.transform.setProjection({name: 'globe'});
+                camera.easeTo({center: [170, 0], offset: [100, 0], duration: 2000, bearing: 45});
+
+                for (let i = 1; i <= 10; i++) {
+                    stub.callsFake(() => i * 200);
+                    camera.simulateFrame();
+                }
+
+                t.deepEqual(fixedLngLat(camera.getCenter()), {lng: 99.6875, lat: 0});
+                t.end();
+            });
+
+            t.end();
+        });
+
         t.end();
     });
 

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -227,6 +227,38 @@ test('ScrollZoomHandler', (t) => {
         t.end();
     });
 
+    t.test('Globe', (t) => {
+        t.test('Zoom towards a point on the globe', (t) => {
+            const map = createMap(t);
+
+            // Scroll zoom should result in identical movement in both mercator and globe projections
+            map.transform.zoom = 0;
+
+            for (let i = 0; i < 5; i++) {
+                simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -100});
+                map._renderTaskQueue.run();
+            }
+
+            t.equal(fixedNum(map.transform.zoom, 5), 2.46106);
+
+            now += 500;
+            map.transform.zoom = 0;
+            map.setProjection({name:'globe'});
+
+            for (let i = 0; i < 5; i++) {
+                simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -100});
+                map._renderTaskQueue.run();
+            }
+
+            t.equal(fixedNum(map.transform.zoom, 5), 2.46106);
+
+            map.remove();
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('Gracefully ignores wheel events with deltaY: 0', (t) => {
         const map = createMap(t);
         map._renderTaskQueue.run();


### PR DESCRIPTION
Rotating the globe with a mouse or touch controls might feel a bit cumbersome experience right now. The current implementation is shared with other projections where the the location of the map under the cursor tries to follow cursor movement on the screen with varying success. This is implemented by casting rays from the cursor position to see how movement on the screen is reflected on the actual map. This works well and feels intuitive on Mercator projection (especially with relatively low pitch angles) but it poses some challenges in the globe view. For example dragging the globe near poles will most likely result in too fast rotation without introduction of special constraints.

This pull request proposes a much simpler approach for implementing the controls. Instead of using raycasting for dragging the map, movement vectors (pan vectors) are applied directly to the map in pixel coordinates. What this means in practice is that the cursor movement on the y-axis changes latitude coordinate and movement on the x-axis changes longitude coordinate. Visually this looks more similar to other globe implementations. Some pros and cons of the proposed change:

Pros
 - Rotation of the globe becomes much more predictable and previously challenging poles are trivialized.
 - Cursor doesn't need to intersect with the globe for controls to work
 - Overall better interaction with touch controls

Cons
 - Not as precise controls as before in highly tilted views
 - Changing control scheme after transition between mercator and globe is somewhat noticeable on high pitch views

cc @mapbox/gl-js, @akoylasar, @tristen 

Would fix https://github.com/mapbox/mapbox-gl-js/issues/11366

Controls before:

https://user-images.githubusercontent.com/55925868/155293235-d28d62a0-ad7d-4318-b8a9-f340032599c2.mp4

Controls after:

https://user-images.githubusercontent.com/55925868/155293241-9ea07583-7e99-4613-8930-5519c597c476.mp4


TODO
 - [x] Unit tests to catch any regression with camera animations on the globe

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
