### PR TITLE
Only pass tile stencil drawing for greater values

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -379,8 +379,8 @@ class Painter {
             const tile = sourceCache.getTile(tileID);
             const {tileBoundsBuffer, tileBoundsIndexBuffer, tileBoundsSegments} = this.getTileBoundsBuffers(tile);
             program.draw(context, gl.TRIANGLES, DepthMode.disabled,
-                // Tests will always pass, and ref value will be written to stencil buffer.
-                new StencilMode({func: gl.ALWAYS, mask: 0}, this._tileClippingMaskIDs[tileID.key], 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE),
+                // Tests will pass if the new ref is greater than the previous value, and ref value will be written to stencil buffer.
+                new StencilMode({func: gl.GREATER, mask: 0xFF}, this._tileClippingMaskIDs[tileID.key], 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE),
                 ColorMode.disabled, CullFaceMode.disabled, clippingMaskUniformValues(tileID.projMatrix),
                 '$clipping', tileBoundsBuffer,
                 tileBoundsIndexBuffer, tileBoundsSegments);
@@ -391,7 +391,7 @@ class Painter {
                 renderStencil(tileID);
             }
         } else {
-            if (this.nextStencilID + tileIDs.length > 256) {
+            if (Object.keys(this._tileClippingMaskIDs).length === 0 || this.nextStencilID + tileIDs.length > 256) {
                 // we'll run out of fresh IDs so we need to clear and start from scratch
                 this.clearStencil();
             }

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1143,7 +1143,7 @@ export class Terrain extends Elevation {
             // 1. overlap is handled by proxy render to texture tiles (there is no overlap there)
             // 2. here we handle only brief zoom out semi-transparent color intensity flickering
             //    and that is avoided fine by stenciling primitives as part of drawing (instead of additional tile quad step).
-            this._overlapStencilMode.ref = this.painter._tileClippingMaskIDs[id.key];
+            this._overlapStencilMode.ref = this.painter._tileClippingMaskIDs.get(id.key) || 0;
         } // else this._overlapStencilMode.ref is set to a single value used per proxy tile, in _setupStencil.
         return this._overlapStencilMode;
     }
@@ -1152,14 +1152,15 @@ export class Terrain extends Elevation {
         const painter = this.painter;
         const context = this.painter.context;
         const gl = context.gl;
-        painter._tileClippingMaskIDs = {};
+        painter._tileClippingMaskIDs.clear();
         context.setColorMode(ColorMode.disabled);
         context.setDepthMode(DepthMode.disabled);
 
         const program = painter.useProgram('clippingMask');
 
         for (const tileID of proxiedCoords) {
-            const id = painter._tileClippingMaskIDs[tileID.key] = --ref;
+            const id = --ref;
+            painter._tileClippingMaskIDs.set(tileID.key, id);
             program.draw(context, gl.TRIANGLES, DepthMode.disabled,
                 // Tests will always pass, and ref value will be written to stencil buffer.
                 new StencilMode({func: gl.ALWAYS, mask: 0}, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE),


### PR DESCRIPTION
A small follow-up for: https://github.com/mapbox/mapbox-gl-js/pull/11542

This change makes sure that we're not overwriting previously rendered stencil masks with higher zoom level tiles. (Assuming the array of the tiles are ordered by their zoom level, and we render lower zoom level tiles first.)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
