### PR TITLE
Allow the second argument to 'in' expression to be an empty string

### DIFF
--- a/src/style-spec/expression/definitions/in.js
+++ b/src/style-spec/expression/definitions/in.js
@@ -42,7 +42,7 @@ class In implements Expression {
         const needle = (this.needle.evaluate(ctx): any);
         const haystack = (this.haystack.evaluate(ctx): any);
 
-        if (!haystack) return false;
+        if (haystack == null) return false;
 
         if (!isValidNativeType(needle, ['boolean', 'string', 'number', 'null'])) {
             throw new RuntimeError(`Expected first argument to be of type boolean, string, number or null, but found ${toString(typeOf(needle))} instead.`);

--- a/test/integration/expression-tests/in/basic-string/test.json
+++ b/test/integration/expression-tests/in/basic-string/test.json
@@ -10,7 +10,10 @@
     [{}, {"properties": {"substr": true, "str": "falsetrue"}}],
     [{}, {"properties": {"substr": false, "str": "falsetrue"}}],
     [{}, {"properties": {"substr": 123, "str": "hello123world"}}],
-    [{}, {"properties": {"substr": "low", "str": null}}]
+    [{}, {"properties": {"substr": "low", "str": null}}],
+    [{}, {"properties": {"substr": "", "str": "helloworld"}}],
+    [{}, {"properties": {"substr": "helloworld", "str": ""}}],
+    [{}, {"properties": {"substr": "", "str": ""}}]
   ],
   "expected": {
     "compiled": {
@@ -26,7 +29,10 @@
       true,
       true,
       true,
-      false
+      false,
+      true,
+      false,
+      true
     ],
     "serialized": [
       "boolean",


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/11543 by allowing the second argument to `in` to be an empty string. this makes sense because `''.indexOf('') >= 0` is true, but the current implementation returns false.
 - [x] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Allow the second argument to the 'in' expression operator to be an empty string</changelog>`
