### PR TITLE
Fix failing unit test

### DIFF
--- a/test/unit/geo/projection/globe.test.js
+++ b/test/unit/geo/projection/globe.test.js
@@ -43,6 +43,9 @@ test('Globe', (t) => {
     t.test('coveringTiles', (t) => {
         const createConstantElevation = (elevation) => {
             return {
+                isDataAvailableAtPoint(_) {
+                    return true;
+                },
                 getAtPointOrZero(_) {
                     return elevation;
                 },


### PR DESCRIPTION
This PR fixes the failing unit test which started to occur after merging [tile cover optimization](https://github.com/mapbox/mapbox-gl-js/issues/11467). The said PR was green so the likely cause of the failure is due to change of assumptions in implementation brought by a different change.
