### PR TITLE
Fix image source performance regression

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -135,7 +135,7 @@ class ImageSource extends Evented implements Source {
         this.options = options;
     }
 
-    load(newCoordinates?: Coordinates, successCallback?: () => void) {
+    load(newCoordinates?: Coordinates) {
         this._loaded = false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
 
@@ -156,9 +156,6 @@ class ImageSource extends Evented implements Source {
                 this.height = this.image.height;
                 if (newCoordinates) {
                     this.coordinates = newCoordinates;
-                }
-                if (successCallback) {
-                    successCallback();
                 }
                 this._finishLoading();
             }

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -152,7 +152,6 @@ class ImageSource extends Evented implements Source {
                 } else {
                     this.image = image;
                 }
-                console.log('this.image: ', this.image);
                 this.width = this.image.width;
                 this.height = this.image.height;
                 if (newCoordinates) {

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -50,9 +50,12 @@ const exported = {
             throw new Error('failed to create canvas 2d context');
         }
 
-        canvas.width = width > canvas.width ? width : canvas.width;
-        canvas.height = height > canvas.height ? height : canvas.height;
+        if (width > canvas.width || height > canvas.height) {
+            canvas.width = width;
+            canvas.height = height;
+        }
 
+        context.clearRect(-padding, -padding, width + 2 * padding, height + 2 * padding);
         context.drawImage(img, 0, 0, width, height);
         return context.getImageData(-padding, -padding, width + 2 * padding, height + 2 * padding);
     },

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -9,7 +9,7 @@ let reducedMotionQuery: MediaQueryList;
 
 let stubTime;
 
-let cachedCanvas;
+let canvas;
 
 /**
  * @private
@@ -41,18 +41,19 @@ const exported = {
     getImageData(img: CanvasImageSource, padding?: number = 0): ImageData {
         const {width, height} = img;
 
-        const canvas = (!cachedCanvas || cachedCanvas.width < width || cachedCanvas.height < height) ?
-            window.document.createElement('canvas') :
-            cachedCanvas;
+        if (!canvas) {
+            canvas = window.document.createElement('canvas');
+        }
 
         const context = canvas.getContext('2d');
         if (!context) {
             throw new Error('failed to create canvas 2d context');
         }
 
-        canvas.width = width;
-        canvas.height = height;
-        cachedCanvas = canvas;
+        if (!canvas.width || canvas.width < width || !canvas.height || canvas.height < height) {
+            canvas.width = width;
+            canvas.height = height;
+        }
 
         context.drawImage(img, 0, 0, width, height);
         return context.getImageData(-padding, -padding, width + 2 * padding, height + 2 * padding);

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -9,6 +9,8 @@ let reducedMotionQuery: MediaQueryList;
 
 let stubTime;
 
+let cachedCanvas;
+
 /**
  * @private
  */
@@ -37,15 +39,23 @@ const exported = {
     },
 
     getImageData(img: CanvasImageSource, padding?: number = 0): ImageData {
-        const canvas = window.document.createElement('canvas');
+        const {width, height} = img;
+
+        const canvas = (!cachedCanvas || cachedCanvas.width < width || cachedCanvas.height < height) ?
+            window.document.createElement('canvas') :
+            cachedCanvas;
+
         const context = canvas.getContext('2d');
         if (!context) {
             throw new Error('failed to create canvas 2d context');
         }
-        canvas.width = img.width;
-        canvas.height = img.height;
-        context.drawImage(img, 0, 0, img.width, img.height);
-        return context.getImageData(-padding, -padding, img.width + 2 * padding, img.height + 2 * padding);
+
+        canvas.width = width;
+        canvas.height = height;
+        cachedCanvas = canvas;
+
+        context.drawImage(img, 0, 0, width, height);
+        return context.getImageData(-padding, -padding, width + 2 * padding, height + 2 * padding);
     },
 
     resolveURL(path: string): string {

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -50,8 +50,8 @@ const exported = {
             throw new Error('failed to create canvas 2d context');
         }
 
-        canvas.width = width;
-        canvas.height = height;
+        canvas.width = width > canvas.width ? width : canvas.width;
+        canvas.height = height > canvas.height ? height : canvas.height;
 
         context.drawImage(img, 0, 0, width, height);
         return context.getImageData(-padding, -padding, width + 2 * padding, height + 2 * padding);

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -50,10 +50,8 @@ const exported = {
             throw new Error('failed to create canvas 2d context');
         }
 
-        if (!canvas.width || canvas.width < width || !canvas.height || canvas.height < height) {
-            canvas.width = width;
-            canvas.height = height;
-        }
+        canvas.width = width;
+        canvas.height = height;
 
         context.drawImage(img, 0, 0, width, height);
         return context.getImageData(-padding, -padding, width + 2 * padding, height + 2 * padding);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - this is a fix for https://github.com/mapbox/mapbox-gl-js/issues/11559
    - most newer browsers will create an ImageBitmap which does not need to be decoded immediately. this lets us use the older pathway that had better performance
    - older browsers that can't create an ImageBitmap (e.g. Safari <= 14) will decode the image element immediately so that they avoid a race condition where image sources that aren't visible right away never render (see https://github.com/mapbox/mapbox-gl-js/issues/10685)
    - also uses `texture.update` rather than always creating a new texture when the source's image is updated
    - adds an `onRemove` that destroys the texture to prevent a memory leak
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Prevent performance regression when animating image sources</changelog>`
