### PR TITLE
Fix map.fitBounds() with non-zero bearing

### DIFF
--- a/debug/padding.html
+++ b/debug/padding.html
@@ -8,15 +8,17 @@
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
-        #getBounds { position: absolute; top: 0; left; 0; }
-        #setBounds { position: absolute; top: 0; left: 78px; }
+        #controls { position: absolute; top: 0; left: 0; }
     </style>
 </head>
 
 <body>
 <div id='map'></div>
-<button id="getBounds">getBounds</button>
-<button id="setBounds">setBounds</button>
+<div id="controls">
+    <button id="getBounds">getBounds</button>
+    <button id="setBounds">setBounds</button>
+    <button id="maintainBearing">Maintain Bearing: false</button>
+</div>
 
 <script src='../dist/mapbox-gl-dev.js'></script>
 <script src='../debug/access_token_generated.js'></script>
@@ -57,6 +59,7 @@ map.on('load', function () {
 });
 
 var bounds;
+var maintainBearing = false;
 document.getElementById('getBounds').addEventListener('click', function () {
     bounds = map.getBounds();
     map.getSource('bounds').setData({
@@ -76,8 +79,14 @@ document.getElementById('getBounds').addEventListener('click', function () {
 });
 document.getElementById('setBounds').addEventListener('click', function () {
     map.fitBounds(bounds, {
-        duration: 0
+        duration: 0,
+        bearing: maintainBearing ? map.getBearing() : 0,
     });
+});
+const maintainBearingElement = document.getElementById('maintainBearing');
+maintainBearingElement.addEventListener('click', function() {
+    maintainBearing = !maintainBearing;
+    maintainBearingElement.innerHTML = `Maintain Bearing: ${maintainBearing}`;
 });
 </script>
 </body>

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -628,10 +628,12 @@ class Camera extends Evented {
         const p1world = tr.project(LngLat.convert(p1));
         const p2world = new Point(p0world.x, p1world.y);
         const p3world = new Point(p1world.x, p0world.y);
-        const p0rotated = p0world.rotate(-degToRad(bearing));
-        const p1rotated = p1world.rotate(-degToRad(bearing));
-        const p2rotated = p2world.rotate(-degToRad(bearing));
-        const p3rotated = p3world.rotate(-degToRad(bearing));
+
+        const angleRadians = -degToRad(bearing);
+        const p0rotated = p0world.rotate(angleRadians);
+        const p1rotated = p1world.rotate(angleRadians);
+        const p2rotated = p2world.rotate(angleRadians);
+        const p3rotated = p3world.rotate(angleRadians);
 
         const upperRight = new Point(
             Math.max(p0rotated.x, p1rotated.x, p2rotated.x, p3rotated.x),

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -621,15 +621,28 @@ class Camera extends Evented {
         const tr = this.transform;
         const edgePadding = tr.padding;
 
-        // We want to calculate the upper right and lower left of the box defined by p0 and p1
-        // in a coordinate system rotate to match the destination bearing.
-        const p0world = tr.project(LngLat.convert(p0));
-        const p1world = tr.project(LngLat.convert(p1));
+        // We want to calculate the corners of the box defined by p0 and p1 in a coordinate system
+        // rotated to match the destination bearing. All four corners of the box must be taken
+        // into account because of camera rotation.
+        const p0LatLng = LngLat.convert(p0);
+        const p1LatLng = LngLat.convert(p1);
+        const p0world = tr.project(p0LatLng);
+        const p1world = tr.project(p1LatLng);
+        const p2world = tr.project(new LngLat(p0LatLng.lng, p1LatLng.lat));
+        const p3world = tr.project(new LngLat(p1LatLng.lng, p0LatLng.lat));
         const p0rotated = p0world.rotate(-degToRad(bearing));
         const p1rotated = p1world.rotate(-degToRad(bearing));
+        const p2rotated = p2world.rotate(-bearing * Math.PI / 180);
+        const p3rotated = p3world.rotate(-bearing * Math.PI / 180);
 
-        const upperRight = new Point(Math.max(p0rotated.x, p1rotated.x), Math.max(p0rotated.y, p1rotated.y));
-        const lowerLeft = new Point(Math.min(p0rotated.x, p1rotated.x), Math.min(p0rotated.y, p1rotated.y));
+        const upperRight = new Point(
+            Math.max(p0rotated.x, p1rotated.x, p2rotated.x, p3rotated.x),
+            Math.max(p0rotated.y, p1rotated.y, p2rotated.y, p3rotated.y)
+        );
+        const lowerLeft = new Point(
+            Math.min(p0rotated.x, p1rotated.x, p2rotated.x, p3rotated.x),
+            Math.min(p0rotated.y, p1rotated.y, p2rotated.y, p3rotated.y)
+        );
 
         // Calculate zoom: consider the original bbox and padding.
         const size = upperRight.sub(lowerLeft);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -624,16 +624,14 @@ class Camera extends Evented {
         // We want to calculate the corners of the box defined by p0 and p1 in a coordinate system
         // rotated to match the destination bearing. All four corners of the box must be taken
         // into account because of camera rotation.
-        const p0LatLng = LngLat.convert(p0);
-        const p1LatLng = LngLat.convert(p1);
-        const p0world = tr.project(p0LatLng);
-        const p1world = tr.project(p1LatLng);
-        const p2world = tr.project(new LngLat(p0LatLng.lng, p1LatLng.lat));
-        const p3world = tr.project(new LngLat(p1LatLng.lng, p0LatLng.lat));
+        const p0world = tr.project(LngLat.convert(p0));
+        const p1world = tr.project(LngLat.convert(p1));
+        const p2world = new Point(p0world.x, p1world.y);
+        const p3world = new Point(p1world.x, p0world.y);
         const p0rotated = p0world.rotate(-degToRad(bearing));
         const p1rotated = p1world.rotate(-degToRad(bearing));
-        const p2rotated = p2world.rotate(-bearing * Math.PI / 180);
-        const p3rotated = p3world.rotate(-bearing * Math.PI / 180);
+        const p2rotated = p2world.rotate(-degToRad(bearing));
+        const p3rotated = p3world.rotate(-degToRad(bearing));
 
         const upperRight = new Point(
             Math.max(p0rotated.x, p1rotated.x, p2rotated.x, p3rotated.x),

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1832,7 +1832,7 @@ test('camera', (t) => {
 
             const transform = camera.cameraForBounds(bb, {bearing: 175});
             t.deepEqual(fixedLngLat(transform.center, 4), {lng: -100.5, lat: 34.7171}, 'correctly calculates coordinates for new bounds');
-            t.equal(fixedNum(transform.zoom, 3), 2.558);
+            t.equal(fixedNum(transform.zoom, 3), 2.396);
             t.equal(transform.bearing, 175);
             t.end();
         });
@@ -1843,7 +1843,7 @@ test('camera', (t) => {
 
             const transform = camera.cameraForBounds(bb, {bearing: -30});
             t.deepEqual(fixedLngLat(transform.center, 4), {lng: -100.5, lat: 34.7171}, 'correctly calculates coordinates for new bounds');
-            t.equal(fixedNum(transform.zoom, 3), 2.392);
+            t.equal(fixedNum(transform.zoom, 3), 2.222);
             t.equal(transform.bearing, -30);
             t.end();
         });
@@ -1945,6 +1945,16 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('padding is calculated with bearing', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            camera.fitBounds(bb, {bearing: 45, duration:0});
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -100.5, lat: 34.7171}, 'pans to coordinates based on fitBounds with bearing applied');
+            t.equal(fixedNum(camera.getZoom(), 3), 2.254);
+            t.end();
+        });
+
         t.test('padding object', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
@@ -1976,12 +1986,12 @@ test('camera', (t) => {
         t.test('bearing 225', (t) => {
             const camera = createCamera();
             const p0 = [128, 128];
-            const p1 = [256, 256];
+            const p1 = [256, 384];
             const bearing = 225;
 
             camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
-            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -45, lat: 40.9799}, 'centers, rotates 225 degrees, and zooms based on screen coordinates');
-            t.equal(fixedNum(camera.getZoom(), 3), 1.5);
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -45, lat: 0}, 'centers, rotates 225 degrees, and zooms based on screen coordinates');
+            t.equal(fixedNum(camera.getZoom(), 3), 0.915); // 0.915 ~= log2(4*sqrt(2)/3)
             t.equal(camera.getBearing(), -135);
             t.equal(camera.getPitch(), 0);
             t.end();
@@ -2022,12 +2032,12 @@ test('camera', (t) => {
             const camera = createCamera();
 
             const p0 = [128, 128];
-            const p1 = [256, 256];
+            const p1 = [256, 384];
             const bearing = 0;
 
             camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
-            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -45, lat: 40.9799}, 'centers and zooms in based on screen coordinates');
-            t.equal(fixedNum(camera.getZoom(), 3), 2);
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -45, lat: 0}, 'centers and zooms in based on screen coordinates');
+            t.equal(fixedNum(camera.getZoom(), 3), 1);
             t.equal(camera.getBearing(), 0);
             t.end();
         });
@@ -2035,12 +2045,12 @@ test('camera', (t) => {
         t.test('inverted points', (t) => {
             const camera = createCamera();
             const p1 = [128, 128];
-            const p0 = [256, 256];
+            const p0 = [256, 384];
             const bearing = 0;
 
             camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
-            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -45, lat: 40.9799}, 'centers and zooms based on screen coordinates in opposite order');
-            t.equal(fixedNum(camera.getZoom(), 3), 2);
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -45, lat: 0}, 'centers and zooms based on screen coordinates in opposite order');
+            t.equal(fixedNum(camera.getZoom(), 3), 1);
             t.equal(camera.getBearing(), 0);
             t.end();
         });


### PR DESCRIPTION
Fix bounds/bearing calculation bug (#10064) in the following methods:

* `map.fitBounds()`
* `map.fitScreenCoordinates()`
* `map.cameraForBounds()`

Consider bearings of 45 and 135 and how all four corners need to be taken into account.

Changes in tests:

* Fix tests for camera => #cameraForBounds (they were incorrect)
* Add new test for camera => #fitBounds with non-zero bearing
* Changed input coordinates in tests camera => #fitScreenCoordinates to make the input region not square

Before
<img width="1172" alt="before" src="https://user-images.githubusercontent.com/1613103/156909802-3d8e7b5d-a558-4571-a486-62fb1455c92b.png">
After
<img width="1156" alt="after" src="https://user-images.githubusercontent.com/1613103/156909804-5b642c3f-980c-454a-8764-0dcd39e8cbb8.png">


## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix bounds calculation where map.fitBounds(), map.fitScreenCoordinates(), and map.cameraForBounds() behave incorrectly with non-zero bearing. (#10064)</changelog>`
