### PR TITLE
Fix globe atmosphere not taking camera padding into account

### DIFF
--- a/src/render/draw_globe_atmosphere.js
+++ b/src/render/draw_globe_atmosphere.js
@@ -25,15 +25,20 @@ function drawGlobeAtmosphere(painter: Painter) {
     // Render the gradient atmosphere by casting rays from screen pixels and determining their
     // closest distance to the globe. This is done in view space where camera is located in the origo
     // facing -z direction.
-    const viewMatrix = transform._camera.getWorldToCamera(transform.worldSize, 1.0);
-    const viewToProj = transform._camera.getCameraToClipPerspective(transform._fov, transform.width / transform.height, transform._nearZ, transform._farZ);
-    const projToView = mat4.invert([], viewToProj);
+    const offset = transform.centerOffset;
+    const cameraToClip = transform._camera.getCameraToClipPerspective(transform._fov, transform.width / transform.height, transform._nearZ, transform._farZ);
+
+    cameraToClip[8] = -offset.x * 2 / transform.width;
+    cameraToClip[9] = offset.y * 2 / transform.height;
+
+    const clipToCamera = mat4.invert([], cameraToClip);
+    const viewMatrix = mat4.mul([], clipToCamera, transform.projMatrix);
 
     // Compute direction vectors to each corner point of the view frustum
-    const frustumTl = project([-1, 1, 1], projToView);
-    const frustumTr = project([1, 1, 1], projToView);
-    const frustumBr = project([1, -1, 1], projToView);
-    const frustumBl = project([-1, -1, 1], projToView);
+    const frustumTl = project([-1, 1, 1], clipToCamera);
+    const frustumTr = project([1, 1, 1], clipToCamera);
+    const frustumBr = project([1, -1, 1], clipToCamera);
+    const frustumBl = project([-1, -1, 1], clipToCamera);
 
     const center = [transform.globeMatrix[12], transform.globeMatrix[13], transform.globeMatrix[14]];
     const globeCenterInViewSpace = project(center, viewMatrix);

--- a/test/ignores.json
+++ b/test/ignores.json
@@ -41,6 +41,5 @@
   "render-tests/video/projected": "https://github.com/mapbox/mapbox-gl-js/issues/11234",
   "query-tests/terrain/draped/lines/slope-occlusion-box-query": "skip - non-deterministic",
   "render-tests/fill-extrusion-pattern/opacity-terrain": "skip - deferred for globe-view",
-  "render-tests/globe/globe-padding": "skip - pending globe-view implementation",
   "render-tests/globe/globe-transition/horizon-during-transition": "skip - pending globe-view implementation"
 }


### PR DESCRIPTION
Recent changes in the globe atmosphere rendering (https://github.com/mapbox/mapbox-gl-js/pull/11515) introduced a regression where the camera padding is not taken into account. A render test already exists to catch this issue but for some reason it has been disabled until now.

This PR fixes the issue by properly applying edge insets into the matrix calculations and enables the render test `globe/globe-padding` for catching any future regressions.

Before:
![actual](https://user-images.githubusercontent.com/55925868/157032990-492cfd82-6aaf-4e20-951d-bd4fb9e07729.png)

After:
![expected](https://user-images.githubusercontent.com/55925868/157033015-57481d48-5595-468c-a637-12da01425957.png)


# Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
