### PR TITLE
fix: update ImageAtlas render callbacks after image removal

### DIFF
--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -123,6 +123,7 @@ export default class ImageAtlas {
     }
 
     patchUpdatedImages(imageManager: ImageManager, texture: Texture) {
+        this.haveRenderCallbacks = this.haveRenderCallbacks.filter(id => imageManager.hasImage(id));
         imageManager.dispatchRenderCallbacks(this.haveRenderCallbacks);
         for (const name in imageManager.updatedImages) {
             this.patchUpdatedImage(this.iconPositions[name], imageManager.getImage(name), texture);

--- a/src/render/image_manager.js
+++ b/src/render/image_manager.js
@@ -82,6 +82,10 @@ class ImageManager extends Evented {
         }
     }
 
+    hasImage(id: string): boolean {
+        return !!this.getImage(id);
+    }
+
     getImage(id: string): ?StyleImage {
         return this.images[id];
     }


### PR DESCRIPTION
`ImageAtlas` may still have render callbacks after removing the image in `ImageManager`.

Closes #11558

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>fix: properly handle animated images render callbacks removal</changelog>`
