### PR TITLE
[Flow] Add missing export types to style-spec/expression/*

### DIFF
--- a/src/style-spec/expression/definitions/within.js
+++ b/src/style-spec/expression/definitions/within.js
@@ -148,7 +148,7 @@ function lineStringWithinPolygons(line, polygons) {
     return false;
 }
 
-function getTilePolygon(coordinates, bbox, canonical) {
+function getTilePolygon(coordinates, bbox: BBox, canonical: CanonicalTileID) {
     const polygon = [];
     for (let i = 0; i < coordinates.length; i++) {
         const ring = [];
@@ -162,7 +162,7 @@ function getTilePolygon(coordinates, bbox, canonical) {
     return polygon;
 }
 
-function getTilePolygons(coordinates, bbox, canonical) {
+function getTilePolygons(coordinates, bbox, canonical: CanonicalTileID) {
     const polygons = [];
     for (let i = 0; i < coordinates.length; i++) {
         const polygon = getTilePolygon(coordinates[i], bbox, canonical);
@@ -188,7 +188,7 @@ function resetBBox(bbox) {
     bbox[2] = bbox[3] = -Infinity;
 }
 
-function getTilePoints(geometry, pointBBox, polyBBox, canonical) {
+function getTilePoints(geometry, pointBBox, polyBBox, canonical: CanonicalTileID) {
     const worldSize = Math.pow(2, canonical.z) * EXTENT;
     const shifts = [canonical.x * EXTENT, canonical.y * EXTENT];
     const tilePoints = [];
@@ -202,7 +202,7 @@ function getTilePoints(geometry, pointBBox, polyBBox, canonical) {
     return tilePoints;
 }
 
-function getTileLines(geometry, lineBBox, polyBBox, canonical) {
+function getTileLines(geometry, lineBBox, polyBBox, canonical: CanonicalTileID) {
     const worldSize = Math.pow(2, canonical.z) * EXTENT;
     const shifts = [canonical.x * EXTENT, canonical.y * EXTENT];
     const tileLines = [];
@@ -231,6 +231,9 @@ function pointsWithinPolygons(ctx: EvaluationContext, polygonGeometry: GeoJSONPo
     const polyBBox = [Infinity, Infinity, -Infinity, -Infinity];
 
     const canonical = ctx.canonicalID();
+    if (!canonical) {
+        return false;
+    }
 
     if (polygonGeometry.type === 'Polygon') {
         const tilePolygon = getTilePolygon(polygonGeometry.coordinates, polyBBox, canonical);
@@ -259,6 +262,9 @@ function linesWithinPolygons(ctx: EvaluationContext, polygonGeometry: GeoJSONPol
     const polyBBox = [Infinity, Infinity, -Infinity, -Infinity];
 
     const canonical = ctx.canonicalID();
+    if (!canonical) {
+        return false;
+    }
 
     if (polygonGeometry.type === 'Polygon') {
         const tilePolygon = getTilePolygon(polygonGeometry.coordinates, polyBBox, canonical);
@@ -292,7 +298,7 @@ class Within implements Expression {
         this.geometries = geometries;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Within {
         if (args.length !== 2)
             return context.error(`'within' expression requires exactly one argument, but found ${args.length - 1} instead.`);
         if (isValue(args[1])) {
@@ -316,7 +322,7 @@ class Within implements Expression {
         return context.error(`'within' expression requires valid geojson object that contains polygon geometry type.`);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): boolean {
         if (ctx.geometry() != null && ctx.canonicalID() != null) {
             if (ctx.geometryType() === 'Point') {
                 return pointsWithinPolygons(ctx, this.geometries);

--- a/src/style-spec/expression/evaluation_context.js
+++ b/src/style-spec/expression/evaluation_context.js
@@ -16,7 +16,7 @@ class EvaluationContext {
     featureState: ?FeatureState;
     formattedSection: ?FormattedSection;
     availableImages: ?Array<string>;
-    canonical: ?CanonicalTileID;
+    canonical: null | CanonicalTileID;
     featureTileCoord: ?Point;
     featureDistanceData: ?FeatureDistanceData;
 
@@ -34,11 +34,11 @@ class EvaluationContext {
         this.featureDistanceData = null;
     }
 
-    id() {
+    id(): null | any {
         return this.feature && 'id' in this.feature ? this.feature.id : null;
     }
 
-    geometryType() {
+    geometryType(): null | string {
         return this.feature ? typeof this.feature.type === 'number' ? geometryTypes[this.feature.type] : this.feature.type : null;
     }
 
@@ -46,15 +46,15 @@ class EvaluationContext {
         return this.feature && 'geometry' in this.feature ? this.feature.geometry : null;
     }
 
-    canonicalID() {
+    canonicalID(): null | CanonicalTileID {
         return this.canonical;
     }
 
-    properties() {
+    properties(): {[string]: any} {
         return (this.feature && this.feature.properties) || {};
     }
 
-    distanceFromCenter() {
+    distanceFromCenter(): number {
         if (this.featureTileCoord && this.featureDistanceData) {
 
             const c = this.featureDistanceData.center;

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -69,7 +69,7 @@ export class StyleExpression {
         this._evaluator.globals = globals;
         this._evaluator.feature = feature;
         this._evaluator.featureState = featureState;
-        this._evaluator.canonical = canonical;
+        this._evaluator.canonical = canonical || null;
         this._evaluator.availableImages = availableImages || null;
         this._evaluator.formattedSection = formattedSection;
         this._evaluator.featureTileCoord = featureTileCoord || null;
@@ -82,7 +82,7 @@ export class StyleExpression {
         this._evaluator.globals = globals;
         this._evaluator.feature = feature || null;
         this._evaluator.featureState = featureState || null;
-        this._evaluator.canonical = canonical;
+        this._evaluator.canonical = canonical || null;
         this._evaluator.availableImages = availableImages || null;
         this._evaluator.formattedSection = formattedSection || null;
         this._evaluator.featureTileCoord = featureTileCoord || null;
@@ -110,7 +110,7 @@ export class StyleExpression {
     }
 }
 
-export function isExpression(expression: mixed) {
+export function isExpression(expression: mixed): boolean {
     return Array.isArray(expression) && expression.length > 0 &&
         typeof expression[0] === 'string' && expression[0] in definitions;
 }

--- a/src/style-spec/expression/is_constant.js
+++ b/src/style-spec/expression/is_constant.js
@@ -4,7 +4,7 @@ import CompoundExpression from './compound_expression.js';
 import Within from './definitions/within.js';
 import type {Expression} from './expression.js';
 
-function isFeatureConstant(e: Expression) {
+function isFeatureConstant(e: Expression): boolean {
     if (e instanceof CompoundExpression) {
         if (e.name === 'get' && e.args.length === 1) {
             return false;
@@ -34,7 +34,7 @@ function isFeatureConstant(e: Expression) {
     return result;
 }
 
-function isStateConstant(e: Expression) {
+function isStateConstant(e: Expression): boolean {
     if (e instanceof CompoundExpression) {
         if (e.name === 'feature-state') {
             return false;
@@ -47,7 +47,7 @@ function isStateConstant(e: Expression) {
     return result;
 }
 
-function isGlobalPropertyConstant(e: Expression, properties: Array<string>) {
+function isGlobalPropertyConstant(e: Expression, properties: Array<string>): boolean {
     if (e instanceof CompoundExpression && properties.indexOf(e.name) >= 0) { return false; }
     let result = true;
     e.eachChild((arg) => {

--- a/src/style-spec/expression/parsing_context.js
+++ b/src/style-spec/expression/parsing_context.js
@@ -155,7 +155,7 @@ class ParsingContext {
      * parsing, is copied by reference rather than cloned.
      * @private
      */
-    concat(index: number, expectedType?: ?Type, bindings?: Array<[string, Expression]>) {
+    concat(index: number, expectedType?: ?Type, bindings?: Array<[string, Expression]>): ParsingContext {
         const path = typeof index === 'number' ? this.path.concat(index) : this.path;
         const scope = bindings ? this.scope.concat(bindings) : this.scope;
         return new ParsingContext(

--- a/src/style-spec/expression/runtime_error.js
+++ b/src/style-spec/expression/runtime_error.js
@@ -9,7 +9,7 @@ class RuntimeError {
         this.message = message;
     }
 
-    toJSON() {
+    toJSON(): string {
         return this.message;
     }
 }

--- a/src/style-spec/expression/scope.js
+++ b/src/style-spec/expression/scope.js
@@ -17,7 +17,7 @@ class Scope {
         }
     }
 
-    concat(bindings: Array<[string, Expression]>) {
+    concat(bindings: Array<[string, Expression]>): Scope {
         return new Scope(this, bindings);
     }
 

--- a/src/style-spec/expression/stops.js
+++ b/src/style-spec/expression/stops.js
@@ -10,7 +10,7 @@ export type Stops = Array<[number, Expression]>;
  * Returns the index of the last stop <= input, or 0 if it doesn't exist.
  * @private
  */
-export function findStopLessThanOrEqualTo(stops: Array<number>, input: number) {
+export function findStopLessThanOrEqualTo(stops: Array<number>, input: number): number {
     const lastIndex = stops.length - 1;
     let lowerIndex = 0;
     let upperIndex = lastIndex;

--- a/src/style-spec/expression/values.js
+++ b/src/style-spec/expression/values.js
@@ -107,7 +107,7 @@ export function typeOf(value: Value): Type {
     }
 }
 
-export function toString(value: Value) {
+export function toString(value: Value): string {
     const type = typeof value;
     if (value === null) {
         return '';

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -15,7 +15,7 @@ export type FeatureFilter = {filter: FilterExpression, dynamicFilter?: FilterExp
 export default createFilter;
 export {isExpressionFilter, isDynamicFilter, extractStaticFilter};
 
-function isExpressionFilter(filter: any) {
+function isExpressionFilter(filter: any): boolean {
     if (filter === true || filter === false) {
         return true;
     }


### PR DESCRIPTION
A part of https://github.com/mapbox/mapbox-gl-js/issues/11426. Add missing export types to a `style-spec/expression/*`