### PR TITLE
[Flow] Add missing export types to style-spec/expression/definitions/*

### DIFF
--- a/src/style-spec/expression/definitions/assertion.js
+++ b/src/style-spec/expression/definitions/assertion.js
@@ -85,7 +85,7 @@ class Assertion implements Expression {
         return new Assertion(type, parsed);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any | null {
         for (let i = 0; i < this.args.length; i++) {
             const value = this.args[i].evaluate(ctx);
             const error = checkSubtype(this.type, typeOf(value));

--- a/src/style-spec/expression/definitions/at.js
+++ b/src/style-spec/expression/definitions/at.js
@@ -21,7 +21,7 @@ class At implements Expression {
         this.input = input;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?At {
         if (args.length !== 3)
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`);
 
@@ -34,7 +34,7 @@ class At implements Expression {
         return new At(t.itemType, index, input);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): Value {
         const index = ((this.index.evaluate(ctx): any): number);
         const array = ((this.input.evaluate(ctx): any): Array<Value>);
 
@@ -58,7 +58,7 @@ class At implements Expression {
         fn(this.input);
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return false;
     }
 

--- a/src/style-spec/expression/definitions/case.js
+++ b/src/style-spec/expression/definitions/case.js
@@ -23,7 +23,7 @@ class Case implements Expression {
         this.otherwise = otherwise;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Case {
         if (args.length < 4)
             return context.error(`Expected at least 3 arguments, but found only ${args.length - 1}.`);
         if (args.length % 2 !== 0)
@@ -54,7 +54,7 @@ class Case implements Expression {
         return new Case((outputType: any), branches, otherwise);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         for (const [test, expression] of this.branches) {
             if (test.evaluate(ctx)) {
                 return expression.evaluate(ctx);

--- a/src/style-spec/expression/definitions/coalesce.js
+++ b/src/style-spec/expression/definitions/coalesce.js
@@ -19,7 +19,7 @@ class Coalesce implements Expression {
         this.args = args;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Coalesce {
         if (args.length < 2) {
             return context.error("Expectected at least one argument.");
         }
@@ -51,7 +51,7 @@ class Coalesce implements Expression {
             new Coalesce((outputType: any), parsedArgs);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any | null {
         let result = null;
         let argCount = 0;
         let firstImage;

--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -60,7 +60,7 @@ class Coercion implements Expression {
         return new Coercion(type, parsed);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): null | boolean | number | string | Color | Formatted | ResolvedImage {
         if (this.type.kind === 'boolean') {
             return Boolean(this.args[0].evaluate(ctx));
         } else if (this.type.kind === 'color') {

--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -46,7 +46,7 @@ export default class CollatorExpression implements Expression {
         return new CollatorExpression(caseSensitive, diacriticSensitive, locale);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): Collator {
         return new Collator(this.caseSensitive.evaluate(ctx), this.diacriticSensitive.evaluate(ctx), this.locale ? this.locale.evaluate(ctx) : null);
     }
 
@@ -58,7 +58,7 @@ export default class CollatorExpression implements Expression {
         }
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         // Technically the set of possible outputs is the combinatoric set of Collators produced
         // by all possible outputs of locale/caseSensitive/diacriticSensitive
         // But for the primary use of Collators in comparison operators, we ignore the Collator's

--- a/src/style-spec/expression/definitions/comparison.js
+++ b/src/style-spec/expression/definitions/comparison.js
@@ -176,9 +176,9 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
     };
 }
 
-export const Equals = makeComparison('==', eq, eqCollate);
-export const NotEquals = makeComparison('!=', neq, neqCollate);
-export const LessThan = makeComparison('<', lt, ltCollate);
-export const GreaterThan = makeComparison('>', gt, gtCollate);
-export const LessThanOrEqual = makeComparison('<=', lteq, lteqCollate);
-export const GreaterThanOrEqual = makeComparison('>=', gteq, gteqCollate);
+export const Equals: $Call<typeof makeComparison, '==', typeof eq, typeof eqCollate> = makeComparison('==', eq, eqCollate);
+export const NotEquals: $Call<typeof makeComparison, '!=', typeof neq, typeof neqCollate> = makeComparison('!=', neq, neqCollate);
+export const LessThan: $Call<typeof makeComparison, '<', typeof lt, typeof ltCollate> = makeComparison('<', lt, ltCollate);
+export const GreaterThan: $Call<typeof makeComparison, '>', typeof gt, typeof gtCollate> = makeComparison('>', gt, gtCollate);
+export const LessThanOrEqual: $Call<typeof makeComparison, '<=', typeof lteq, typeof lteqCollate> = makeComparison('<=', lteq, lteqCollate);
+export const GreaterThanOrEqual: $Call<typeof makeComparison, '>=', typeof gteq, typeof gteqCollate> = makeComparison('>=', gteq, gteqCollate);

--- a/src/style-spec/expression/definitions/format.js
+++ b/src/style-spec/expression/definitions/format.js
@@ -83,7 +83,7 @@ export default class FormatExpression implements Expression {
         return new FormatExpression(sections);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): Formatted {
         const evaluateSection = section => {
             const evaluatedContent = section.content.evaluate(ctx);
             if (typeOf(evaluatedContent) === ResolvedImageType) {
@@ -117,7 +117,7 @@ export default class FormatExpression implements Expression {
         }
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         // Technically the combinatoric set of all children
         // Usually, this.text will be undefined anyway
         return false;

--- a/src/style-spec/expression/definitions/image.js
+++ b/src/style-spec/expression/definitions/image.js
@@ -28,7 +28,7 @@ export default class ImageExpression implements Expression {
         return new ImageExpression(name);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): null | ResolvedImage {
         const evaluatedImageName = this.input.evaluate(ctx);
 
         const value = ResolvedImage.fromString(evaluatedImageName);
@@ -41,7 +41,7 @@ export default class ImageExpression implements Expression {
         fn(this.input);
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         // The output of image is determined by the list of available images in the evaluation context
         return false;
     }

--- a/src/style-spec/expression/definitions/in.js
+++ b/src/style-spec/expression/definitions/in.js
@@ -20,7 +20,7 @@ class In implements Expression {
         this.haystack = haystack;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?In {
         if (args.length !== 3) {
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`);
         }
@@ -38,7 +38,7 @@ class In implements Expression {
         return new In(needle, haystack);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): boolean {
         const needle = (this.needle.evaluate(ctx): any);
         const haystack = (this.haystack.evaluate(ctx): any);
 
@@ -60,7 +60,7 @@ class In implements Expression {
         fn(this.haystack);
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return true;
     }
 

--- a/src/style-spec/expression/definitions/index_of.js
+++ b/src/style-spec/expression/definitions/index_of.js
@@ -22,7 +22,7 @@ class IndexOf implements Expression {
         this.fromIndex = fromIndex;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?IndexOf {
         if (args.length <= 2 ||  args.length >= 5) {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`);
         }
@@ -45,7 +45,7 @@ class IndexOf implements Expression {
         }
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         const needle = (this.needle.evaluate(ctx): any);
         const haystack = (this.haystack.evaluate(ctx): any);
 
@@ -73,7 +73,7 @@ class IndexOf implements Expression {
         }
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return false;
     }
 

--- a/src/style-spec/expression/definitions/interpolate.js
+++ b/src/style-spec/expression/definitions/interpolate.js
@@ -41,7 +41,7 @@ class Interpolate implements Expression {
         }
     }
 
-    static interpolationFactor(interpolation: InterpolationType, input: number, lower: number, upper: number) {
+    static interpolationFactor(interpolation: InterpolationType, input: number, lower: number, upper: number): number {
         let t = 0;
         if (interpolation.name === 'exponential') {
             t = exponentialInterpolation(input, interpolation.base, lower, upper);
@@ -55,7 +55,7 @@ class Interpolate implements Expression {
         return t;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Interpolate {
         let [operator, interpolation, input, ...rest] = args;
 
         if (!Array.isArray(interpolation) || interpolation.length === 0) {

--- a/src/style-spec/expression/definitions/length.js
+++ b/src/style-spec/expression/definitions/length.js
@@ -19,7 +19,7 @@ class Length implements Expression {
         this.input = input;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Length {
         if (args.length !== 2)
             return context.error(`Expected 1 argument, but found ${args.length - 1} instead.`);
 
@@ -32,7 +32,7 @@ class Length implements Expression {
         return new Length(input);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any | number {
         const input = this.input.evaluate(ctx);
         if (typeof input === 'string') {
             return input.length;
@@ -47,7 +47,7 @@ class Length implements Expression {
         fn(this.input);
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return false;
     }
 

--- a/src/style-spec/expression/definitions/let.js
+++ b/src/style-spec/expression/definitions/let.js
@@ -16,7 +16,7 @@ class Let implements Expression {
         this.result = result;
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         return this.result.evaluate(ctx);
     }
 
@@ -27,7 +27,7 @@ class Let implements Expression {
         fn(this.result);
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Let {
         if (args.length < 4)
             return context.error(`Expected at least 3 arguments, but found ${args.length - 1} instead.`);
 
@@ -55,7 +55,7 @@ class Let implements Expression {
         return new Let(bindings, result);
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return this.result.outputDefined();
     }
 

--- a/src/style-spec/expression/definitions/literal.js
+++ b/src/style-spec/expression/definitions/literal.js
@@ -18,7 +18,7 @@ class Literal implements Expression {
         this.value = value;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): void | Literal {
         if (args.length !== 2)
             return context.error(`'literal' expression requires exactly one argument, but found ${args.length - 1} instead.`);
 
@@ -43,13 +43,13 @@ class Literal implements Expression {
         return new Literal(type, value);
     }
 
-    evaluate() {
+    evaluate(): Value {
         return this.value;
     }
 
     eachChild() {}
 
-    outputDefined() {
+    outputDefined(): boolean {
         return true;
     }
 

--- a/src/style-spec/expression/definitions/match.js
+++ b/src/style-spec/expression/definitions/match.js
@@ -30,7 +30,7 @@ class Match implements Expression {
         this.otherwise = otherwise;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Match {
         if (args.length < 5)
             return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
         if (args.length % 2 !== 1)
@@ -99,7 +99,7 @@ class Match implements Expression {
         return new Match((inputType: any), (outputType: any), input, cases, outputs, otherwise);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         const input = (this.input.evaluate(ctx): any);
         const output = (typeOf(input) === this.inputType && this.outputs[this.cases[input]]) || this.otherwise;
         return output.evaluate(ctx);

--- a/src/style-spec/expression/definitions/number_format.js
+++ b/src/style-spec/expression/definitions/number_format.js
@@ -93,7 +93,7 @@ export default class NumberFormat implements Expression {
         return new NumberFormat(number, locale, currency, minFractionDigits, maxFractionDigits);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): string {
         return new Intl.NumberFormat(this.locale ? this.locale.evaluate(ctx) : [],
             {
                 style: this.currency ? "currency" : "decimal",
@@ -119,7 +119,7 @@ export default class NumberFormat implements Expression {
         }
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return false;
     }
 

--- a/src/style-spec/expression/definitions/slice.js
+++ b/src/style-spec/expression/definitions/slice.js
@@ -23,7 +23,7 @@ class Slice implements Expression {
 
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Slice {
         if (args.length <= 2 ||  args.length >= 5) {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`);
         }
@@ -46,7 +46,7 @@ class Slice implements Expression {
         }
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         const input = (this.input.evaluate(ctx): any);
         const beginIndex = (this.beginIndex.evaluate(ctx): number);
 
@@ -70,7 +70,7 @@ class Slice implements Expression {
         }
     }
 
-    outputDefined() {
+    outputDefined(): boolean {
         return false;
     }
 

--- a/src/style-spec/expression/definitions/step.js
+++ b/src/style-spec/expression/definitions/step.js
@@ -29,7 +29,7 @@ class Step implements Expression {
         }
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): ?Step {
         if (args.length - 1 < 4) {
             return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
         }
@@ -72,7 +72,7 @@ class Step implements Expression {
         return new Step(outputType, input, stops);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         const labels = this.labels;
         const outputs = this.outputs;
 

--- a/src/style-spec/expression/definitions/var.js
+++ b/src/style-spec/expression/definitions/var.js
@@ -16,7 +16,7 @@ class Var implements Expression {
         this.boundExpression = boundExpression;
     }
 
-    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext) {
+    static parse(args: $ReadOnlyArray<mixed>, context: ParsingContext): void | Var {
         if (args.length !== 2 || typeof args[1] !== 'string')
             return context.error(`'var' expression requires exactly one string literal argument.`);
 
@@ -28,17 +28,17 @@ class Var implements Expression {
         return new Var(name, context.scope.get(name));
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): any {
         return this.boundExpression.evaluate(ctx);
     }
 
     eachChild() {}
 
-    outputDefined() {
+    outputDefined(): boolean {
         return false;
     }
 
-    serialize() {
+    serialize(): Array<string> {
         return ["var", this.name];
     }
 }

--- a/src/style-spec/expression/expression.js
+++ b/src/style-spec/expression/expression.js
@@ -4,7 +4,7 @@ import type {Type} from './types.js';
 import type ParsingContext from './parsing_context.js';
 import type EvaluationContext from './evaluation_context.js';
 
-type SerializedExpression = Array<mixed> | string | number | boolean | null;
+type SerializedExpression = Array<mixed> | Array<string> | string | number | boolean | null;
 
 export interface Expression {
     +type: Type;


### PR DESCRIPTION
A part of https://github.com/mapbox/mapbox-gl-js/issues/11426. Add missing export types to a `style-spec/expression/definitions/*`