### PR TITLE
[Flow] Add missing export types to style-spec/expression/definitions/*

### DIFF
--- a/src/style-spec/expression/definitions/assertion.js
+++ b/src/style-spec/expression/definitions/assertion.js
@@ -15,7 +15,7 @@ import {
 import RuntimeError from '../runtime_error.js';
 import {typeOf} from '../values.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -108,7 +108,7 @@ class Assertion implements Expression {
         return this.args.every(arg => arg.outputDefined());
     }
 
-    serialize(): Array<mixed> {
+    serialize(): SerializedExpression {
         const type = this.type;
         const serialized = [type.kind];
         if (type.kind === 'array') {

--- a/src/style-spec/expression/definitions/at.js
+++ b/src/style-spec/expression/definitions/at.js
@@ -4,7 +4,7 @@ import {array, ValueType, NumberType} from '../types.js';
 
 import RuntimeError from '../runtime_error.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type, ArrayType} from '../types.js';
@@ -62,7 +62,7 @@ class At implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         return ["at", this.index.serialize(), this.input.serialize()];
     }
 }

--- a/src/style-spec/expression/definitions/case.js
+++ b/src/style-spec/expression/definitions/case.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 
 import {BooleanType} from '../types.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -75,7 +75,7 @@ class Case implements Expression {
         return this.branches.every(([_, out]) => out.outputDefined()) && this.otherwise.outputDefined();
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const serialized = ["case"];
         this.eachChild(child => { serialized.push(child.serialize()); });
         return serialized;

--- a/src/style-spec/expression/definitions/coalesce.js
+++ b/src/style-spec/expression/definitions/coalesce.js
@@ -5,7 +5,7 @@ import assert from 'assert';
 import {checkSubtype, ValueType} from '../types.js';
 import ResolvedImage from '../types/resolved_image.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -85,7 +85,7 @@ class Coalesce implements Expression {
         return this.args.every(arg => arg.outputDefined());
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const serialized = ["coalesce"];
         this.eachChild(child => { serialized.push(child.serialize()); });
         return serialized;

--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -10,7 +10,7 @@ import FormatExpression from '../definitions/format.js';
 import ImageExpression from '../definitions/image.js';
 import ResolvedImage from '../types/resolved_image.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -115,7 +115,7 @@ class Coercion implements Expression {
         return this.args.every(arg => arg.outputDefined());
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         if (this.type.kind === 'formatted') {
             return new FormatExpression([{content: this.args[0], scale: null, font: null, textColor: null}]).serialize();
         }

--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -3,7 +3,7 @@
 import {StringType, BooleanType, CollatorType} from '../types.js';
 import Collator from '../types/collator.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type ParsingContext from '../parsing_context.js';
 import type {Type} from '../types.js';
@@ -66,7 +66,7 @@ export default class CollatorExpression implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const options = {};
         options['case-sensitive'] = this.caseSensitive.serialize();
         options['diacritic-sensitive'] = this.diacriticSensitive.serialize();

--- a/src/style-spec/expression/definitions/format.js
+++ b/src/style-spec/expression/definitions/format.js
@@ -4,7 +4,7 @@ import {NumberType, ValueType, FormattedType, array, StringType, ColorType, Reso
 import Formatted, {FormattedSection} from '../types/formatted.js';
 import {toString, typeOf} from '../values.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type ParsingContext from '../parsing_context.js';
 import type {Type} from '../types.js';
@@ -123,7 +123,7 @@ export default class FormatExpression implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const serialized = ["format"];
         for (const section of this.sections) {
             serialized.push(section.content.serialize());

--- a/src/style-spec/expression/definitions/image.js
+++ b/src/style-spec/expression/definitions/image.js
@@ -3,7 +3,7 @@
 import {ResolvedImageType, StringType} from '../types.js';
 import ResolvedImage from '../types/resolved_image.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type ParsingContext from '../parsing_context.js';
 import type {Type} from '../types.js';
@@ -46,7 +46,7 @@ export default class ImageExpression implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         return ["image", this.input.serialize()];
     }
 }

--- a/src/style-spec/expression/definitions/in.js
+++ b/src/style-spec/expression/definitions/in.js
@@ -4,7 +4,7 @@ import {BooleanType, StringType, ValueType, NullType, toString, NumberType, isVa
 import RuntimeError from '../runtime_error.js';
 import {typeOf} from '../values.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -64,7 +64,7 @@ class In implements Expression {
         return true;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         return ["in", this.needle.serialize(), this.haystack.serialize()];
     }
 }

--- a/src/style-spec/expression/definitions/index_of.js
+++ b/src/style-spec/expression/definitions/index_of.js
@@ -4,7 +4,7 @@ import {BooleanType, StringType, ValueType, NullType, toString, NumberType, isVa
 import RuntimeError from '../runtime_error.js';
 import {typeOf} from '../values.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -77,7 +77,7 @@ class IndexOf implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         if (this.fromIndex != null && this.fromIndex !== undefined) {
             const fromIndex = this.fromIndex.serialize();
             return ["index-of", this.needle.serialize(), this.haystack.serialize(), fromIndex];

--- a/src/style-spec/expression/definitions/interpolate.js
+++ b/src/style-spec/expression/definitions/interpolate.js
@@ -6,9 +6,10 @@ import * as interpolate from '../../util/interpolate.js';
 import {toString, NumberType, ColorType} from '../types.js';
 import {findStopLessThanOrEqualTo} from '../stops.js';
 import {hcl, lab} from '../../util/color_spaces.js';
+import Color from '../../util/color.js';
 
 import type {Stops} from '../stops.js';
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -144,7 +145,7 @@ class Interpolate implements Expression {
         return new Interpolate(outputType, (operator: any), interpolation, input, stops);
     }
 
-    evaluate(ctx: EvaluationContext) {
+    evaluate(ctx: EvaluationContext): Color {
         const labels = this.labels;
         const outputs = this.outputs;
 
@@ -190,7 +191,7 @@ class Interpolate implements Expression {
         return this.outputs.every(out => out.outputDefined());
     }
 
-    serialize(): Array<mixed> {
+    serialize(): SerializedExpression {
         let interpolation;
         if (this.interpolation.name === 'linear') {
             interpolation = ["linear"];

--- a/src/style-spec/expression/definitions/length.js
+++ b/src/style-spec/expression/definitions/length.js
@@ -5,7 +5,7 @@ import {NumberType, toString} from '../types.js';
 import {typeOf} from '../values.js';
 import RuntimeError from '../runtime_error.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -51,7 +51,7 @@ class Length implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const serialized = ["length"];
         this.eachChild(child => { serialized.push(child.serialize()); });
         return serialized;

--- a/src/style-spec/expression/definitions/let.js
+++ b/src/style-spec/expression/definitions/let.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Type} from '../types.js';
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext  from '../evaluation_context.js';
 
@@ -59,7 +59,7 @@ class Let implements Expression {
         return this.result.outputDefined();
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const serialized = ["let"];
         for (const [name, expr] of this.bindings) {
             serialized.push(name, expr.serialize());

--- a/src/style-spec/expression/definitions/literal.js
+++ b/src/style-spec/expression/definitions/literal.js
@@ -6,7 +6,7 @@ import Formatted from '../types/formatted.js';
 
 import type {Type} from '../types.js';
 import type {Value}  from '../values.js';
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 
 class Literal implements Expression {
@@ -53,7 +53,7 @@ class Literal implements Expression {
         return true;
     }
 
-    serialize(): Array<mixed> {
+    serialize(): SerializedExpression {
         if (this.type.kind === 'array' || this.type.kind === 'object') {
             return ["literal", this.value];
         } else if (this.value instanceof Color) {

--- a/src/style-spec/expression/definitions/match.js
+++ b/src/style-spec/expression/definitions/match.js
@@ -5,7 +5,7 @@ import assert from 'assert';
 import {typeOf} from '../values.js';
 import {ValueType, type Type} from '../types.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 
@@ -115,7 +115,7 @@ class Match implements Expression {
         return this.outputs.every(out => out.outputDefined()) && this.otherwise.outputDefined();
     }
 
-    serialize(): Array<mixed> {
+    serialize(): SerializedExpression {
         const serialized = ["match", this.input.serialize()];
 
         // Sort so serialization has an arbitrary defined order, even though

--- a/src/style-spec/expression/definitions/number_format.js
+++ b/src/style-spec/expression/definitions/number_format.js
@@ -2,7 +2,7 @@
 
 import {StringType, NumberType} from '../types.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type ParsingContext from '../parsing_context.js';
 import type {Type} from '../types.js';
@@ -123,7 +123,7 @@ export default class NumberFormat implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const options = {};
         if (this.locale) {
             options['locale'] = this.locale.serialize();

--- a/src/style-spec/expression/definitions/slice.js
+++ b/src/style-spec/expression/definitions/slice.js
@@ -4,7 +4,7 @@ import {ValueType, NumberType, StringType, array, toString, isValidType, isValid
 import RuntimeError from '../runtime_error.js';
 import {typeOf} from '../values.js';
 
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -74,7 +74,7 @@ class Slice implements Expression {
         return false;
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         if (this.endIndex != null && this.endIndex !== undefined) {
             const endIndex = this.endIndex.serialize();
             return ["slice", this.input.serialize(), this.beginIndex.serialize(), endIndex];

--- a/src/style-spec/expression/definitions/step.js
+++ b/src/style-spec/expression/definitions/step.js
@@ -5,7 +5,7 @@ import {NumberType} from '../types.js';
 import {findStopLessThanOrEqualTo} from '../stops.js';
 
 import type {Stops} from '../stops.js';
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {Type} from '../types.js';
@@ -105,7 +105,7 @@ class Step implements Expression {
         return this.outputs.every(out => out.outputDefined());
     }
 
-    serialize() {
+    serialize(): SerializedExpression {
         const serialized = ["step", this.input.serialize()];
         for (let i = 0; i < this.labels.length; i++) {
             if (i > 0) {

--- a/src/style-spec/expression/definitions/within.js
+++ b/src/style-spec/expression/definitions/within.js
@@ -3,7 +3,7 @@
 import {isValue} from '../values.js';
 import type {Type} from '../types.js';
 import {BooleanType} from '../types.js';
-import type {Expression} from '../expression.js';
+import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {GeoJSON, GeoJSONPolygon, GeoJSONMultiPolygon} from '@mapbox/geojson-types';
@@ -339,7 +339,7 @@ class Within implements Expression {
         return true;
     }
 
-    serialize(): Array<mixed> {
+    serialize(): SerializedExpression {
         return ["within", this.geojson];
     }
 

--- a/src/style-spec/expression/evaluation_context.js
+++ b/src/style-spec/expression/evaluation_context.js
@@ -34,8 +34,8 @@ class EvaluationContext {
         this.featureDistanceData = null;
     }
 
-    id(): null | any {
-        return this.feature && 'id' in this.feature ? this.feature.id : null;
+    id(): number | null {
+        return this.feature && 'id' in this.feature && this.feature.id ? this.feature.id : null;
     }
 
     geometryType(): null | string {

--- a/src/style-spec/expression/expression.js
+++ b/src/style-spec/expression/expression.js
@@ -4,7 +4,7 @@ import type {Type} from './types.js';
 import type ParsingContext from './parsing_context.js';
 import type EvaluationContext from './evaluation_context.js';
 
-type SerializedExpression = Array<mixed> | Array<string> | string | number | boolean | null;
+export type SerializedExpression = Array<mixed> | Array<string> | string | number | boolean | null;
 
 export interface Expression {
     +type: Type;

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -31,7 +31,7 @@ import type {FeatureDistanceData} from '../feature_filter/index.js';
 
 export type Feature = {
     +type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon',
-    +id?: any,
+    +id?: number | null,
     +properties: {[_: string]: any},
     +patterns?: {[_: string]: {"min": string, "mid": string, "max": string}},
     +geometry?: Array<Array<Point>>


### PR DESCRIPTION
A part of https://github.com/mapbox/mapbox-gl-js/issues/11426. Add missing export types to a `style-spec/expression/definitions/*`