### PR TITLE
[Flow] Add missing export types to map.js & style.js

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -62,9 +62,15 @@ import type {
     TerrainSpecification,
     FogSpecification,
     SourceSpecification,
-    ProjectionSpecification
+    ProjectionSpecification,
+    PropertyValueSpecification,
+    TransitionSpecification
 } from '../style-spec/types.js';
+import type StyleLayer from '../style/style_layer.js';
 import type {ElevationQueryOptions} from '../terrain/elevation.js';
+import type {Source} from '../source/source.js';
+import type {QueryFeature} from '../util/vectortile_to_geojson.js';
+import type {QueryResult} from '../data/feature_index.js';
 
 export type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 /* eslint-disable no-use-before-define */
@@ -586,7 +592,7 @@ class Map extends Camera {
     * @private
     * @returns {number}
     */
-    _getMapId() {
+    _getMapId(): number {
         return this._mapId;
     }
 
@@ -604,7 +610,7 @@ class Map extends Camera {
      * map.addControl(new mapboxgl.NavigationControl());
      * @see [Example: Display map navigation controls](https://www.mapbox.com/mapbox-gl-js/example/navigation/)
      */
-    addControl(control: IControl, position?: ControlPosition) {
+    addControl(control: IControl, position?: ControlPosition): this {
         if (position === undefined) {
             if (control.getDefaultPosition) {
                 position = control.getDefaultPosition();
@@ -641,7 +647,7 @@ class Map extends Camera {
      * // Remove zoom and rotation controls from the map.
      * map.removeControl(navigation);
      */
-    removeControl(control: IControl) {
+    removeControl(control: IControl): this {
         if (!control || !control.onRemove) {
             return this.fire(new ErrorEvent(new Error(
                 'Invalid argument to map.removeControl(). Argument must be a control with onAdd and onRemove methods.')));
@@ -666,7 +672,7 @@ class Map extends Camera {
      * const added = map.hasControl(navigation);
      * // added === true
      */
-    hasControl(control: IControl) {
+    hasControl(control: IControl): boolean {
         return this._controls.indexOf(control) > -1;
     }
 
@@ -677,7 +683,7 @@ class Map extends Camera {
      * @example
      * const container = map.getContainer();
      */
-    getContainer() {
+    getContainer(): HTMLElement {
         return this._container;
     }
 
@@ -696,7 +702,7 @@ class Map extends Camera {
      * @see [Example: Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      * @see [Example: Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      */
-    getCanvasContainer() {
+    getCanvasContainer(): HTMLElement {
         return this._canvasContainer;
     }
 
@@ -710,7 +716,7 @@ class Map extends Camera {
      * @see [Example: Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
      * @see [Example: Center the map on a clicked symbol](https://www.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
      */
-    getCanvas() {
+    getCanvas(): HTMLCanvasElement {
         return this._canvas;
     }
 
@@ -734,7 +740,7 @@ class Map extends Camera {
      * const mapDiv = document.getElementById('map');
      * if (mapDiv.style.visibility === true) map.resize();
      */
-    resize(eventData?: Object) {
+    resize(eventData?: Object): this {
         this._updateContainerDimensions();
 
         // do nothing if container remained the same size
@@ -804,7 +810,7 @@ class Map extends Camera {
      * // Set the map's max bounds.
      * map.setMaxBounds(bounds);
      */
-    setMaxBounds(bounds: LngLatBoundsLike) {
+    setMaxBounds(bounds: LngLatBoundsLike): this {
         this.transform.setMaxBounds(LngLatBounds.convert(bounds));
         return this._update();
     }
@@ -825,7 +831,7 @@ class Map extends Camera {
      * @example
      * map.setMinZoom(12.25);
      */
-    setMinZoom(minZoom?: ?number) {
+    setMinZoom(minZoom?: ?number): this {
 
         minZoom = minZoom === null || minZoom === undefined ? defaultMinZoom : minZoom;
 
@@ -853,7 +859,7 @@ class Map extends Camera {
      * @example
      * const minZoom = map.getMinZoom();
      */
-    getMinZoom() { return this.transform.minZoom; }
+    getMinZoom(): number { return this.transform.minZoom; }
 
     /**
      * Sets or clears the map's maximum zoom level.
@@ -866,7 +872,7 @@ class Map extends Camera {
      * @example
      * map.setMaxZoom(18.75);
      */
-    setMaxZoom(maxZoom?: ?number) {
+    setMaxZoom(maxZoom?: ?number): this {
 
         maxZoom = maxZoom === null || maxZoom === undefined ? defaultMaxZoom : maxZoom;
 
@@ -894,7 +900,7 @@ class Map extends Camera {
      * @example
      * const maxZoom = map.getMaxZoom();
      */
-    getMaxZoom() { return this.transform.maxZoom; }
+    getMaxZoom(): number { return this.transform.maxZoom; }
 
     /**
      * Sets or clears the map's minimum pitch.
@@ -906,7 +912,7 @@ class Map extends Camera {
      * @example
      * map.setMinPitch(5);
      */
-    setMinPitch(minPitch?: ?number) {
+    setMinPitch(minPitch?: ?number): this {
 
         minPitch = minPitch === null || minPitch === undefined ? defaultMinPitch : minPitch;
 
@@ -938,7 +944,7 @@ class Map extends Camera {
      * @example
      * const minPitch = map.getMinPitch();
      */
-    getMinPitch() { return this.transform.minPitch; }
+    getMinPitch(): number { return this.transform.minPitch; }
 
     /**
      * Sets or clears the map's maximum pitch.
@@ -951,7 +957,7 @@ class Map extends Camera {
      * @example
      * map.setMaxPitch(70);
      */
-    setMaxPitch(maxPitch?: ?number) {
+    setMaxPitch(maxPitch?: ?number): this {
 
         maxPitch = maxPitch === null || maxPitch === undefined ? defaultMaxPitch : maxPitch;
 
@@ -983,7 +989,7 @@ class Map extends Camera {
      * @example
      * const maxPitch = map.getMaxPitch();
      */
-    getMaxPitch() { return this.transform.maxPitch; }
+    getMaxPitch(): number { return this.transform.maxPitch; }
 
     /**
      * Returns the state of `renderWorldCopies`. If `true`, multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude. If set to `false`:
@@ -997,7 +1003,7 @@ class Map extends Camera {
      * const worldCopiesRendered = map.getRenderWorldCopies();
      * @see [Example: Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
      */
-    getRenderWorldCopies() { return this.transform.renderWorldCopies; }
+    getRenderWorldCopies(): boolean { return this.transform.renderWorldCopies; }
 
     /**
      * Sets the state of `renderWorldCopies`.
@@ -1014,7 +1020,7 @@ class Map extends Camera {
      * map.setRenderWorldCopies(true);
      * @see [Example: Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
      */
-    setRenderWorldCopies(renderWorldCopies?: ?boolean) {
+    setRenderWorldCopies(renderWorldCopies?: ?boolean): this {
         this.transform.renderWorldCopies = renderWorldCopies;
         return this._update();
     }
@@ -1054,7 +1060,7 @@ class Map extends Camera {
      * @see [Example: Display a web map using an alternate projection](https://docs.mapbox.com/mapbox-gl-js/example/map-projection/)
      * @see [Example: Use different map projections for web maps](https://docs.mapbox.com/mapbox-gl-js/example/projections/)
      */
-    setProjection(projection?: ?ProjectionSpecification | string) {
+    setProjection(projection?: ?ProjectionSpecification | string): this {
         this._lazyInitEmptyStyle();
         if (!projection) {
             projection = null;
@@ -1064,7 +1070,7 @@ class Map extends Camera {
         return this._updateProjection(projection);
     }
 
-    _updateProjection(explicitProjection?: ProjectionSpecification | null) {
+    _updateProjection(explicitProjection?: ProjectionSpecification | null): this {
         const prevProjection = this.getProjection();
         if (explicitProjection === null) { this._explicitProjection = null; }
         const projection = explicitProjection || this.getProjection();
@@ -1112,7 +1118,7 @@ class Map extends Camera {
      * const coordinate = [-122.420679, 37.772537];
      * const point = map.project(coordinate);
      */
-    project(lnglat: LngLatLike) {
+    project(lnglat: LngLatLike): Point {
         return this.transform.locationPoint3D(LngLat.convert(lnglat));
     }
 
@@ -1130,7 +1136,7 @@ class Map extends Camera {
      *     const coordinate = map.unproject(e.point);
      * });
      */
-    unproject(point: PointLike) {
+    unproject(point: PointLike): LngLat {
         return this.transform.pointLocation3D(Point.convert(point));
     }
 
@@ -1169,7 +1175,7 @@ class Map extends Camera {
         return this._rotating || (this.handlers && this.handlers.isRotating()) || false;
     }
 
-    _createDelegatedListener(type: MapEvent, layers: Array<any>, listener: any) {
+    _createDelegatedListener(type: MapEvent, layers: Array<any>, listener: any): any {
         if (type === 'mouseenter' || type === 'mouseover') {
             let mousein = false;
             const mousemove = (e) => {
@@ -1337,7 +1343,7 @@ class Map extends Camera {
      * @see [Example: Create a hover effect](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/)
      * @see [Example: Display popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
      */
-    on(type: MapEvent, layerIds: any, listener: any) {
+    on(type: MapEvent, layerIds: any, listener: any): this {
         if (listener === undefined) {
             return super.on(type, layerIds);
         }
@@ -1397,7 +1403,7 @@ class Map extends Camera {
      * @see [Example: Animate the camera around a point with 3D terrain](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-point/)
      * @see [Example: Play map locations as a slideshow](https://docs.mapbox.com/mapbox-gl-js/example/playback-locations/)
      */
-    once(type: MapEvent, layerIds: any, listener: any) {
+    once(type: MapEvent, layerIds: any, listener: any): this | Promise<Event> {
 
         if (listener === undefined) {
             return super.once(type, layerIds);
@@ -1440,7 +1446,7 @@ class Map extends Camera {
      * });
      * @see [Example: Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
-    off(type: MapEvent, layerIds: any, listener: any) {
+    off(type: MapEvent, layerIds: any, listener: any): this {
         if (listener === undefined) {
             return super.off(type, layerIds);
         }
@@ -1561,7 +1567,7 @@ class Map extends Camera {
      * @see [Example: Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      * @see [Example: Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
      */
-    queryRenderedFeatures(geometry?: PointLike | [PointLike, PointLike], options?: Object) {
+    queryRenderedFeatures(geometry?: PointLike | [PointLike, PointLike], options?: Object): Array<QueryResult> {
         // The first parameter can be omitted entirely, making this effectively an overloaded method
         // with two signatures:
         //
@@ -1623,7 +1629,7 @@ class Map extends Camera {
      *
      * @see [Example: Highlight features containing similar data](https://www.mapbox.com/mapbox-gl-js/example/query-similar-features/)
      */
-    querySourceFeatures(sourceId: string, parameters: ?{sourceLayer: ?string, filter: ?Array<any>, validate?: boolean}) {
+    querySourceFeatures(sourceId: string, parameters: ?{sourceLayer: ?string, filter: ?Array<any>, validate?: boolean}): Array<QueryFeature> {
         return this.style.querySourceFeatures(sourceId, parameters);
     }
 
@@ -1680,7 +1686,7 @@ class Map extends Camera {
      *
      * @see [Example: Change a map's style](https://www.mapbox.com/mapbox-gl-js/example/setstyle/)
      */
-    setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
+    setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions): this {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily, localFontFamily: this._localFontFamily}, options);
 
         if ((options.diff !== false &&
@@ -1695,7 +1701,7 @@ class Map extends Camera {
         }
     }
 
-    _getUIString(key: string) {
+    _getUIString(key: string): string {
         const str = this._locale[key];
         if (str == null) {
             throw new Error(`Missing UI string '${key}'`);
@@ -1704,7 +1710,7 @@ class Map extends Camera {
         return str;
     }
 
-    _updateStyle(style: StyleSpecification | string | null,  options?: {diff?: boolean} & StyleOptions) {
+    _updateStyle(style: StyleSpecification | string | null,  options?: {diff?: boolean} & StyleOptions): this {
         if (this.style) {
             this.style.setEventedParent(null);
             this.style._remove();
@@ -1773,7 +1779,7 @@ class Map extends Camera {
      * });
      *
      */
-    getStyle() {
+    getStyle(): ?StyleSpecification {
         if (this.style) {
             return this.style.serialize();
         }
@@ -1787,8 +1793,11 @@ class Map extends Camera {
      * @example
      * const styleLoadStatus = map.isStyleLoaded();
      */
-    isStyleLoaded() {
-        if (!this.style) return warnOnce('There is no style added to the map.');
+    isStyleLoaded(): boolean {
+        if (!this.style) {
+            warnOnce('There is no style added to the map.');
+            return false;
+        }
         return this.style.loaded();
     }
 
@@ -1826,7 +1835,7 @@ class Map extends Camera {
      * @see Example: GeoJSON source: [Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
      * @see Example: Raster DEM source: [Add hillshading](https://docs.mapbox.com/mapbox-gl-js/example/hillshade/)
      */
-    addSource(id: string, source: SourceSpecification) {
+    addSource(id: string, source: SourceSpecification): this {
         this._lazyInitEmptyStyle();
         this.style.addSource(id, source);
         return this._update(true);
@@ -1841,8 +1850,8 @@ class Map extends Camera {
      * @example
      * const sourceLoaded = map.isSourceLoaded('bathymetry-data');
      */
-    isSourceLoaded(id: string) {
-        return this.style && this.style._isSourceCacheLoaded(id);
+    isSourceLoaded(id: string): boolean {
+        return !!this.style && this.style._isSourceCacheLoaded(id);
     }
 
     /**
@@ -1854,7 +1863,7 @@ class Map extends Camera {
      * const tilesLoaded = map.areTilesLoaded();
      */
 
-    areTilesLoaded() {
+    areTilesLoaded(): boolean {
         const sources = this.style && this.style._sourceCaches;
         for (const id in sources) {
             const source = sources[id];
@@ -1877,7 +1886,7 @@ class Map extends Camera {
      */
     addSourceType(name: string, SourceType: any, callback: Function) {
         this._lazyInitEmptyStyle();
-        return this.style.addSourceType(name, SourceType, callback);
+        this.style.addSourceType(name, SourceType, callback);
     }
 
     /**
@@ -1888,7 +1897,7 @@ class Map extends Camera {
      * @example
      * map.removeSource('bathymetry-data');
      */
-    removeSource(id: string) {
+    removeSource(id: string): this {
         this.style.removeSource(id);
         this._updateTerrain();
         return this._update(true);
@@ -1914,7 +1923,7 @@ class Map extends Camera {
      * @see [Example: Animate a point](https://docs.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
      * @see [Example: Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
      */
-    getSource(id: string) {
+    getSource(id: string): ?Source {
         return this.style.getSource(id);
     }
 
@@ -1975,9 +1984,10 @@ class Map extends Camera {
             const {width, height, data} = browser.getImageData(image);
             this.style.addImage(id, {data: new RGBAImage({width, height}, data), pixelRatio, stretchX, stretchY, content, sdf, version});
         } else if (image.width === undefined || image.height === undefined) {
-            return this.fire(new ErrorEvent(new Error(
+            this.fire(new ErrorEvent(new Error(
                 'Invalid arguments to map.addImage(). The second argument must be an `HTMLImageElement`, `ImageData`, `ImageBitmap`, ' +
                 'or object with `width`, `height`, and `data` properties with the same format as `ImageData`')));
+            return;
         } else {
             const {width, height} = image;
             const userImage = ((image: any): StyleImageInterface);
@@ -2023,8 +2033,9 @@ class Map extends Camera {
 
         const existingImage = this.style.getImage(id);
         if (!existingImage) {
-            return this.fire(new ErrorEvent(new Error(
+            this.fire(new ErrorEvent(new Error(
                 'The map has no image with that id. If you are adding a new image use `map.addImage(...)` instead.')));
+            return;
         }
         const imageData = (image instanceof window.HTMLImageElement || (window.ImageBitmap && image instanceof window.ImageBitmap)) ? browser.getImageData(image) : image;
         const {width, height} = imageData;
@@ -2032,14 +2043,16 @@ class Map extends Camera {
         const data = ((imageData: any).data: Uint8Array | Uint8ClampedArray);
 
         if (width === undefined || height === undefined) {
-            return this.fire(new ErrorEvent(new Error(
+            this.fire(new ErrorEvent(new Error(
                 'Invalid arguments to map.updateImage(). The second argument must be an `HTMLImageElement`, `ImageData`, `ImageBitmap`, ' +
                 'or object with `width`, `height`, and `data` properties with the same format as `ImageData`')));
+            return;
         }
 
         if (width !== existingImage.data.width || height !== existingImage.data.height) {
-            return this.fire(new ErrorEvent(new Error(
+            this.fire(new ErrorEvent(new Error(
                 'The width and height of the updated image must be that same as the previous version of the image')));
+            return;
         }
 
         const copy = !(image instanceof window.HTMLImageElement || (window.ImageBitmap && image instanceof window.ImageBitmap));
@@ -2120,7 +2133,7 @@ class Map extends Camera {
     * const allImages = map.listImages();
     *
     */
-    listImages() {
+    listImages(): Array<string> {
         return this.style.listImages();
     }
 
@@ -2235,7 +2248,7 @@ class Map extends Camera {
      * @see [Example: Add a vector tile source](https://docs.mapbox.com/mapbox-gl-js/example/vector-source/)
      * @see [Example: Add a WMS source](https://docs.mapbox.com/mapbox-gl-js/example/wms/)
      */
-    addLayer(layer: LayerSpecification | CustomLayerInterface, beforeId?: string) {
+    addLayer(layer: LayerSpecification | CustomLayerInterface, beforeId?: string): this {
         this._lazyInitEmptyStyle();
         this.style.addLayer(layer, beforeId);
         return this._update(true);
@@ -2252,7 +2265,7 @@ class Map extends Camera {
      * // Move a layer with ID 'polygon' before the layer with ID 'country-label'. The `polygon` layer will appear beneath the `country-label` layer on the map.
      * map.moveLayer('polygon', 'country-label');
      */
-    moveLayer(id: string, beforeId?: string) {
+    moveLayer(id: string, beforeId?: string): this {
         this.style.moveLayer(id, beforeId);
         return this._update(true);
     }
@@ -2270,7 +2283,7 @@ class Map extends Camera {
      * // If a layer with ID 'state-data' exists, remove it.
      * if (map.getLayer('state-data')) map.removeLayer('state-data');
      */
-    removeLayer(id: string) {
+    removeLayer(id: string): this {
         this.style.removeLayer(id);
         return this._update(true);
     }
@@ -2288,7 +2301,7 @@ class Map extends Camera {
      * @see [Example: Filter symbols by toggling a list](https://www.mapbox.com/mapbox-gl-js/example/filter-markers/)
      * @see [Example: Filter symbols by text input](https://www.mapbox.com/mapbox-gl-js/example/filter-markers-by-input/)
      */
-    getLayer(id: string) {
+    getLayer(id: string): ?StyleLayer {
         return this.style.getLayer(id);
     }
 
@@ -2312,7 +2325,7 @@ class Map extends Camera {
      * map.setLayerZoomRange('my-layer', 2, 5);
      *
      */
-    setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number) {
+    setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this {
         this.style.setLayerZoomRange(layerId, minzoom, maxzoom);
         return this._update(true);
     }
@@ -2350,7 +2363,7 @@ class Map extends Camera {
      * @see [Example: Create a timeline animation](https://www.mapbox.com/mapbox-gl-js/example/timeline-animation/)
      * @see [Tutorial: Show changes over time](https://docs.mapbox.com/help/tutorials/show-changes-over-time/)
      */
-    setFilter(layerId: string, filter: ?FilterSpecification,  options: StyleSetterOptions = {}) {
+    setFilter(layerId: string, filter: ?FilterSpecification,  options: StyleSetterOptions = {}): this {
         this.style.setFilter(layerId, filter, options);
         return this._update(true);
     }
@@ -2363,7 +2376,7 @@ class Map extends Camera {
      * @example
      * const filter = map.getFilter('myLayer');
      */
-    getFilter(layerId: string) {
+    getFilter(layerId: string): ?FilterSpecification {
         return this.style.getFilter(layerId);
     }
 
@@ -2383,7 +2396,7 @@ class Map extends Camera {
      * @see [Example: Adjust a layer's opacity](https://www.mapbox.com/mapbox-gl-js/example/adjust-layer-opacity/)
      * @see [Example: Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
-    setPaintProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
+    setPaintProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}): this {
         this.style.setPaintProperty(layerId, name, value, options);
         return this._update(true);
     }
@@ -2397,7 +2410,7 @@ class Map extends Camera {
      * @example
      * const paintProperty = map.getPaintProperty('mySymbolLayer', 'icon-color');
      */
-    getPaintProperty(layerId: string, name: string) {
+    getPaintProperty(layerId: string, name: string): void | TransitionSpecification | PropertyValueSpecification<mixed> {
         return this.style.getPaintProperty(layerId, name);
     }
 
@@ -2414,7 +2427,7 @@ class Map extends Camera {
      * map.setLayoutProperty('my-layer', 'visibility', 'none');
      * @see [Example: Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      */
-    setLayoutProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
+    setLayoutProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}): this {
         this.style.setLayoutProperty(layerId, name, value, options);
         return this._update(true);
     }
@@ -2428,7 +2441,7 @@ class Map extends Camera {
      * @example
      * const layoutProperty = map.getLayoutProperty('mySymbolLayer', 'icon-anchor');
      */
-    getLayoutProperty(layerId: string, name: string) {
+    getLayoutProperty(layerId: string, name: string): ?PropertyValueSpecification<mixed> {
         return this.style.getLayoutProperty(layerId, name);
     }
 
@@ -2445,7 +2458,7 @@ class Map extends Camera {
      * const layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
      * @see [Example: Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      */
-    setLight(light: LightSpecification, options: StyleSetterOptions = {}) {
+    setLight(light: LightSpecification, options: StyleSetterOptions = {}): this {
         this._lazyInitEmptyStyle();
         this.style.setLight(light, options);
         return this._update(true);
@@ -2458,7 +2471,7 @@ class Map extends Camera {
      * @example
      * const light = map.getLight();
      */
-    getLight() {
+    getLight(): LightSpecification {
         return this.style.getLight();
     }
 
@@ -2479,7 +2492,7 @@ class Map extends Camera {
      * // add the DEM source as a terrain layer with exaggerated height
      * map.setTerrain({'source': 'mapbox-dem', 'exaggeration': 1.5});
      */
-    setTerrain(terrain: TerrainSpecification) {
+    setTerrain(terrain: TerrainSpecification): this {
         this._lazyInitEmptyStyle();
         if (!terrain && this.transform.projection.requiresDraping) {
             this.style.setTerrainForDraping();
@@ -2515,7 +2528,7 @@ class Map extends Camera {
      * });
      * @see [Example: Add fog to a map](https://docs.mapbox.com/mapbox-gl-js/example/add-fog/)
      */
-    setFog(fog: FogSpecification) {
+    setFog(fog: FogSpecification): this {
         this._lazyInitEmptyStyle();
         this.style.setFog(fog);
         return this._update(true);
@@ -2589,7 +2602,7 @@ class Map extends Camera {
      * @see [Example: Create a hover effect](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/)
      * @see [Tutorial: Create interactive hover effects with Mapbox GL JS](https://docs.mapbox.com/help/tutorials/create-interactive-hover-effects-with-mapbox-gl-js/)
      */
-    setFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }, state: Object) {
+    setFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }, state: Object): this {
         this.style.setFeatureState(feature, state);
         return this._update();
     }
@@ -2641,7 +2654,7 @@ class Map extends Camera {
      * });
      *
     */
-    removeFeatureState(feature: { source: string; sourceLayer?: string; id?: string | number; }, key?: string) {
+    removeFeatureState(feature: { source: string; sourceLayer?: string; id?: string | number; }, key?: string): this {
         this.style.removeFeatureState(feature, key);
         return this._update();
     }
@@ -2811,7 +2824,7 @@ class Map extends Camera {
         this.fire(new Event('webglcontextrestored', {originalEvent: event}));
     }
 
-    _onMapScroll(event: *) {
+    _onMapScroll(event: *): ?boolean {
         if (event.target !== this._container) return;
 
         // Revert any scroll which would move the canvas outside of the view
@@ -2833,7 +2846,7 @@ class Map extends Camera {
      * @example
      * const isLoaded = map.loaded();
      */
-    loaded() {
+    loaded(): boolean {
         return !this._styleDirty && !this._sourcesDirty && !!this.style && this.style.loaded();
     }
 
@@ -2845,7 +2858,7 @@ class Map extends Camera {
      * @returns {Map} this
      * @private
      */
-    _update(updateStyle?: boolean) {
+    _update(updateStyle?: boolean): this {
         if (!this.style) return this;
 
         this._styleDirty = this._styleDirty || updateStyle;
@@ -3089,8 +3102,6 @@ class Map extends Camera {
             this._authenticate();
             PerformanceUtils.mark(PerformanceMarkers.fullLoad);
         }
-
-        return this;
     }
 
     _forceMarkerUpdate() {
@@ -3331,7 +3342,7 @@ class Map extends Camera {
      * @private
      * @returns {Object} Returns `this` | Promise.
      */
-    _preloadTiles(transform: Transform | Array<Transform>) {
+    _preloadTiles(transform: Transform | Array<Transform>): this {
         const sources: Array<SourceCache> = this.style ? (Object.values(this.style._sourceCaches): any) : [];
         asyncAll(sources, (source, done) => source._preloadTiles(transform, done), () => {
             this.triggerRepaint();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1987,7 +1987,6 @@ class Map extends Camera {
             this.fire(new ErrorEvent(new Error(
                 'Invalid arguments to map.addImage(). The second argument must be an `HTMLImageElement`, `ImageData`, `ImageBitmap`, ' +
                 'or object with `width`, `height`, and `data` properties with the same format as `ImageData`')));
-            return;
         } else {
             const {width, height} = image;
             const userImage = ((image: any): StyleImageInterface);

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -525,7 +525,7 @@ export default class Marker extends Evented {
      * @example
      * const offset = marker.getOffset();
      */
-    getOffset() {
+    getOffset(): Point {
         return this._offset;
     }
 

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -84,7 +84,7 @@ export class AJAXError extends Error {
         this.url = url;
     }
 
-    toString() {
+    toString(): string {
         return `${this.name}: ${this.message} (${this.status}): ${this.url}`;
     }
 }


### PR DESCRIPTION
A part of #11426. Adds missing export types to `map.js` and a few more leftovers, in particular in `style.js`.