### PR TITLE
Fix globe atmosphere precision on Android/iOS-OpenGLES

### DIFF
--- a/src/shaders/globe_atmosphere.fragment.glsl
+++ b/src/shaders/globe_atmosphere.fragment.glsl
@@ -5,11 +5,11 @@ uniform vec3 u_end_color;
 uniform highp vec3 u_globe_pos;
 uniform highp float u_globe_radius;
 
-varying vec3 v_ray_dir;
+varying highp vec3 v_ray_dir;
 
 void main() {
-    vec3 dir = normalize(v_ray_dir);
-    vec3 closest_point = abs(dot(u_globe_pos, dir)) * dir;
+    highp vec3 dir = normalize(v_ray_dir);
+    highp vec3 closest_point = abs(dot(u_globe_pos, dir)) * dir;
     float norm_dist_from_center = length(closest_point - u_globe_pos) / u_globe_radius;
 
     if (norm_dist_from_center < 1.0)

--- a/src/shaders/globe_atmosphere.vertex.glsl
+++ b/src/shaders/globe_atmosphere.vertex.glsl
@@ -7,7 +7,7 @@ uniform vec3 u_frustum_tr;
 uniform vec3 u_frustum_br;
 uniform vec3 u_frustum_bl;
 
-varying vec3 v_ray_dir;
+varying highp vec3 v_ray_dir;
 
 void main() {
     v_ray_dir = mix(mix(u_frustum_tl, u_frustum_tr, a_uv.x),


### PR DESCRIPTION
After porting to gl-native, it is noticeable that computation and varying require highp in OpenGL ES. E.g. Pixel 5, before after:

![Screenshot 2022-03-15 at 21 50 49](https://user-images.githubusercontent.com/549216/158459894-3be3792e-fe46-40ef-acd5-e0f035b375f9.png)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 ~~- [ ] write tests for all new functionality~~ tests exist, gl native tests this on various hardware.
 ~~- [ ] document any changes to public APIs~~
 ~~- [ ] post benchmark scores~~
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 ~~- [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'~~
 ~~- [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`~~
