### PR TITLE
Disables cooperative gestures when map is fullscreen in Safari

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -398,8 +398,7 @@ class ScrollZoomHandler {
     }
 
     _isFullscreen(): boolean {
-        if (isSafari(window)) return !!window.document.webkitFullscreenElement;
-        return !!window.document.fullscreenElement;
+        return !!window.document.fullscreenElement || !!window.document.webkitFullscreenElement;
     }
 
     _showBlockerAlert() {

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import * as DOM from '../../util/dom.js';
 
-import {ease as _ease, bindAll, bezier} from '../../util/util.js';
+import {ease as _ease, bindAll, bezier, isSafari} from '../../util/util.js';
 import browser from '../../util/browser.js';
 import window from '../../util/window.js';
 import {number as interpolate} from '../../style-spec/util/interpolate.js';
@@ -398,6 +398,7 @@ class ScrollZoomHandler {
     }
 
     _isFullscreen(): boolean {
+        if (isSafari(window)) return !!window.document.webkitCurrentFullScreenElement;
         return !!window.document.fullscreenElement;
     }
 

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import * as DOM from '../../util/dom.js';
 
-import {ease as _ease, bindAll, bezier, isSafari} from '../../util/util.js';
+import {ease as _ease, bindAll, bezier} from '../../util/util.js';
 import browser from '../../util/browser.js';
 import window from '../../util/window.js';
 import {number as interpolate} from '../../style-spec/util/interpolate.js';

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -398,7 +398,7 @@ class ScrollZoomHandler {
     }
 
     _isFullscreen(): boolean {
-        if (isSafari(window)) return !!window.document.webkitCurrentFullScreenElement;
+        if (isSafari(window)) return !!window.document.webkitFullscreenElement;
         return !!window.document.fullscreenElement;
     }
 

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 import {createConstElevationDEM, setMockElevationTerrain} from '../../../util/dem_mock.js';
 import {fixedNum} from '../../../util/fixed.js';
 import MercatorCoordinate from '../../../../src/geo/mercator_coordinate.js';
+import FullscreenControl from '../../../../src/ui/control/fullscreen_control.js';
 
 function createMap(t) {
     t.stub(Map.prototype, '_detectMissingCSS');
@@ -452,6 +453,27 @@ test('When cooperativeGestures option is set to true, scroll zoom is activated w
     map._renderTaskQueue.run();
 
     t.equal(zoomSpy.callCount, 1);
+    t.end();
+});
+
+test('When cooperativeGestures option is set to true, scroll zoom is not activated when map is fullscreen, cooperativeGestures', (t) => {
+    window.document.fullscreenEnabled = true;
+    const map = createMapWithCooperativeGestures(t);
+    const fullscreen = new FullscreenControl();
+
+    map.addControl(fullscreen);
+    const control = map._controls.find((ctrl) => {
+        return ctrl.hasOwnProperty('_fullscreen');
+    });
+    control._onClickFullscreen();
+
+    map.on('zoom', () => {
+        t.spy();
+        control._onClickFullscreen();
+        t.equal(zoomSpy.callCount, 1);
+    });
+
+    simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
     t.end();
 });
 

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -457,15 +457,8 @@ test('When cooperativeGestures option is set to true, scroll zoom is activated w
 });
 
 test('When cooperativeGestures option is set to true, scroll zoom is not prevented when map is fullscreen', (t) => {
-    window.document.fullscreenEnabled = true;
+    window.document.fullscreenElement = true;
     const map = createMapWithCooperativeGestures(t);
-    const fullscreen = new FullscreenControl();
-
-    map.addControl(fullscreen);
-    const control = map._controls.find((ctrl) => {
-        return ctrl.hasOwnProperty('_fullscreen');
-    });
-    control._onClickFullscreen();
 
     const zoomSpy = t.spy();
     map.on('zoom', zoomSpy);

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -466,9 +466,9 @@ test('When cooperativeGestures option is set to true, scroll zoom is not prevent
         return ctrl.hasOwnProperty('_fullscreen');
     });
     control._onClickFullscreen();
+    const zoomSpy = t.spy(map, 'zoom');
 
     map.on('zoom', () => {
-        t.spy();
         control._onClickFullscreen();
         t.equal(zoomSpy.callCount, 1);
     });

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -9,7 +9,6 @@ import sinon from 'sinon';
 import {createConstElevationDEM, setMockElevationTerrain} from '../../../util/dem_mock.js';
 import {fixedNum} from '../../../util/fixed.js';
 import MercatorCoordinate from '../../../../src/geo/mercator_coordinate.js';
-import FullscreenControl from '../../../../src/ui/control/fullscreen_control.js';
 
 function createMap(t) {
     t.stub(Map.prototype, '_detectMissingCSS');

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -456,7 +456,7 @@ test('When cooperativeGestures option is set to true, scroll zoom is activated w
     t.end();
 });
 
-test('When cooperativeGestures option is set to true, scroll zoom is not activated when map is fullscreen, cooperativeGestures', (t) => {
+test('When cooperativeGestures option is set to true, scroll zoom is not prevented when map is fullscreen', (t) => {
     window.document.fullscreenEnabled = true;
     const map = createMapWithCooperativeGestures(t);
     const fullscreen = new FullscreenControl();

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -464,7 +464,7 @@ test('When cooperativeGestures option is set to true, scroll zoom is not prevent
 
     simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
     map._renderTaskQueue.run();
-    
+
     t.equal(zoomSpy.callCount, 1);
     t.end();
 });

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -466,14 +466,14 @@ test('When cooperativeGestures option is set to true, scroll zoom is not prevent
         return ctrl.hasOwnProperty('_fullscreen');
     });
     control._onClickFullscreen();
-    const zoomSpy = t.spy(map, 'zoom');
 
-    map.on('zoom', () => {
-        control._onClickFullscreen();
-        t.equal(zoomSpy.callCount, 1);
-    });
+    const zoomSpy = t.spy();
+    map.on('zoom', zoomSpy);
 
     simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
+    map._renderTaskQueue.run();
+    
+    t.equal(zoomSpy.callCount, 1);
     t.end();
 });
 


### PR DESCRIPTION
Closes #11607. When a map is full screen, cooperative gestures should be disabled - this is more user-friendly as the presumption is that the user will want to only interact with the fullscreen map (e.g. not scroll to other content on the screen). This is expected behavior and works in other browsers. Recently discovered while testing Safari 15.4 that cooperative gestures continued to be enabled when map is fullscreen. It was believed that this was working prior (see PR #11086), but is also not working in 15.3. 

Added unit test that mocks fullscreenElement, doesn't necessarily address this problem with safari but was a previously missing unit test that checks scroll zoom happens when map is full screen.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes disabling cooperative gestures when map is fullscreen in Safari.</changelog>`
