### PR TITLE
Deferred render GPU time queries

### DIFF
--- a/debug/flytolocations.html
+++ b/debug/flytolocations.html
@@ -80,12 +80,12 @@ let timings = [];
 
 const trials = [];
 
-map.on('gpu-timing-frame', function(data) {
-    if (measuring) {
+map.on('gpu-timing-deferred-render', function(data) {
+    if (measuring && data.gpuTime !== 0.0) {
         totalGPUTime += data.gpuTime;
         counter += 1;
         const t = totalGPUTime / counter;
-        // console.log(t);
+        console.log(t);
         timings.push(t);
     }
 });

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -92,7 +92,7 @@ type PainterOptions = {
     zooming: boolean,
     moving: boolean,
     gpuTiming: boolean,
-    gpuTimingGlobe: boolean,
+    gpuTimingDeferredRender: boolean,
     fadeDuration: number,
     isInitialLoad: boolean,
     speedIndexTiming: boolean
@@ -152,7 +152,7 @@ class Painter {
     crossTileSymbolIndex: CrossTileSymbolIndex;
     symbolFadeChange: number;
     gpuTimers: GPUTimers;
-    globeGpuTimeQuery: any;
+    deferredRenderGpuTimeQueries: Array<any>;
     emptyTexture: Texture;
     identityMat: Float32Array;
     debugOverlayTexture: Texture;
@@ -180,6 +180,7 @@ class Painter {
 
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
+        this.deferredRenderGpuTimeQueries = [];
         this.gpuTimers = {};
         this.frameCounter = 0;
         this._backgroundTiles = {};
@@ -748,17 +749,17 @@ class Painter {
         ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, layerTimer.query);
     }
 
-    gpuTimingGlobeStart() {
-        if (this.options.gpuTimingGlobe) {
+    gpuTimingDeferredRenderStart() {
+        if (this.options.gpuTimingDeferredRender) {
             const ext = this.context.extTimerQuery;
-            if (!this.globeGpuTimeQuery)
-                this.globeGpuTimeQuery = ext.createQueryEXT();
-            ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, this.globeGpuTimeQuery);
+            const query = ext.createQueryEXT();
+            this.deferredRenderGpuTimeQueries.push(query);
+            ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
         }
     }
 
-    gpuTimingGlobeEnd() {
-        if (!this.options.gpuTimingGlobe) return;
+    gpuTimingDeferredRenderEnd() {
+        if (!this.options.gpuTimingDeferredRender) return;
         const ext = this.context.extTimerQuery;
         ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
     }
@@ -787,13 +788,18 @@ class Painter {
         return layers;
     }
 
-    queryGpuTimeGlobe(): number {
-        if (!this.globeGpuTimeQuery) return 0;
+    queryGpuTimeDeferredRender(): number {
+        if (!this.options.gpuTimingDeferredRender) return 0;
         const ext = this.context.extTimerQuery;
-        const gpuTime = ext.getQueryObjectEXT(this.globeGpuTimeQuery, ext.QUERY_RESULT_EXT) / (1000 * 1000);
-        ext.deleteQueryEXT(this.globeGpuTimeQuery);
-        this.globeGpuTimeQuery = null;
-        return gpuTime;
+
+        let deferredRenderGpuTime = 0;
+        for (const query of this.deferredRenderGpuTimeQueries) {
+            deferredRenderGpuTime += ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT) / (1000 * 1000);
+            ext.deleteQueryEXT(query);
+        }
+
+        this.deferredRenderGpuTimeQueries = [];
+        return deferredRenderGpuTime;
     }
 
     /**

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -776,6 +776,12 @@ class Painter {
         return currentLayerTimers;
     }
 
+    collectDeferredRenderGpuQueries(): Array<any> {
+        const currentQueries = this.deferredRenderGpuTimeQueries;
+        this.deferredRenderGpuTimeQueries = [];
+        return currentQueries;
+    }
+
     queryGpuTimers(gpuTimers: GPUTimers): {[layerId: string]: number} {
         const layers = {};
         for (const layerId in gpuTimers) {
@@ -788,18 +794,17 @@ class Painter {
         return layers;
     }
 
-    queryGpuTimeDeferredRender(): number {
+    queryGpuTimeDeferredRender(gpuQueries: Array<any>): number {
         if (!this.options.gpuTimingDeferredRender) return 0;
         const ext = this.context.extTimerQuery;
 
-        let deferredRenderGpuTime = 0;
-        for (const query of this.deferredRenderGpuTimeQueries) {
-            deferredRenderGpuTime += ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT) / (1000 * 1000);
+        let gpuTime = 0;
+        for (const query of gpuQueries) {
+            gpuTime += ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT) / (1000 * 1000);
             ext.deleteQueryEXT(query);
         }
 
-        this.deferredRenderGpuTimeQueries = [];
-        return deferredRenderGpuTime;
+        return gpuTime;
     }
 
     /**

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -262,9 +262,7 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
 
 function drawTerrainRaster(painter: Painter, terrain: Terrain, sourceCache: SourceCache, tileIDs: Array<OverscaledTileID>, now: number) {
     if (painter.transform.projection.name === 'globe') {
-        painter.gpuTimingGlobeStart();
         drawTerrainForGlobe(painter, terrain, sourceCache, tileIDs, now);
-        painter.gpuTimingGlobeEnd();
     } else {
         const context = painter.context;
         const gl = context.gl;

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -674,9 +674,13 @@ export class Terrain extends Elevation {
         context.bindFramebuffer.set(null);
         context.viewport.set([0, 0, painter.width, painter.height]);
 
+        painter.gpuTimingDeferredRenderStart();
+
         this.renderingToTexture = false;
         drawTerrainRaster(painter, this, this.proxySourceCache, accumulatedDrapes, this._updateTimestamp);
         this.renderingToTexture = true;
+
+        painter.gpuTimingDeferredRenderEnd();
 
         accumulatedDrapes.splice(0, accumulatedDrapes.length);
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2998,7 +2998,7 @@ class Map extends Camera {
                 isInitialLoad: this._isInitialLoad,
                 showPadding: this.showPadding,
                 gpuTiming: !!this.listens('gpu-timing-layer'),
-                gpuTimingGlobe: !!this.listens('gpu-timing-globe'),
+                gpuTimingDeferredRender: !!this.listens('gpu-timing-deferred-render'),
                 speedIndexTiming: this.speedIndexTiming,
             });
         }
@@ -3051,10 +3051,10 @@ class Map extends Camera {
             }, 50); // Wait 50ms to give time for all GPU calls to finish before querying
         }
 
-        if (this.listens('gpu-timing-globe')) {
+        if (this.listens('gpu-timing-deferred-render')) {
             setTimeout(() => {
-                this.fire(new Event('gpu-timing-globe', {
-                    gpuTime: this.painter.queryGpuTimeGlobe()
+                this.fire(new Event('gpu-timing-deferred-render', {
+                    gpuTime: this.painter.queryGpuTimeDeferredRender()
                 }));
             }, 50); // Wait 50ms to give time for all GPU calls to finish before querying
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3052,10 +3052,11 @@ class Map extends Camera {
         }
 
         if (this.listens('gpu-timing-deferred-render')) {
+            const deferredRenderQueries = this.painter.collectDeferredRenderGpuQueries();
+
             setTimeout(() => {
-                this.fire(new Event('gpu-timing-deferred-render', {
-                    gpuTime: this.painter.queryGpuTimeDeferredRender()
-                }));
+                const gpuTime = this.painter.queryGpuTimeDeferredRender(deferredRenderQueries);
+                this.fire(new Event('gpu-timing-deferred-render', {gpuTime}));
             }, 50); // Wait 50ms to give time for all GPU calls to finish before querying
         }
 


### PR DESCRIPTION
This PR adds gpu time queries (as proposed in https://github.com/mapbox/mapbox-gl-js/pull/11604#discussion_r831595001 and discussed in https://github.com/mapbox/mapbox-gl-js/pull/11604#discussion_r831820926) around the deferred render call (to main framebuffer), instead of around the globe render. This also make the queries accurate since several deferred render call to main framebuffer may happen within a frame, currently this only gather the timing data around a single call, which can override it if we have several dispatch happening (when reaching the max framebuffer pool of 5).