### PR TITLE
Increase diff threshold for terrain/wireframe render test

### DIFF
--- a/test/integration/render-tests/terrain/wireframe/style.json
+++ b/test/integration/render-tests/terrain/wireframe/style.json
@@ -6,7 +6,7 @@
       "width": 256,
       "description": "In addition to terrain raster, verifies also toggling terrain off / on",
       "showTerrainWireframe": true,
-      "allowed": 0.002,
+      "allowed": 0.009,
       "operations": [
         ["wait"],
         ["setTerrain", null],


### PR DESCRIPTION
This PR increases the allowed difference threshold for the terrain/wireframe render test. This needs to be done because the wireframe feature is being ported to native and the different platforms that we are running render tests on don't match exactly when it comes to line rendering. Highest diff seen is about 0.00885.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
