### PR TITLE
Add `synchronize` to check-changelog github action types

### DIFF
--- a/.github/workflows/pull-request-requirements.yml
+++ b/.github/workflows/pull-request-requirements.yml
@@ -2,6 +2,7 @@ name: Check PR Requirements
 
 on:
   pull_request:
+    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
 
 jobs:
   check-changelog:

--- a/.github/workflows/pull-request-requirements.yml
+++ b/.github/workflows/pull-request-requirements.yml
@@ -2,7 +2,6 @@ name: Check PR Requirements
 
 on:
   pull_request:
-    types: [opened, reopened, edited, labeled, unlabeled]
 
 jobs:
   check-changelog:


### PR DESCRIPTION
The new github action checks pull requests for changelogs or if a skip changelog label is applied. It is currently triggered when a PR is labeled, unlabeled, edited, reopened and opened. This affects the status check for PRs. 

After seeing a couple PRs with recent pushes, we should also add `synchronize` as a trigger (meaning when there is a new commit pushed) as the other status checks run and then do not run the check-changelog github action which causes it to show as "expected" until the PR is edited, labeled, unlabeled, etc. Adding `synchronize` as a trigger will allow the PR to run this status check again so the author doesn't have to do an additional step to trigger the action. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
