### PR TITLE
fix map center calculation in ScaleControl

### DIFF
--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -93,8 +93,9 @@ function updateScale(map, container, options) {
     const maxWidth = (options && options.maxWidth) || 100;
 
     const y = map._containerHeight / 2;
-    const left = map.unproject([0, y]);
-    const right = map.unproject([maxWidth, y]);
+    const x = (map._containerWidth / 2) - maxWidth / 2;
+    const left = map.unproject([x, y]);
+    const right = map.unproject([x + maxWidth, y]);
     const maxMeters = left.distanceTo(right);
     // The real distance corresponding to 100px scale length is rounded off to
     // near pretty number and the scale length for the same is found out.

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -51,3 +51,38 @@ test('ScaleControl should respect the maxWidth regardless of the unit and actual
     t.ok(parseFloat(el.style.width, 10) <= maxWidth, 'ScaleControl respects maxWidth');
     t.end();
 });
+
+test('ScaleControl should support different projections', (t) => {
+    const map = createMap(t, {
+        center: [-180, 0]
+    });
+
+    const scale = new ScaleControl();
+    const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
+    map.addControl(scale);
+    map.setZoom(12.5);
+
+    map._domRenderTaskQueue.run();
+    let contents = map.getContainer().querySelector(selector).innerHTML;
+    t.notMatch(contents, /NaN|undefined/);
+
+    const projections = [
+        'albers',
+        'equalEarth',
+        'equirectangular',
+        'lambertConformalConic',
+        'mercator',
+        'globe',
+        'naturalEarth',
+        'winkelTripel',
+    ];
+
+    for (const projection of projections) {
+        map.setProjection(projection);
+        map._domRenderTaskQueue.run();
+        contents = map.getContainer().querySelector(selector).innerHTML;
+        t.notMatch(contents, /NaN|undefined/, `ScaleControl supports ${projection}`);
+    }
+
+    t.end();
+});


### PR DESCRIPTION
The Scale control was always using the left-hand side of the map to calculate the scale. In some cases, e.g., when using the Equal Earth projection, the scale couldn't calculate correctly.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>fix map center calculation in ScaleControl</changelog>`
