### PR TITLE
Add source field requirement to terrain exaggeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### 🐞 Bug fixes
 
-* Add source field requirement to terrain exaggeration ([#11664](https://github.com/mapbox/mapbox-gl-js/pull/11664))
 * Work around a [Safari rendering bug](https://bugs.webkit.org/show_bug.cgi?id=237918#c3) by disabling WebGL context antialiasing for Safari 15.4 and 15.5 ([#11615](https://github.com/mapbox/mapbox-gl-js/pull/11615))
 * Fix disabling cooperative gesture handling when map is fullscreen in Safari ([#11619](https://github.com/mapbox/mapbox-gl-js/pull/11619))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 🐞 Bug fixes
 
+* Add source field requirement to terrain exaggeration ([#11664](https://github.com/mapbox/mapbox-gl-js/pull/11664))
 * Work around a [Safari rendering bug](https://bugs.webkit.org/show_bug.cgi?id=237918#c3) by disabling WebGL context antialiasing for Safari 15.4 and 15.5 ([#11615](https://github.com/mapbox/mapbox-gl-js/pull/11615))
 * Fix disabling cooperative gesture handling when map is fullscreen in Safari ([#11619](https://github.com/mapbox/mapbox-gl-js/pull/11619))
 

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4083,6 +4083,9 @@
       },
       "transition": true,
       "doc": "Exaggerates the elevation of the terrain by multiplying the data from the DEM with this value.",
+      "requires": [
+        "source"
+      ],
       "sdk-support": {
         "basic functionality": {
           "js": "2.0.0",


### PR DESCRIPTION

 - [X] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add `source` field requirement to terrain exaggeration. </changelog>`