### PR TITLE
temporarily revert dependency version to fix build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.4",
     "flow-bin": "0.142.0",
-    "gl": "^4.9.2",
+    "gl": "4.9.0",
     "glob": "^7.2.0",
     "is-builtin-module": "^3.1.0",
     "jsdom": "^13.2.0",


### PR DESCRIPTION
Temporarily revert `gl` devDependency version to fix build issue. Once we resolve the build issue, we can bump this again.