### PR TITLE
Move fog properties to stage-specific preludes

### DIFF
--- a/src/shaders/_prelude.glsl
+++ b/src/shaders/_prelude.glsl
@@ -13,30 +13,24 @@
 
 #ifdef FOG
 
-uniform mediump vec4 u_fog_color;
-uniform mediump vec2 u_fog_range;
-uniform mediump float u_fog_horizon_blend;
-
-varying vec3 v_fog_pos;
-
-float fog_range(float depth) {
+float fog_range(vec2 range, float depth) {
     // Map [near, far] to [0, 1] without clamping
-    return (depth - u_fog_range[0]) / (u_fog_range[1] - u_fog_range[0]);
+    return (depth - range[0]) / (range[1] - range[0]);
 }
 
 // Assumes z up and camera_dir *normalized* (to avoid computing
 // its length multiple times for different functions).
-float fog_horizon_blending(vec3 camera_dir) {
-    float t = max(0.0, camera_dir.z / u_fog_horizon_blend);
+float fog_horizon_blending(vec4 color, float blend, vec3 camera_dir) {
+    float t = max(0.0, camera_dir.z / blend);
     // Factor of 3 chosen to roughly match smoothstep.
     // See: https://www.desmos.com/calculator/pub31lvshf
-    return u_fog_color.a * exp(-3.0 * t * t);
+    return color.a * exp(-3.0 * t * t);
 }
 
 // Compute a ramp for fog opacity
 //   - t: depth, rescaled to 0 at fogStart and 1 at fogEnd
 // See: https://www.desmos.com/calculator/3taufutxid
-float fog_opacity(float t) {
+float fog_opacity(vec4 color, float t) {
     const float decay = 6.0;
     float falloff = 1.0 - min(1.0, exp(-decay * t));
 
@@ -44,7 +38,7 @@ float fog_opacity(float t) {
     falloff *= falloff * falloff;
 
     // Scale and clip to 1 at the far limit
-    return u_fog_color.a * min(1.0, 1.00747 * falloff);
+    return color.a * min(1.0, 1.00747 * falloff);
 }
 
 #endif

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -1,18 +1,22 @@
 #ifdef FOG
 
-uniform float u_fog_temporal_offset;
+uniform mediump vec4 u_fog_color;
+uniform mediump vec2 u_fog_range;
+uniform mediump float u_fog_horizon_blend;
+uniform mediump float u_fog_temporal_offset;
+varying vec3 v_fog_pos;
 
 // This function is only used in rare places like heatmap where opacity is used
 // directly, outside the normal fog_apply method.
 float fog_opacity(vec3 pos) {
     float depth = length(pos);
-    return fog_opacity(fog_range(depth));
+    return fog_opacity(u_fog_color, fog_range(u_fog_range, depth));
 }
 
 vec3 fog_apply(vec3 color, vec3 pos) {
     float depth = length(pos);
-    float opacity = fog_opacity(fog_range(depth));
-    opacity *= fog_horizon_blending(pos / depth);
+    float opacity = fog_opacity(u_fog_color, fog_range(u_fog_range, depth));
+    opacity *= fog_horizon_blending(u_fog_color, u_fog_horizon_blend, pos / depth);
     return mix(color, u_fog_color.rgb, opacity);
 }
 
@@ -25,7 +29,7 @@ vec4 fog_apply_from_vert(vec4 color, float fog_opac) {
 
 // Assumes z up
 vec3 fog_apply_sky_gradient(vec3 camera_ray, vec3 sky_color) {
-    float horizon_blend = fog_horizon_blending(normalize(camera_ray));
+    float horizon_blend = fog_horizon_blending(u_fog_color, u_fog_horizon_blend, normalize(camera_ray));
     return mix(sky_color, u_fog_color.rgb, horizon_blend);
 }
 

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -1,6 +1,10 @@
 #ifdef FOG
 
-uniform mat4 u_fog_matrix;
+uniform mediump vec4 u_fog_color;
+uniform mediump vec2 u_fog_range;
+uniform mediump float u_fog_horizon_blend;
+uniform mediump mat4 u_fog_matrix;
+varying vec3 v_fog_pos;
 
 vec3 fog_position(vec3 pos) {
     // The following function requires that u_fog_matrix be affine and
@@ -14,8 +18,8 @@ vec3 fog_position(vec2 pos) {
 
 float fog(vec3 pos) {
     float depth = length(pos);
-    float opacity = fog_opacity(fog_range(depth));
-    return opacity * fog_horizon_blending(pos / depth);
+    float opacity = fog_opacity(u_fog_color, fog_range(u_fog_range, depth));
+    return opacity * fog_horizon_blending(u_fog_color, u_fog_horizon_blend, pos / depth);
 }
 
 #endif


### PR DESCRIPTION
During the porting of the fog effect in gl-native, I’ve noticed that we have an issue with the shader preludes:
- The fog uniforms are defined in `_prelude.glsl` which is prepended before all vertex and fragment shaders
- But the fallback definitions for the precision qualifiers are separately configured for the vertex and fragment shaders and it’s appended after the common `_prelude`

This breaks the shader compilation on machines where the fallbacks are needed.
This PR fixes it by moving it to the stage-specific preludes, which will are included after the precision qualifier definitions.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
