### PR TITLE
fix: force loaded state for CustomSource tiles

### DIFF
--- a/src/source/custom_source.js
+++ b/src/source/custom_source.js
@@ -326,6 +326,7 @@ class CustomSource<T> extends Evented implements Source {
         if (!data) return null;
 
         this.loadTileData(tile, data);
+        tile.state = 'loaded';
         return data;
     }
 

--- a/test/unit/source/custom_source.test.js
+++ b/test/unit/source/custom_source.test.js
@@ -202,6 +202,27 @@ test('CustomSource', (t) => {
         sourceCache._addTile(tileID);
     });
 
+    t.test('loadTile is not called if prepareTile returns data', (t) => {
+        const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
+
+        const loadTile = t.spy();
+        const prepareTile = t.spy((tile) => {
+            const {x, y, z} = tileID.canonical;
+            t.deepEqual(tile, {x, y, z});
+            return new window.ImageData(512, 512);
+        });
+
+        const {sourceCache} = createSource(t, {loadTile, prepareTile});
+
+        sourceCache.onAdd();
+        sourceCache._addTile(tileID);
+
+        t.ok(prepareTile.calledOnce, 'prepareTile must be called');
+        t.notOk(loadTile.calledOnce, 'loadTile must not be called');
+        t.equal(sourceCache._tiles[tileID.key].state, 'loaded', 'tile must be in the loaded state');
+        t.end();
+    });
+
     t.test('prepareTile updates the tile data if it returns valid tile data', (t) => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
 


### PR DESCRIPTION
Always set tile state to `loaded` if the user returns tile data in `prepareTile`

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
