### PR TITLE
Fix missing release testing pages due to broken CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ jobs:
       - run: yarn run build-style-spec
       - run: yarn run build-flow-types
       - run: yarn run test-build
+      - run: while read l; do cp debug/$l test/release/$l; done < test/release/local_release_page_list.txt
       - store_artifacts:
           path: "dist"
       - store_artifacts:

--- a/test/release/README.md
+++ b/test/release/README.md
@@ -6,6 +6,6 @@ To load this page, execute `npm run start-release` to build the required files, 
 
 Alternatively, you can also access the test page on Circle CI. Find a job named `build`, click the "Artifacts" tab, and navigate to the `mapbox-gl-js/test/release/index.html` page. You'll have to enter your own access token there. Before sharing the URL, be aware that it will be stored in the hash of the URL.
 
-To add new pages to the list from our online documentatione, add them to the `pages` object at the beginning of `index.js`. By default, it will load the HTML sample from https://github.com/mapbox/mapbox-gl-js-docs/tree/publisher-production/docs/pages/example using the ID. You can override this by specifying a custom `url` property next to the `title`.
+To add new pages to the list from our online documentation, add them to the `pages` object at the beginning of `index.js`. By default, it will load the HTML sample from https://github.com/mapbox/mapbox-gl-js-docs/tree/publisher-production/docs/pages/example using the ID. You can override this by specifying a custom `url` property next to the `title`.
 
-To add new pages from our `debug/` folder, simply add their file names to [`local_release_page_list.txt`](./local_release_page_list.txt).
+To add new pages from our `debug/` folder, add their file names to [`local_release_page_list.txt`](./local_release_page_list.txt).

--- a/test/release/README.md
+++ b/test/release/README.md
@@ -8,4 +8,4 @@ Alternatively, you can also access the test page on Circle CI. Find a job named 
 
 To add new pages to the list from our online documentatione, add them to the `pages` object at the beginning of `index.js`. By default, it will load the HTML sample from https://github.com/mapbox/mapbox-gl-js-docs/tree/publisher-production/docs/pages/example using the ID. You can override this by specifying a custom `url` property next to the `title`.
 
-To add new pages from our `debug/` folder, simply add their file names to `local_release_page_list.txt`.
+To add new pages from our `debug/` folder, simply add their file names to [`local_release_page_list.txt`](./local_release_page_list.txt).

--- a/test/release/README.md
+++ b/test/release/README.md
@@ -8,4 +8,4 @@ Alternatively, you can also access the test page on Circle CI. Find a job named 
 
 To add new pages to the list, add them to the `pages` object at the beginning of `index.js`. By default, it will load the HTML sample from https://github.com/mapbox/mapbox-gl-js-docs/tree/publisher-production/docs/pages/example using the ID. You can override this by specifying a custom `url` property next to the `title`.
 
-To add new pages from our `debug/` folder, simply create a symbolic link for the page you would like to add by running `ln -s ../../debug/page-to-add.html page-to-add.html` from this folder.
+To add new pages from our `debug/` folder, simply add their file names to `local_release_page_list.txt`.

--- a/test/release/README.md
+++ b/test/release/README.md
@@ -6,6 +6,6 @@ To load this page, execute `npm run start-release` to build the required files, 
 
 Alternatively, you can also access the test page on Circle CI. Find a job named `build`, click the "Artifacts" tab, and navigate to the `mapbox-gl-js/test/release/index.html` page. You'll have to enter your own access token there. Before sharing the URL, be aware that it will be stored in the hash of the URL.
 
-To add new pages to the list, add them to the `pages` object at the beginning of `index.js`. By default, it will load the HTML sample from https://github.com/mapbox/mapbox-gl-js-docs/tree/publisher-production/docs/pages/example using the ID. You can override this by specifying a custom `url` property next to the `title`.
+To add new pages to the list from our online documentatione, add them to the `pages` object at the beginning of `index.js`. By default, it will load the HTML sample from https://github.com/mapbox/mapbox-gl-js-docs/tree/publisher-production/docs/pages/example using the ID. You can override this by specifying a custom `url` property next to the `title`.
 
 To add new pages from our `debug/` folder, simply add their file names to `local_release_page_list.txt`.

--- a/test/release/custom-source.html
+++ b/test/release/custom-source.html
@@ -1,1 +1,0 @@
-../../debug/custom-source.html

--- a/test/release/extrusion-query.html
+++ b/test/release/extrusion-query.html
@@ -1,1 +1,0 @@
-../../debug/extrusion-query.html

--- a/test/release/featurestate.html
+++ b/test/release/featurestate.html
@@ -1,1 +1,0 @@
-../../debug/featurestate.html

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -47,9 +47,9 @@ const pages = [
         "title": "Add a heatmap layer"
     },
     {
-        "key": "three-js-antenna",
+        "key": "threejs-antenna",
         "title": "Add a 3d model on terrain with ThreeJS",
-        "url": "./three-js-antenna.html"
+        "url": "./threejs-antenna.html"
     },
     {
         "key": "free-camera-path",

--- a/test/release/local_release_page_list.txt
+++ b/test/release/local_release_page_list.txt
@@ -1,0 +1,8 @@
+extrusion-query.html
+featurestate.html
+markers.html
+preload-tiles.html
+projections.html
+scroll_zoom_blocker.html
+threejs-antenna.html
+video.html

--- a/test/release/local_release_page_list.txt
+++ b/test/release/local_release_page_list.txt
@@ -6,3 +6,4 @@ projections.html
 scroll_zoom_blocker.html
 threejs-antenna.html
 video.html
+custom-source.html

--- a/test/release/markers.html
+++ b/test/release/markers.html
@@ -1,1 +1,0 @@
-../../debug/markers.html

--- a/test/release/preload-tiles.html
+++ b/test/release/preload-tiles.html
@@ -1,1 +1,0 @@
-../../debug/preload-tiles.html

--- a/test/release/projections.html
+++ b/test/release/projections.html
@@ -1,1 +1,0 @@
-../../debug/projections.html

--- a/test/release/scroll_zoom_blocker.html
+++ b/test/release/scroll_zoom_blocker.html
@@ -1,1 +1,0 @@
-../../debug/scroll_zoom_blocker.html

--- a/test/release/three-js-antenna.html
+++ b/test/release/three-js-antenna.html
@@ -1,1 +1,0 @@
-../../debug/threejs-antenna.html

--- a/test/release/video.html
+++ b/test/release/video.html
@@ -1,1 +1,0 @@
-../../debug/video.html


### PR DESCRIPTION
## Launch Checklist

Due to what appears to be a change in CircleCI, release testing pages using debug pages are broken due to missing links.

![image](https://user-images.githubusercontent.com/14878684/162019690-5241f7db-576c-4c12-9110-bce4cd7f79e7.png)

This is because CircleCI is no longer supporting symbolic links. In this PR, I remove the symbolic links and add a script to `.circleci/config.yml` to copy the necessary files.

Further discussion [here](https://mapbox.slack.com/archives/C0S9M8WUS/p1649197801785909)

 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
