### PR TITLE
Show render test diff in result page

### DIFF
--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -302,7 +302,7 @@ async function runTest(t) {
                 actual,
                 expected,
                 imgDiff,
-                minDiff
+                minDiff.toFixed(5)
             };
 
             const pass = minDiff <= options.allowed;

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -302,7 +302,7 @@ async function runTest(t) {
                 actual,
                 expected,
                 imgDiff,
-                minDiff.toFixed(5)
+                minDiff: minDiff.toFixed(5)
             };
 
             const pass = minDiff <= options.allowed;

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -301,7 +301,8 @@ async function runTest(t) {
                 name: currentTestName,
                 actual,
                 expected,
-                imgDiff
+                imgDiff,
+                minDiff
             };
 
             const pass = minDiff <= options.allowed;

--- a/test/integration/render-tests/globe/globe-horizon/style.json
+++ b/test/integration/render-tests/globe/globe-horizon/style.json
@@ -4,7 +4,6 @@
     "test": {
       "width": 512,
       "height": 512,
-      "allowed": 0.0015,
       "operations": [
         ["setProjection", "globe"],
         ["wait"]

--- a/test/integration/render-tests/globe/globe-horizon/style.json
+++ b/test/integration/render-tests/globe/globe-horizon/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 512,
       "height": 512,
+      "allowed": 0.0015,
       "operations": [
         ["setProjection", "globe"],
         ["wait"]

--- a/test/util/html_generator.js
+++ b/test/util/html_generator.js
@@ -10,7 +10,7 @@ const generateResultHTML = template(`
     <% } else { %>
       <input type="checkbox" id="<%- r.id %>">
     <% } %>
-    <label class="tab-label" style="background: <%- r.color %>" for="<%- r.id %>"><p class="status-container"><span class="status"><%- r.status %></span> - <%- r.name %></p></label>
+    <label class="tab-label" style="background: <%- r.color %>" for="<%- r.id %>"><p class="status-container"><span class="status"><%- r.status %></span> - <%- r.name %> - diff: <%- r.minDiff %></p></label>
     <div class="tab-content">
       <% if (r.status !== 'errored') { %>
           <img src="<%- r.actual %>">


### PR DESCRIPTION
Add render test diff in render test status title. This is useful in a workflow where developer accepts failed baseline as valid and increases the render test "allowed" value threshold.

It's shown here with `FAILED - test name - diff: value`:

![Screenshot from 2022-04-07 12-20-38](https://user-images.githubusercontent.com/7061573/162282018-37fefd11-ae51-42ef-b4e2-d6fa21abfc44.png)

For example, the diff from this test failed on CI hardware as it reports some very slight differences in the test, possibly due to precision. To accept that baseline as valid, we need to know the actual threshold in order to update the original test.

![Screenshot from 2022-04-07 12-35-34](https://user-images.githubusercontent.com/7061573/162282646-3780fd33-92c9-4795-9207-4699b6758c8f.png)
