### PR TITLE
Add localization for UI strings in Catalan

### DIFF
--- a/src/ui/locales/ca.js
+++ b/src/ui/locales/ca.js
@@ -1,7 +1,7 @@
 // @flow
 
 const locale = {
-    "AttributionControl.ToggleAttribution": "Commuta l'atribució",
+    "AttributionControl.ToggleAttribution": "Mostrar atribució",
     "AttributionControl.MapFeedback": "Comentaris sobre el mapa",
     "FullscreenControl.Enter": "Entra a pantalla completa",
     "FullscreenControl.Exit": "Sortir de pantalla completa",
@@ -9,13 +9,13 @@ const locale = {
     "GeolocateControl.LocationNotAvailable": "Ubicació no disponible",
     "LogoControl.Title": "Logotip de Mapbox",
     "Map.Title": "Mapa",
-    "NavigationControl.ResetBearing": "Restableix el rumb cap al nord",
+    "NavigationControl.ResetBearing": "Restableix l'orientació cap al nord",
     "NavigationControl.ZoomIn": "Ampliar",
     "NavigationControl.ZoomOut": "Disminuir el zoom",
-    "ScaleControl.Feet": "peus",
+    "ScaleControl.Feet": "ft",
     "ScaleControl.Meters": "m",
     "ScaleControl.Kilometers": "km",
-    "ScaleControl.Miles": "el meu",
+    "ScaleControl.Miles": "mi",
     "ScaleControl.NauticalMiles": "nm",
     "ScrollZoomBlocker.CtrlMessage": "Utilitzeu ctrl + desplaçament per ampliar el mapa",
     "ScrollZoomBlocker.CmdMessage": "Utilitzeu ⌘ + desplaçament per ampliar el mapa",

--- a/src/ui/locales/ca.js
+++ b/src/ui/locales/ca.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "Commuta l'atribució",
+    "AttributionControl.MapFeedback": "Comentaris sobre el mapa",
+    "FullscreenControl.Enter": "Entra a pantalla completa",
+    "FullscreenControl.Exit": "Sortir de pantalla completa",
+    "GeolocateControl.FindMyLocation": "Troba la meva ubicació",
+    "GeolocateControl.LocationNotAvailable": "Ubicació no disponible",
+    "LogoControl.Title": "Logotip de Mapbox",
+    "Map.Title": "Mapa",
+    "NavigationControl.ResetBearing": "Restableix el rumb cap al nord",
+    "NavigationControl.ZoomIn": "Ampliar",
+    "NavigationControl.ZoomOut": "Disminuir el zoom",
+    "ScaleControl.Feet": "peus",
+    "ScaleControl.Meters": "m",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "el meu",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "Utilitzeu ctrl + desplaçament per ampliar el mapa",
+    "ScrollZoomBlocker.CmdMessage": "Utilitzeu ⌘ + desplaçament per ampliar el mapa",
+    "TouchPanBlocker.Message": "Feu servir dos dits per moure el mapa"
+}
+
+export default locale;

--- a/src/ui/locales/ca.js
+++ b/src/ui/locales/ca.js
@@ -20,6 +20,6 @@ const locale = {
     "ScrollZoomBlocker.CtrlMessage": "Utilitzeu ctrl + desplaçament per ampliar el mapa",
     "ScrollZoomBlocker.CmdMessage": "Utilitzeu ⌘ + desplaçament per ampliar el mapa",
     "TouchPanBlocker.Message": "Feu servir dos dits per moure el mapa"
-}
+};
 
 export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Catalan. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
