### PR TITLE
Add localization for UI strings in Hungarian

### DIFF
--- a/src/ui/locales/hu.js
+++ b/src/ui/locales/hu.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "Kapcsolja be a hozzárendelést",
+    "AttributionControl.MapFeedback": "Térkép-visszajelzés",
+    "FullscreenControl.Enter": "Lépjen be a teljes képernyőre",
+    "FullscreenControl.Exit": "Lépjen ki a teljes képernyőről",
+    "GeolocateControl.FindMyLocation": "Keresse meg a helyemet",
+    "GeolocateControl.LocationNotAvailable": "A helyszín nem elérhető",
+    "LogoControl.Title": "Mapbox logó",
+    "Map.Title": "Térkép",
+    "NavigationControl.ResetBearing": "Állítsa vissza a csapágyat északra",
+    "NavigationControl.ZoomIn": "Nagyítás",
+    "NavigationControl.ZoomOut": "Kicsinyítés",
+    "ScaleControl.Feet": "ft",
+    "ScaleControl.Meters": "m",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "nekem",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "A térkép nagyításához használja a ctrl + görgetést",
+    "ScrollZoomBlocker.CmdMessage": "A térkép nagyításához használja a ⌘ + görgetést",
+    "TouchPanBlocker.Message": "Két ujjal mozgassa a térképet"
+}
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Hungarian. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
