### PR TITLE
Add localization for UI strings in Japanese

### DIFF
--- a/src/ui/locales/ja.js
+++ b/src/ui/locales/ja.js
@@ -1,25 +1,25 @@
 // @flow
 
 const locale = {
-    "AttributionControl.ToggleAttribution": "アトリビューションを切り替える",
-    "AttributionControl.MapFeedback": "マップフィードバック",
-    "FullscreenControl.Enter": "フルスクリーンに入る",
+    "AttributionControl.ToggleAttribution": "アトリビューションを切り替え",
+    "AttributionControl.MapFeedback": "地図へのフィードバック",
+    "FullscreenControl.Enter": "全画面表示を開始",
     "FullscreenControl.Exit": "全画面表示を終了",
-    "GeolocateControl.FindMyLocation": "私の場所を探す",
-    "GeolocateControl.LocationNotAvailable": "場所は利用できません",
+    "GeolocateControl.FindMyLocation": "現在地を検索",
+    "GeolocateControl.LocationNotAvailable": "現在地が見つかりません",
     "LogoControl.Title": "Mapboxのロゴ",
     "Map.Title": "地図",
-    "NavigationControl.ResetBearing": "ベアリングを北にリセット",
+    "NavigationControl.ResetBearing": "北向きに変える",
     "NavigationControl.ZoomIn": "ズームイン",
-    "NavigationControl.ZoomOut": "ズームアウトする",
+    "NavigationControl.ZoomOut": "ズームアウト",
     "ScaleControl.Feet": "フィート",
     "ScaleControl.Meters": "m",
     "ScaleControl.Kilometers": "km",
-    "ScaleControl.Miles": "自分",
-    "ScaleControl.NauticalMiles": "nm",
-    "ScrollZoomBlocker.CtrlMessage": "Ctrlキーを押しながらスクロールして地図をズームします",
-    "ScrollZoomBlocker.CmdMessage": "⌘+スクロールを使用して地図をズームします",
-    "TouchPanBlocker.Message": "2本の指で地図を移動します"
+    "ScaleControl.Miles": "マイル",
+    "ScaleControl.NauticalMiles": "海里",
+    "ScrollZoomBlocker.CtrlMessage": "ctrlキー+スクロールで地図を縮小/拡大",
+    "ScrollZoomBlocker.CmdMessage": "⌘+スクロールで地図を縮小/拡大",
+    "TouchPanBlocker.Message": "指2本で地図をスクロール"
 };
 
 export default locale;

--- a/src/ui/locales/ja.js
+++ b/src/ui/locales/ja.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "アトリビューションを切り替える",
+    "AttributionControl.MapFeedback": "マップフィードバック",
+    "FullscreenControl.Enter": "フルスクリーンに入る",
+    "FullscreenControl.Exit": "全画面表示を終了",
+    "GeolocateControl.FindMyLocation": "私の場所を探す",
+    "GeolocateControl.LocationNotAvailable": "場所は利用できません",
+    "LogoControl.Title": "Mapboxのロゴ",
+    "Map.Title": "地図",
+    "NavigationControl.ResetBearing": "ベアリングを北にリセット",
+    "NavigationControl.ZoomIn": "ズームイン",
+    "NavigationControl.ZoomOut": "ズームアウトする",
+    "ScaleControl.Feet": "フィート",
+    "ScaleControl.Meters": "m",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "自分",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "Ctrlキーを押しながらスクロールして地図をズームします",
+    "ScrollZoomBlocker.CmdMessage": "⌘+スクロールを使用して地図をズームします",
+    "TouchPanBlocker.Message": "2本の指で地図を移動します"
+};
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Japanese. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
