### PR TITLE
Add localization for UI strings in Korean

### DIFF
--- a/src/ui/locales/ko.js
+++ b/src/ui/locales/ko.js
@@ -13,12 +13,12 @@ const locale = {
     "NavigationControl.ZoomIn": "확대",
     "NavigationControl.ZoomOut": "축소",
     "ScaleControl.Feet": "피트",
-    "ScaleControl.Meters": "중",
-    "ScaleControl.Kilometers": "km",
-    "ScaleControl.Miles": "나",
-    "ScaleControl.NauticalMiles": "nm",
+    "ScaleControl.Meters": "미터",
+    "ScaleControl.Kilometers": "킬로미터",
+    "ScaleControl.Miles": "마일",
+    "ScaleControl.NauticalMiles": "해리",
     "ScrollZoomBlocker.CtrlMessage": "ctrl + 스크롤을 사용하여 지도 확대/축소",
-    "ScrollZoomBlocker.CmdMessage": "⌘ + 스크롤을 사용하여 지도를 확대/축소하세요.",
+    "ScrollZoomBlocker.CmdMessage": "⌘ + 스크롤을 사용하여 지도 확대/축소",
     "TouchPanBlocker.Message": "두 손가락을 사용하여 지도 이동"
 };
 

--- a/src/ui/locales/ko.js
+++ b/src/ui/locales/ko.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "속성 전환",
+    "AttributionControl.MapFeedback": "지도 피드백",
+    "FullscreenControl.Enter": "전체 화면으로 전환",
+    "FullscreenControl.Exit": "전체화면 종료",
+    "GeolocateControl.FindMyLocation": "내 위치 찾기",
+    "GeolocateControl.LocationNotAvailable": "위치를 사용할 수 없음",
+    "LogoControl.Title": "맵박스 로고",
+    "Map.Title": "지도",
+    "NavigationControl.ResetBearing": "방위를 북쪽으로 재설정",
+    "NavigationControl.ZoomIn": "확대",
+    "NavigationControl.ZoomOut": "축소",
+    "ScaleControl.Feet": "피트",
+    "ScaleControl.Meters": "중",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "나",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "ctrl + 스크롤을 사용하여 지도 확대/축소",
+    "ScrollZoomBlocker.CmdMessage": "⌘ + 스크롤을 사용하여 지도를 확대/축소하세요.",
+    "TouchPanBlocker.Message": "두 손가락을 사용하여 지도 이동"
+};
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Korean. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
