### PR TITLE
Add localization for UI strings in Latvian

### DIFF
--- a/src/ui/locales/lv.js
+++ b/src/ui/locales/lv.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "Pārslēgt attiecinājumu",
+    "AttributionControl.MapFeedback": "Atsauksmes par karti",
+    "FullscreenControl.Enter": "Ieiet pilnekrāna režīmā",
+    "FullscreenControl.Exit": "Iziet pilnekrāna režīmā",
+    "GeolocateControl.FindMyLocation": "Atrodi manu atrašanās vietu",
+    "GeolocateControl.LocationNotAvailable": "Atrašanās vieta nav pieejama",
+    "LogoControl.Title": "Mapbox logotips",
+    "Map.Title": "Karte",
+    "NavigationControl.ResetBearing": "Atiestatīt gultni uz ziemeļiem",
+    "NavigationControl.ZoomIn": "Pietuvināt",
+    "NavigationControl.ZoomOut": "Attālināt",
+    "ScaleControl.Feet": "pēdas",
+    "ScaleControl.Meters": "m",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "es",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "Izmantojiet ctrl + ritināšanu, lai tuvinātu karti",
+    "ScrollZoomBlocker.CmdMessage": "Izmantojiet ⌘ + ritināšanu, lai tuvinātu karti",
+    "TouchPanBlocker.Message": "Izmantojiet divus pirkstus, lai pārvietotu karti"
+};
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Latvian. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
