### PR TITLE
Add localization for UI strings in Slovenian

### DIFF
--- a/src/ui/locales/sl.js
+++ b/src/ui/locales/sl.js
@@ -12,11 +12,6 @@ const locale = {
     "NavigationControl.ResetBearing": "Ponastavite smer proti severu",
     "NavigationControl.ZoomIn": "Približaj",
     "NavigationControl.ZoomOut": "Pomanjšanje",
-    "ScaleControl.Feet": "ft",
-    "ScaleControl.Meters": "m",
-    "ScaleControl.Kilometers": "km",
-    "ScaleControl.Miles": "jaz",
-    "ScaleControl.NauticalMiles": "nm",
     "ScrollZoomBlocker.CtrlMessage": "Uporabite ctrl + drsenje za povečavo zemljevida",
     "ScrollZoomBlocker.CmdMessage": "Uporabite ⌘ + pomikanje, da povečate zemljevid",
     "TouchPanBlocker.Message": "Uporabite dva prsta za premikanje zemljevida"

--- a/src/ui/locales/sl.js
+++ b/src/ui/locales/sl.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "Preklop dodeljevanja",
+    "AttributionControl.MapFeedback": "Povratne informacije o zemljevidu",
+    "FullscreenControl.Enter": "Vstopite v celozaslonski način",
+    "FullscreenControl.Exit": "Zapustite celozaslonski način",
+    "GeolocateControl.FindMyLocation": "Najdi mojo lokacijo",
+    "GeolocateControl.LocationNotAvailable": "Lokacija ni na voljo",
+    "LogoControl.Title": "Logotip Mapbox",
+    "Map.Title": "Zemljevid",
+    "NavigationControl.ResetBearing": "Ponastavite smer proti severu",
+    "NavigationControl.ZoomIn": "Približaj",
+    "NavigationControl.ZoomOut": "Pomanjšanje",
+    "ScaleControl.Feet": "ft",
+    "ScaleControl.Meters": "m",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "jaz",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "Uporabite ctrl + drsenje za povečavo zemljevida",
+    "ScrollZoomBlocker.CmdMessage": "Uporabite ⌘ + pomikanje, da povečate zemljevid",
+    "TouchPanBlocker.Message": "Uporabite dva prsta za premikanje zemljevida"
+};
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Slovenian. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

To improve the machine translation, click the plus sign next to the line you want to enhance in the `Files changed` tab and suggest a translation.

If the translation looks good, you can approve it in the PR's comments section below.

Thanks for helping 🙌

| Context | Screenshot |
| :------ | :--------: |
| **ID**: `AttributionControl.ToggleAttribution`<br/>**English**: `Toggle attribution`<br/>**Context**: Tooltip text on `AttributionControl` hover | ![Screenshot 2022-04-12 at 12 22 53](https://user-images.githubusercontent.com/533564/162927219-dcd9a273-6f97-4c3f-b157-858562ed13c8.png)
| **ID**: `AttributionControl.MapFeedback`<br/>**English**: `Map feedback`<br/>**Context**: Accessibility label for the `Improve this map` link in the expanded `AttributionControl`. That label can be read by assistive technology | <img width="379" alt="Screenshot 2022-04-11 at 21 40 33" src="https://user-images.githubusercontent.com/533564/162928890-741d219a-40d3-4b41-94e6-7822459bcdd0.png">
| **ID**: `FullscreenControl.Enter`<br/>**English**: `Enter fullscreen`<br/>**Context**: Tooltip text on FullscreenControl hover when not in the fullscreen mode | ![Screenshot 2022-04-12 at 12 31 49](https://user-images.githubusercontent.com/533564/162929539-45df3d07-0294-43dd-a283-420b5c093e98.png)
| **ID**: `FullscreenControl.Exit`<br/>**English**: `Exit fullscreen`<br/>**Context**: Tooltip text on `FullscreenControl` hover when in the fullscreen mode | ![Screenshot 2022-04-12 at 12 31 58](https://user-images.githubusercontent.com/533564/162929582-4eca7620-62da-449f-8178-75a2006a473d.png)
| **ID**: `GeolocateControl.FindMyLocation`<br/>**English**: `Find my location`<br/>**Context**: Tooltip text on `GeolocateControl` hover | ![Screenshot 2022-04-12 at 12 34 57](https://user-images.githubusercontent.com/533564/162930227-85b56c0a-cce1-4fae-a9d1-d421d97c9c6f.png)
| **ID**: `GeolocateControl.LocationNotAvailable`<br/>**English**: `Location not available`<br/>**Context**: Tooltip text on `GeolocateControl` hover when we can't locate user | ![Screenshot 2022-04-12 at 12 35 08](https://user-images.githubusercontent.com/533564/162930255-c66b503d-50a8-40a6-b7cd-5563434d3038.png)
| **ID**: `LogoControl.Title`<br/>**English**: `Mapbox logo`<br/>**Context**: Accessibility label for the Mapbox logo image. That label can be read by assistive technology | ![Screenshot 2022-04-12 at 12 38 52](https://user-images.githubusercontent.com/533564/162930902-b942f607-6f6a-4e8a-89b3-da7663670fff.png)
| **ID**: `Map.Title`<br/>**English**: `Map`<br/>**Context**: Accessibility label for the map canvas element on the webpage. That label can be read by assistive technology | ![Screenshot 2022-04-12 at 12 42 03](https://user-images.githubusercontent.com/533564/162931221-bcd3dc1f-0ca9-424d-b1b7-0b411a860473.png)
| **ID**: `NavigationControl.ResetBearing`<br/>**English**: `Reset bearing to north`<br/>**Context**: Tooltip text on bearing button in `NavigationControl` | ![Screenshot 2022-04-12 at 12 45 06](https://user-images.githubusercontent.com/533564/162932083-77dea226-1887-4152-8e7f-40a38bc0a36f.png)
| **ID**: `NavigationControl.ZoomIn`<br/>**English**: `Zoom in`<br/>**Context**: Tooltip text on plus button in `NavigationControl` | ![Screenshot 2022-04-12 at 12 45 56](https://user-images.githubusercontent.com/533564/162932188-683d62ae-6f0c-4414-96fd-0e2727c255cd.png)
| **ID**: `NavigationControl.ZoomOut`<br/>**English**: `Zoom out`<br/>**Context**: Tooltip text on minus button in `NavigationControl` | ![Screenshot 2022-04-12 at 12 46 02](https://user-images.githubusercontent.com/533564/162932227-fec4a30a-80fc-4fa8-a023-b05e8bdc147b.png)
| **ID**: `ScrollZoomBlocker.CtrlMessage`<br/>**English**: `Use ctrl + scroll to zoom the map`<br/>**Context**: Text on map blocker alert when cooperative gestures are enabled | ![Screenshot 2022-04-12 at 13 08 03](https://user-images.githubusercontent.com/533564/162937534-ae6534cc-ad5c-4e47-9d13-9a62bd5ad336.png)
| **ID**: `ScrollZoomBlocker.CmdMessage`<br/>**English**: `Use ⌘ + scroll to zoom the map`<br/>**Context**: Text on map blocker alert when cooperative gestures are enabled | ![Screenshot 2022-04-12 at 13 08 03](https://user-images.githubusercontent.com/533564/162937534-ae6534cc-ad5c-4e47-9d13-9a62bd5ad336.png)
| **ID**: `TouchPanBlocker.Message`<br/>**English**: `Use two fingers to move the map`<br/>**Context**: Text on map blocker alert when cooperative gestures are enabled | ![IMG_A42AFAB7325C-1](https://user-images.githubusercontent.com/533564/162937827-0a020d24-3edf-434f-b4dc-dcfcdfafd904.jpeg)