### PR TITLE
Add localization for UI strings in Serbian

### DIFF
--- a/src/ui/locales/sr.js
+++ b/src/ui/locales/sr.js
@@ -7,7 +7,7 @@ const locale = {
     "FullscreenControl.Exit": "Прекини приказ на целом екрану",
     "GeolocateControl.FindMyLocation": "Пронађи моју локацију",
     "GeolocateControl.LocationNotAvailable": "Локација није доступна",
-    "LogoControl.Title": "© Mapbox лого",
+    "LogoControl.Title": "Mapbox лого",
     "Map.Title": "Мапа",
     "NavigationControl.ResetBearing": "Ресетoвати смер на север",
     "NavigationControl.ZoomIn": "Приближити мапу",

--- a/src/ui/locales/sr.js
+++ b/src/ui/locales/sr.js
@@ -1,25 +1,25 @@
 // @flow
 
 const locale = {
-    "AttributionControl.ToggleAttribution": "Укључите приписивање",
+    "AttributionControl.ToggleAttribution": "Укључи приписивање",
     "AttributionControl.MapFeedback": "Повратне информације о мапи",
-    "FullscreenControl.Enter": "Унесите цео екран",
-    "FullscreenControl.Exit": "Изађите преко целог екрана",
-    "GeolocateControl.FindMyLocation": "Пронађите моју локацију",
+    "FullscreenControl.Enter": "Прикажи на целом екрану",
+    "FullscreenControl.Exit": "Прекини приказ на целом екрану",
+    "GeolocateControl.FindMyLocation": "Пронађи моју локацију",
     "GeolocateControl.LocationNotAvailable": "Локација није доступна",
-    "LogoControl.Title": "Мапбок лого",
+    "LogoControl.Title": "© Mapbox лого",
     "Map.Title": "Мапа",
-    "NavigationControl.ResetBearing": "Ресетујте смер на север",
-    "NavigationControl.ZoomIn": "Увеличати",
-    "NavigationControl.ZoomOut": "Умањите",
+    "NavigationControl.ResetBearing": "Ресетoвати смер на север",
+    "NavigationControl.ZoomIn": "Приближити мапу",
+    "NavigationControl.ZoomOut": "Удаљити мапу",
     "ScaleControl.Feet": "фт",
     "ScaleControl.Meters": "м",
     "ScaleControl.Kilometers": "км",
     "ScaleControl.Miles": "ја",
     "ScaleControl.NauticalMiles": "нм",
-    "ScrollZoomBlocker.CtrlMessage": "Користите цтрл + скрол да бисте зумирали мапу",
-    "ScrollZoomBlocker.CmdMessage": "Користите ⌘ + скролујте да бисте зумирали мапу",
-    "TouchPanBlocker.Message": "Користите два прста да померите мапу"
+    "ScrollZoomBlocker.CtrlMessage": "Користити Ctrl + скрол да бисте зумирали мапу",
+    "ScrollZoomBlocker.CmdMessage": "Користити ⌘ (Cmd) + скрол да бисте зумирали мапу",
+    "TouchPanBlocker.Message": "Користити два прста да померaте мапу"
 };
 
 export default locale;

--- a/src/ui/locales/sr.js
+++ b/src/ui/locales/sr.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "Укључите приписивање",
+    "AttributionControl.MapFeedback": "Повратне информације о мапи",
+    "FullscreenControl.Enter": "Унесите цео екран",
+    "FullscreenControl.Exit": "Изађите преко целог екрана",
+    "GeolocateControl.FindMyLocation": "Пронађите моју локацију",
+    "GeolocateControl.LocationNotAvailable": "Локација није доступна",
+    "LogoControl.Title": "Мапбок лого",
+    "Map.Title": "Мапа",
+    "NavigationControl.ResetBearing": "Ресетујте смер на север",
+    "NavigationControl.ZoomIn": "Увеличати",
+    "NavigationControl.ZoomOut": "Умањите",
+    "ScaleControl.Feet": "фт",
+    "ScaleControl.Meters": "м",
+    "ScaleControl.Kilometers": "км",
+    "ScaleControl.Miles": "ја",
+    "ScaleControl.NauticalMiles": "нм",
+    "ScrollZoomBlocker.CtrlMessage": "Користите цтрл + скрол да бисте зумирали мапу",
+    "ScrollZoomBlocker.CmdMessage": "Користите ⌘ + скролујте да бисте зумирали мапу",
+    "TouchPanBlocker.Message": "Користите два прста да померите мапу"
+};
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Serbian. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
