### PR TITLE
Add localization for UI strings in Tagalog

### DIFF
--- a/src/ui/locales/tl.js
+++ b/src/ui/locales/tl.js
@@ -15,7 +15,7 @@ const locale = {
     "ScaleControl.Feet": "ft",
     "ScaleControl.Meters": "m",
     "ScaleControl.Kilometers": "km",
-    "ScaleControl.Miles": "ako",
+    "ScaleControl.Miles": "mi",
     "ScaleControl.NauticalMiles": "nm",
     "ScrollZoomBlocker.CtrlMessage": "Gamitin ang ctrl + scroll para i-zoom ang mapa",
     "ScrollZoomBlocker.CmdMessage": "Gamitin ang ⌘ + scroll upang i-zoom ang mapa",

--- a/src/ui/locales/tl.js
+++ b/src/ui/locales/tl.js
@@ -1,0 +1,25 @@
+// @flow
+
+const locale = {
+    "AttributionControl.ToggleAttribution": "I-toggle ang attribution",
+    "AttributionControl.MapFeedback": "Feedback sa mapa",
+    "FullscreenControl.Enter": "Ipasok ang fullscreen",
+    "FullscreenControl.Exit": "Lumabas sa fullscreen",
+    "GeolocateControl.FindMyLocation": "Hanapin ang aking lokasyon",
+    "GeolocateControl.LocationNotAvailable": "Hindi available ang lokasyon",
+    "LogoControl.Title": "Logo ng mapbox",
+    "Map.Title": "Mapa",
+    "NavigationControl.ResetBearing": "I-reset ang bearing sa hilaga",
+    "NavigationControl.ZoomIn": "Palakihin",
+    "NavigationControl.ZoomOut": "Mag-zoom out",
+    "ScaleControl.Feet": "ft",
+    "ScaleControl.Meters": "m",
+    "ScaleControl.Kilometers": "km",
+    "ScaleControl.Miles": "ako",
+    "ScaleControl.NauticalMiles": "nm",
+    "ScrollZoomBlocker.CtrlMessage": "Gamitin ang ctrl + scroll para i-zoom ang mapa",
+    "ScrollZoomBlocker.CmdMessage": "Gamitin ang ⌘ + scroll upang i-zoom ang mapa",
+    "TouchPanBlocker.Message": "Gumamit ng dalawang daliri upang ilipat ang mapa"
+};
+
+export default locale;


### PR DESCRIPTION
Hey 👋

This PR adds translations for UI strings we use in GL JS into Tagalog. We translated the UI strings automatically using the Google Translate API, and we need to verify that the translation is correct.

To help us verify the translations, you can open the `Files changed` tab on this page and compare the translations with the original file [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js).

If the translation looks good, you can approve it using the `Review changes` button in the `Files changed` tab and selecting the `Approve` radio button when submitting the review.

To improve the machine translation, you can click the plus sign next to the line you want to enhance and select the suggestion button on the toolbar.

After making the suggestions, you can mark the review as finished using the `Review changes` button and selecting the `Request changes` radio button.

Thanks for helping 🙌
