### PR TITLE
Fix CSP bundle by not mangling class names there, and add CSP tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-render-csp:
+          requires:
+            - prepare
+          filters:
+            tags:
+              only: /.*/
       - test-query:
           requires:
             - prepare
@@ -266,6 +272,18 @@ jobs:
           at: ~/
       - browser-tools/install-chrome
       - run: yarn run test-render-prod
+      - store_test_results:
+          path: test/integration/render-tests
+      - store_artifacts:
+          path: "test/integration/render-tests/index.html"
+
+  test-render-csp:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - browser-tools/install-chrome
+      - run: yarn run test-render-csp
       - store_test_results:
           path: test/integration/render-tests
       - store_artifacts:

--- a/bench/rollup_config_benchmarks.js
+++ b/bench/rollup_config_benchmarks.js
@@ -20,7 +20,7 @@ const replaceConfig = {
     'process.env.NODE_ENV': JSON.stringify('production')
 };
 
-const allPlugins = plugins(true, true).concat(replace(replaceConfig));
+const allPlugins = plugins({minified: true, production: true}).concat(replace(replaceConfig));
 const intro = fs.readFileSync('rollup/bundle_prelude.js', 'utf8');
 
 const splitConfig = (name) => [{

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -13,7 +13,7 @@ import replace from '@rollup/plugin-replace';
 // Common set of plugins/transformations shared across different rollup
 // builds (main mapboxgl bundle, style-spec package, benchmarks bundle)
 
-export const plugins = (minified, production, test, bench) => [
+export const plugins = ({minified, production, test, bench, keepClassNames}) => [
     flow(),
     minifyStyleSpec(),
     json({
@@ -33,7 +33,8 @@ export const plugins = (minified, production, test, bench) => [
         compress: {
             pure_getters: true,
             passes: 3
-        }
+        },
+        keep_classnames: keepClassNames
     }) : false,
     resolve({
         browser: true,

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "watch-query": "SUITE_NAME=query testem -f test/integration/testem/testem.js",
     "test-render": "SUITE_NAME=render CI=true testem ci -f test/integration/testem/testem.js",
     "test-render-prod": "BUILD=production SUITE_NAME=render CI=true testem ci -f test/integration/testem/testem.js",
+    "test-render-csp": "BUILD=csp SUITE_NAME=render CI=true testem ci -f test/integration/testem/testem.js",
     "test-query": "SUITE_NAME=query CI=true testem ci -f test/integration/testem/testem.js",
     "test-expressions": "build/run-node test/expression.test.js",
     "test-flow": "build/run-node build/generate-flow-typed-style-spec && flow .",

--- a/rollup.config.csp.js
+++ b/rollup.config.csp.js
@@ -15,7 +15,7 @@ const config = (input, file, format) => ({
         banner
     },
     treeshake: true,
-    plugins: plugins(true, true, false)
+    plugins: plugins({minified: true, production: true, keepClassNames: true})
 });
 
 export default [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,7 @@ export default [{
         chunkFileNames: 'shared.js'
     },
     treeshake: production,
-    plugins: plugins(minified, production, false, bench)
+    plugins: plugins({minified, production, bench})
 }, {
     // Next, bundle together the three "chunks" produced in the previous pass
     // into a single, final bundle. See rollup/bundle_prelude.js and

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -77,6 +77,9 @@ type SerializedGrid = { buffer: ArrayBuffer };
 (Grid: any).deserialize = function deserialize(serialized: SerializedGrid): Grid {
     return new Grid(serialized.buffer);
 };
+
+Object.defineProperty(Grid, 'name', {value: 'Grid'});
+
 register(Grid);
 
 register(Color);

--- a/test/integration/rollup.config.test.js
+++ b/test/integration/rollup.config.test.js
@@ -11,6 +11,6 @@ export default {
         indent: false,
         file: `test/integration/dist/integration-test.js`
     },
-    plugins: plugins(false, false, true),
+    plugins: plugins({test: true}),
     external: [ 'tape', 'mapboxgl' ]
 };

--- a/test/integration/testem/testem.js
+++ b/test/integration/testem/testem.js
@@ -25,10 +25,10 @@ const suitePath = `${suiteName}-tests`;
 const ciOutputFile = `${rootFixturePath}${suitePath}/test-results.xml`;
 const fixtureBuildInterval = 2000;
 
-const testPage = "test/integration/testem_page_" + (
+const testPage = `test/integration/testem_page_${
     process.env.BUILD === "production" ? "prod" :
     process.env.BUILD === "csp" ? "csp" : "dev"
-) + ".html";
+}.html`;
 
 const buildJob =
     process.env.BUILD === "production" ? "build-prod-min" :

--- a/test/integration/testem/testem.js
+++ b/test/integration/testem/testem.js
@@ -24,8 +24,15 @@ const suiteName = process.env.SUITE_NAME;
 const suitePath = `${suiteName}-tests`;
 const ciOutputFile = `${rootFixturePath}${suitePath}/test-results.xml`;
 const fixtureBuildInterval = 2000;
-const testPage = process.env.BUILD === "production" ? "test/integration/testem_page_prod.html" : "test/integration/testem_page_dev.html";
-const buildJob = process.env.BUILD === "production" ? "build-prod-min" : "build-dev";
+
+const testPage = "test/integration/testem_page_" + (
+    process.env.BUILD === "production" ? "prod" :
+    process.env.BUILD === "csp" ? "csp" : "dev"
+) + ".html";
+
+const buildJob =
+    process.env.BUILD === "production" ? "build-prod-min" :
+    process.env.BUILD === "csp" ? "build-csp" : "build-dev";
 
 let beforeHookInvoked = false;
 let server;

--- a/test/integration/testem_page_csp.html
+++ b/test/integration/testem_page_csp.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+    <title>
+        Mapbox GL JS Integration Tests
+    </title>
+    <style>
+        @font-face {
+            font-family: 'Open Sans';
+            src: url('/node_modules/npm-font-open-sans/fonts/Bold/OpenSans-Bold.ttf')
+        }
+    </style>
+</head>
+<body>
+
+    <script src="/testem.js"></script>
+    <script src="/test/integration/dist/tape.js"></script>
+    <script src="/dist/mapbox-gl-csp.js"></script>
+    <script>
+        mapboxgl.workerUrl = '/dist/mapbox-gl-csp-worker.js';
+    </script>
+    <script src="../../debug/access_token_generated.js"></script>
+    <script src="/test/integration/dist/integration-test.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #11684, fixes #11686 (regression introduced in #11511). Disables class name mangling when making the CSP bundle. To make generic transfer of class instances between web worker and main thread work, we depend on class names being the same on both sides. However, the CSP bundle config runs the bundling process separately for the main thread and the worker, meaning that mangled names won't align as they are in the default bundle.

Disabling class name mangling only increases the size of both bundled files by ~2KB, and it's not the default bundle but rather one for strict CSP environments only, so it should be fine. We could approach this with a more elaborate fix that uses chunks to avoid this tiny overhead, but it doesn't seem to be worth it.

~~Also needs a test if possible to make sure this doesn't regress in the future.~~ Added a new render test job that uses the CSP bundle to make sure we never regress on this again.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix the special bundle for CSP-restricted environments that broke in the previous release.</changelog>`
