### PR TITLE
add missing roundZoom in CustomSource coveringTiles

### DIFF
--- a/src/source/custom_source.js
+++ b/src/source/custom_source.js
@@ -358,6 +358,7 @@ class CustomSource<T> extends Evented implements Source {
             tileSize: this.tileSize,
             minzoom: this.minzoom,
             maxzoom: this.maxzoom,
+            roundZoom: this.roundZoom
         });
 
         return tileIDs.map(tileID => ({x: tileID.canonical.x, y: tileID.canonical.y, z: tileID.canonical.z}));


### PR DESCRIPTION
This PR fixes the `coveringTiles` method of `CustomSource`

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
