### PR TITLE
Fix tiles being erroneously culled near poles

### DIFF
--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -181,7 +181,13 @@ export function aabbForTileOnGlobe(tr: Transform, numTiles: number, tileId: Cano
     }
 
     if (bounds.contains(tr.center)) {
+        // Extend the aabb by encapsulating the center point
         cornerMax[2] = 0.0;
+        const point = tr.point;
+        const center = [point.x * scale, point.y * scale, 0];
+        vec3.min(cornerMin, cornerMin, center);
+        vec3.max(cornerMax, cornerMax, center);
+
         return new Aabb(cornerMin, cornerMax);
     }
 

--- a/test/unit/geo/projection/globe.test.js
+++ b/test/unit/geo/projection/globe.test.js
@@ -147,6 +147,23 @@ test('Globe', (t) => {
             t.end();
         });
 
+        t.test('Highly curved tiles near polar regions', (t) => {
+            tr.zoom = 4.95;
+            tr.pitch = 0;
+            tr.bearing = 0;
+            tr.center = new LngLat(45, 66.55);
+            tr.resize(1024, 1024);
+
+            t.deepEqual(tr.coveringTiles(options), [
+                new OverscaledTileID(4, 0, 4, 10, 3),
+                new OverscaledTileID(4, 0, 4, 9, 3),
+                new OverscaledTileID(4, 0, 4, 10, 4),
+                new OverscaledTileID(4, 0, 4, 9, 4)
+            ]);
+
+            t.end();
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
This PR fixes a rare issue where visible tiles are being erroneously culled in globe view. This might happen near polar regions where tiles are highly curved.

The bug can be triggered for example by navigating to http://localhost:9966/debug/terrain-debug.html#4.95/66.55/45 and setting window size to 1024x1024 or smaller. Tiles on the upper side of the screen are missing.

![image](https://user-images.githubusercontent.com/55925868/164315024-49ac5a76-2b8d-4491-9359-2397798f4943.png)

This happens because the parent tile `2/2/0` is not reported visible due to an erroneous aabb. The bug exists only in the code path that is taken for tiles that are encapsulating the map center point. The invalid aabb (blue rect) and approximation of camera frustum (red) can be seen in the following image.

![image](https://user-images.githubusercontent.com/55925868/164315764-acd9ba4f-8e8a-4de1-992f-92e9f67bfa09.png)

The fix is to extend the aabb to include the center point. A new regression unit test has been added to catch this bug.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'`
