### PR TITLE
Move fog shader functions from common prelude to stage specific preludes

### DIFF
--- a/src/shaders/_prelude.glsl
+++ b/src/shaders/_prelude.glsl
@@ -10,35 +10,3 @@
 #define RAD_TO_DEG 180.0 / PI
 #define DEG_TO_RAD PI / 180.0
 #define GLOBE_RADIUS EXTENT / PI / 2.0
-
-#ifdef FOG
-
-float fog_range(vec2 range, float depth) {
-    // Map [near, far] to [0, 1] without clamping
-    return (depth - range[0]) / (range[1] - range[0]);
-}
-
-// Assumes z up and camera_dir *normalized* (to avoid computing
-// its length multiple times for different functions).
-float fog_horizon_blending(vec4 color, float blend, vec3 camera_dir) {
-    float t = max(0.0, camera_dir.z / blend);
-    // Factor of 3 chosen to roughly match smoothstep.
-    // See: https://www.desmos.com/calculator/pub31lvshf
-    return color.a * exp(-3.0 * t * t);
-}
-
-// Compute a ramp for fog opacity
-//   - t: depth, rescaled to 0 at fogStart and 1 at fogEnd
-// See: https://www.desmos.com/calculator/3taufutxid
-float fog_opacity(vec4 color, float t) {
-    const float decay = 6.0;
-    float falloff = 1.0 - min(1.0, exp(-decay * t));
-
-    // Cube without pow() to smooth the onset
-    falloff *= falloff * falloff;
-
-    // Scale and clip to 1 at the far limit
-    return color.a * min(1.0, 1.00747 * falloff);
-}
-
-#endif

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -6,6 +6,34 @@ uniform mediump float u_fog_horizon_blend;
 uniform mediump mat4 u_fog_matrix;
 varying vec3 v_fog_pos;
 
+float fog_range(float depth) {
+    // Map [near, far] to [0, 1] without clamping
+    return (depth - u_fog_range[0]) / (u_fog_range[1] - u_fog_range[0]);
+}
+
+// Assumes z up and camera_dir *normalized* (to avoid computing
+// its length multiple times for different functions).
+float fog_horizon_blending(vec3 camera_dir) {
+    float t = max(0.0, camera_dir.z / u_fog_horizon_blend);
+    // Factor of 3 chosen to roughly match smoothstep.
+    // See: https://www.desmos.com/calculator/pub31lvshf
+    return u_fog_color.a * exp(-3.0 * t * t);
+}
+
+// Compute a ramp for fog opacity
+//   - t: depth, rescaled to 0 at fogStart and 1 at fogEnd
+// See: https://www.desmos.com/calculator/3taufutxid
+float fog_opacity(float t) {
+    const float decay = 6.0;
+    float falloff = 1.0 - min(1.0, exp(-decay * t));
+
+    // Cube without pow() to smooth the onset
+    falloff *= falloff * falloff;
+
+    // Scale and clip to 1 at the far limit
+    return u_fog_color.a * min(1.0, 1.00747 * falloff);
+}
+
 vec3 fog_position(vec3 pos) {
     // The following function requires that u_fog_matrix be affine and
     // results in a vector with w = 1. Otherwise we must divide by w.
@@ -18,8 +46,8 @@ vec3 fog_position(vec2 pos) {
 
 float fog(vec3 pos) {
     float depth = length(pos);
-    float opacity = fog_opacity(u_fog_color, fog_range(u_fog_range, depth));
-    return opacity * fog_horizon_blending(u_fog_color, u_fog_horizon_blend, pos / depth);
+    float opacity = fog_opacity(fog_range(depth));
+    return opacity * fog_horizon_blending(pos / depth);
 }
 
 #endif


### PR DESCRIPTION
Same issue which was discussed in the previous PR: https://github.com/mapbox/mapbox-gl-js/pull/11673

Unfortunately that fix wasn't enough, we have to move all fog functions to the stage specific preludes, because some OpenGL versions fail if they're defined before the precision qualifiers.

Tested the branch before and after the change in GL-Native. Before this, I get the following error on iOS:
```
ERROR: 0:14: 'vec2' : declaration must include a precision qualifier for type
ERROR: 0:14: 'float' : declaration must include a precision qualifier for type
ERROR: 0:14: 'float' : declaration must include a precision qualifier for type
ERROR: 0:14: 'vec4' : declaration must include a precision qualifier for type
ERROR: 0:14: 'float' : declaration must include a precision qualifier for type
ERROR: 0:14: 'vec3' : declaration must include a precision qualifier for type
ERROR: 0:14: 'float' : declaration must include a precision qualifier for type
ERROR: 0:14: 'vec4' : declaration must include a precision qualifier for type
ERROR: 0:14: 'float' : declaration must include a precision qualifier for type
ERROR: 0:34: Invalid call of undeclared identifier 'fog_range'
ERROR: 0:34: Invalid call of undeclared identifier 'fog_range'
ERROR: 0:34: Use of undeclared identifier 'opacity'
ERROR: 0:34: Invalid call of undeclared identifier 'fog_horizon_blending'
ERROR: 0:34: Use of undeclared identifier 'opacity'
ERROR: 0:34: Invalid call of undeclared identifier 'fog_horizon_blending'
ERROR: 0:34: Use of undeclared identifier 'horizon_blend'
```

After the change the fog rendering works as expected.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
