### PR TITLE
Revert web worker registry name refactor to fix CSP build edge case

### DIFF
--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -36,7 +36,7 @@ class StructArrayLayout2i4 extends StructArray {
 }
 
 StructArrayLayout2i4.prototype.bytesPerElement = 4;
-register(StructArrayLayout2i4);
+register(StructArrayLayout2i4, 'StructArrayLayout2i4');
 
 /**
  * Implementation of the StructArray layout:
@@ -69,7 +69,7 @@ class StructArrayLayout3i6 extends StructArray {
 }
 
 StructArrayLayout3i6.prototype.bytesPerElement = 6;
-register(StructArrayLayout3i6);
+register(StructArrayLayout3i6, 'StructArrayLayout3i6');
 
 /**
  * Implementation of the StructArray layout:
@@ -103,7 +103,7 @@ class StructArrayLayout4i8 extends StructArray {
 }
 
 StructArrayLayout4i8.prototype.bytesPerElement = 8;
-register(StructArrayLayout4i8);
+register(StructArrayLayout4i8, 'StructArrayLayout4i8');
 
 /**
  * Implementation of the StructArray layout:
@@ -146,15 +146,15 @@ class StructArrayLayout2i4ub1f12 extends StructArray {
 }
 
 StructArrayLayout2i4ub1f12.prototype.bytesPerElement = 12;
-register(StructArrayLayout2i4ub1f12);
+register(StructArrayLayout2i4ub1f12, 'StructArrayLayout2i4ub1f12');
 
 /**
  * Implementation of the StructArray layout:
- * [0]: Float32[3]
+ * [0]: Float32[4]
  *
  * @private
  */
-class StructArrayLayout3f12 extends StructArray {
+class StructArrayLayout4f16 extends StructArray {
     uint8: Uint8Array;
     float32: Float32Array;
 
@@ -163,23 +163,24 @@ class StructArrayLayout3f12 extends StructArray {
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
-    emplaceBack(v0: number, v1: number, v2: number): number {
+    emplaceBack(v0: number, v1: number, v2: number, v3: number): number {
         const i = this.length;
         this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2);
+        return this.emplace(i, v0, v1, v2, v3);
     }
 
-    emplace(i: number, v0: number, v1: number, v2: number): number {
-        const o4 = i * 3;
+    emplace(i: number, v0: number, v1: number, v2: number, v3: number): number {
+        const o4 = i * 4;
         this.float32[o4 + 0] = v0;
         this.float32[o4 + 1] = v1;
         this.float32[o4 + 2] = v2;
+        this.float32[o4 + 3] = v3;
         return i;
     }
 }
 
-StructArrayLayout3f12.prototype.bytesPerElement = 12;
-register(StructArrayLayout3f12);
+StructArrayLayout4f16.prototype.bytesPerElement = 16;
+register(StructArrayLayout4f16, 'StructArrayLayout4f16');
 
 /**
  * Implementation of the StructArray layout:
@@ -219,7 +220,7 @@ class StructArrayLayout10ui20 extends StructArray {
 }
 
 StructArrayLayout10ui20.prototype.bytesPerElement = 20;
-register(StructArrayLayout10ui20);
+register(StructArrayLayout10ui20, 'StructArrayLayout10ui20');
 
 /**
  * Implementation of the StructArray layout:
@@ -257,7 +258,7 @@ class StructArrayLayout8ui16 extends StructArray {
 }
 
 StructArrayLayout8ui16.prototype.bytesPerElement = 16;
-register(StructArrayLayout8ui16);
+register(StructArrayLayout8ui16, 'StructArrayLayout8ui16');
 
 /**
  * Implementation of the StructArray layout:
@@ -293,7 +294,7 @@ class StructArrayLayout6i12 extends StructArray {
 }
 
 StructArrayLayout6i12.prototype.bytesPerElement = 12;
-register(StructArrayLayout6i12);
+register(StructArrayLayout6i12, 'StructArrayLayout6i12');
 
 /**
  * Implementation of the StructArray layout:
@@ -344,7 +345,40 @@ class StructArrayLayout4i4ui4i4i32 extends StructArray {
 }
 
 StructArrayLayout4i4ui4i4i32.prototype.bytesPerElement = 32;
-register(StructArrayLayout4i4ui4i4i32);
+register(StructArrayLayout4i4ui4i4i32, 'StructArrayLayout4i4ui4i4i32');
+
+/**
+ * Implementation of the StructArray layout:
+ * [0]: Float32[3]
+ *
+ * @private
+ */
+class StructArrayLayout3f12 extends StructArray {
+    uint8: Uint8Array;
+    float32: Float32Array;
+
+    _refreshViews() {
+        this.uint8 = new Uint8Array(this.arrayBuffer);
+        this.float32 = new Float32Array(this.arrayBuffer);
+    }
+
+    emplaceBack(v0: number, v1: number, v2: number): number {
+        const i = this.length;
+        this.resize(i + 1);
+        return this.emplace(i, v0, v1, v2);
+    }
+
+    emplace(i: number, v0: number, v1: number, v2: number): number {
+        const o4 = i * 3;
+        this.float32[o4 + 0] = v0;
+        this.float32[o4 + 1] = v1;
+        this.float32[o4 + 2] = v2;
+        return i;
+    }
+}
+
+StructArrayLayout3f12.prototype.bytesPerElement = 12;
+register(StructArrayLayout3f12, 'StructArrayLayout3f12');
 
 /**
  * Implementation of the StructArray layout:
@@ -375,7 +409,7 @@ class StructArrayLayout1ul4 extends StructArray {
 }
 
 StructArrayLayout1ul4.prototype.bytesPerElement = 4;
-register(StructArrayLayout1ul4);
+register(StructArrayLayout1ul4, 'StructArrayLayout1ul4');
 
 /**
  * Implementation of the StructArray layout:
@@ -429,7 +463,7 @@ class StructArrayLayout5i4f1i1ul2ui40 extends StructArray {
 }
 
 StructArrayLayout5i4f1i1ul2ui40.prototype.bytesPerElement = 40;
-register(StructArrayLayout5i4f1i1ul2ui40);
+register(StructArrayLayout5i4f1i1ul2ui40, 'StructArrayLayout5i4f1i1ul2ui40');
 
 /**
  * Implementation of the StructArray layout:
@@ -468,7 +502,7 @@ class StructArrayLayout3i2i2i16 extends StructArray {
 }
 
 StructArrayLayout3i2i2i16.prototype.bytesPerElement = 16;
-register(StructArrayLayout3i2i2i16);
+register(StructArrayLayout3i2i2i16, 'StructArrayLayout3i2i2i16');
 
 /**
  * Implementation of the StructArray layout:
@@ -508,7 +542,7 @@ class StructArrayLayout2f1f2i16 extends StructArray {
 }
 
 StructArrayLayout2f1f2i16.prototype.bytesPerElement = 16;
-register(StructArrayLayout2f1f2i16);
+register(StructArrayLayout2f1f2i16, 'StructArrayLayout2f1f2i16');
 
 /**
  * Implementation of the StructArray layout:
@@ -544,7 +578,7 @@ class StructArrayLayout2ub2f12 extends StructArray {
 }
 
 StructArrayLayout2ub2f12.prototype.bytesPerElement = 12;
-register(StructArrayLayout2ub2f12);
+register(StructArrayLayout2ub2f12, 'StructArrayLayout2ub2f12');
 
 /**
  * Implementation of the StructArray layout:
@@ -577,7 +611,7 @@ class StructArrayLayout3ui6 extends StructArray {
 }
 
 StructArrayLayout3ui6.prototype.bytesPerElement = 6;
-register(StructArrayLayout3ui6);
+register(StructArrayLayout3ui6, 'StructArrayLayout3ui6');
 
 /**
  * Implementation of the StructArray layout:
@@ -645,7 +679,7 @@ class StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60 extends StructArray {
 }
 
 StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60.prototype.bytesPerElement = 60;
-register(StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60);
+register(StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60, 'StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1ub60');
 
 /**
  * Implementation of the StructArray layout:
@@ -717,7 +751,7 @@ class StructArrayLayout3i2f6i15ui1ul3f76 extends StructArray {
 }
 
 StructArrayLayout3i2f6i15ui1ul3f76.prototype.bytesPerElement = 76;
-register(StructArrayLayout3i2f6i15ui1ul3f76);
+register(StructArrayLayout3i2f6i15ui1ul3f76, 'StructArrayLayout3i2f6i15ui1ul3f76');
 
 /**
  * Implementation of the StructArray layout:
@@ -748,7 +782,7 @@ class StructArrayLayout1f4 extends StructArray {
 }
 
 StructArrayLayout1f4.prototype.bytesPerElement = 4;
-register(StructArrayLayout1f4);
+register(StructArrayLayout1f4, 'StructArrayLayout1f4');
 
 /**
  * Implementation of the StructArray layout:
@@ -785,7 +819,7 @@ class StructArrayLayout7f28 extends StructArray {
 }
 
 StructArrayLayout7f28.prototype.bytesPerElement = 28;
-register(StructArrayLayout7f28);
+register(StructArrayLayout7f28, 'StructArrayLayout7f28');
 
 /**
  * Implementation of the StructArray layout:
@@ -820,7 +854,7 @@ class StructArrayLayout5f20 extends StructArray {
 }
 
 StructArrayLayout5f20.prototype.bytesPerElement = 20;
-register(StructArrayLayout5f20);
+register(StructArrayLayout5f20, 'StructArrayLayout5f20');
 
 /**
  * Implementation of the StructArray layout:
@@ -858,7 +892,7 @@ class StructArrayLayout1ul3ui12 extends StructArray {
 }
 
 StructArrayLayout1ul3ui12.prototype.bytesPerElement = 12;
-register(StructArrayLayout1ul3ui12);
+register(StructArrayLayout1ul3ui12, 'StructArrayLayout1ul3ui12');
 
 /**
  * Implementation of the StructArray layout:
@@ -890,7 +924,7 @@ class StructArrayLayout2ui4 extends StructArray {
 }
 
 StructArrayLayout2ui4.prototype.bytesPerElement = 4;
-register(StructArrayLayout2ui4);
+register(StructArrayLayout2ui4, 'StructArrayLayout2ui4');
 
 /**
  * Implementation of the StructArray layout:
@@ -921,7 +955,7 @@ class StructArrayLayout1ui2 extends StructArray {
 }
 
 StructArrayLayout1ui2.prototype.bytesPerElement = 2;
-register(StructArrayLayout1ui2);
+register(StructArrayLayout1ui2, 'StructArrayLayout1ui2');
 
 /**
  * Implementation of the StructArray layout:
@@ -953,41 +987,7 @@ class StructArrayLayout2f8 extends StructArray {
 }
 
 StructArrayLayout2f8.prototype.bytesPerElement = 8;
-register(StructArrayLayout2f8);
-
-/**
- * Implementation of the StructArray layout:
- * [0]: Float32[4]
- *
- * @private
- */
-class StructArrayLayout4f16 extends StructArray {
-    uint8: Uint8Array;
-    float32: Float32Array;
-
-    _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
-        this.float32 = new Float32Array(this.arrayBuffer);
-    }
-
-    emplaceBack(v0: number, v1: number, v2: number, v3: number): number {
-        const i = this.length;
-        this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2, v3);
-    }
-
-    emplace(i: number, v0: number, v1: number, v2: number, v3: number): number {
-        const o4 = i * 4;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.float32[o4 + 3] = v3;
-        return i;
-    }
-}
-
-StructArrayLayout4f16.prototype.bytesPerElement = 16;
-register(StructArrayLayout4f16);
+register(StructArrayLayout2f8, 'StructArrayLayout2f8');
 
 /**
  * Implementation of the StructArray layout:
@@ -1028,7 +1028,7 @@ class StructArrayLayout6i1f16 extends StructArray {
 }
 
 StructArrayLayout6i1f16.prototype.bytesPerElement = 16;
-register(StructArrayLayout6i1f16);
+register(StructArrayLayout6i1f16, 'StructArrayLayout6i1f16');
 
 class FillExtrusionExtStruct extends Struct {
     _structArray: FillExtrusionExtArray;
@@ -1059,7 +1059,7 @@ export class FillExtrusionExtArray extends StructArrayLayout6i12 {
     }
 }
 
-register(FillExtrusionExtArray);
+register(FillExtrusionExtArray, 'FillExtrusionExtArray');
 
 class CollisionBoxStruct extends Struct {
     _structArray: CollisionBoxArray;
@@ -1097,7 +1097,7 @@ export class CollisionBoxArray extends StructArrayLayout5i4f1i1ul2ui40 {
     }
 }
 
-register(CollisionBoxArray);
+register(CollisionBoxArray, 'CollisionBoxArray');
 
 class PlacedSymbolStruct extends Struct {
     _structArray: PlacedSymbolArray;
@@ -1147,7 +1147,7 @@ export class PlacedSymbolArray extends StructArrayLayout3i2f2ui3ul3ui2f3ub1ul1i1
     }
 }
 
-register(PlacedSymbolArray);
+register(PlacedSymbolArray, 'PlacedSymbolArray');
 
 class SymbolInstanceStruct extends Struct {
     _structArray: SymbolInstanceArray;
@@ -1203,7 +1203,7 @@ export class SymbolInstanceArray extends StructArrayLayout3i2f6i15ui1ul3f76 {
     }
 }
 
-register(SymbolInstanceArray);
+register(SymbolInstanceArray, 'SymbolInstanceArray');
 
 /**
  * @private
@@ -1212,7 +1212,7 @@ export class GlyphOffsetArray extends StructArrayLayout1f4 {
     getoffsetX(index: number): number { return this.float32[index * 1 + 0]; }
 }
 
-register(GlyphOffsetArray);
+register(GlyphOffsetArray, 'GlyphOffsetArray');
 
 /**
  * @private
@@ -1223,7 +1223,7 @@ export class SymbolLineVertexArray extends StructArrayLayout3i6 {
     gettileUnitDistanceFromAnchor(index: number): number { return this.int16[index * 3 + 2]; }
 }
 
-register(SymbolLineVertexArray);
+register(SymbolLineVertexArray, 'SymbolLineVertexArray');
 
 class FeatureIndexStruct extends Struct {
     _structArray: FeatureIndexArray;
@@ -1252,7 +1252,7 @@ export class FeatureIndexArray extends StructArrayLayout1ul3ui12 {
     }
 }
 
-register(FeatureIndexArray);
+register(FeatureIndexArray, 'FeatureIndexArray');
 
 class FillExtrusionCentroidStruct extends Struct {
     _structArray: FillExtrusionCentroidArray;
@@ -1279,7 +1279,7 @@ export class FillExtrusionCentroidArray extends StructArrayLayout2ui4 {
     }
 }
 
-register(FillExtrusionCentroidArray);
+register(FillExtrusionCentroidArray, 'FillExtrusionCentroidArray');
 
 class CircleGlobeExtStruct extends Struct {
     _structArray: CircleGlobeExtArray;
@@ -1311,18 +1311,19 @@ export class CircleGlobeExtArray extends StructArrayLayout6i1f16 {
     }
 }
 
-register(CircleGlobeExtArray);
+register(CircleGlobeExtArray, 'CircleGlobeExtArray');
 
 export {
     StructArrayLayout2i4,
     StructArrayLayout3i6,
     StructArrayLayout4i8,
     StructArrayLayout2i4ub1f12,
-    StructArrayLayout3f12,
+    StructArrayLayout4f16,
     StructArrayLayout10ui20,
     StructArrayLayout8ui16,
     StructArrayLayout6i12,
     StructArrayLayout4i4ui4i4i32,
+    StructArrayLayout3f12,
     StructArrayLayout1ul4,
     StructArrayLayout5i4f1i1ul2ui40,
     StructArrayLayout3i2i2i16,
@@ -1338,7 +1339,6 @@ export {
     StructArrayLayout2ui4,
     StructArrayLayout1ui2,
     StructArrayLayout2f8,
-    StructArrayLayout4f16,
     StructArrayLayout6i1f16,
     StructArrayLayout2i4 as PosArray,
     StructArrayLayout3i6 as PosGlobeExtArray,

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -242,6 +242,6 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
     }
 }
 
-register(CircleBucket, {omit: ['layers']});
+register(CircleBucket, 'CircleBucket', {omit: ['layers']});
 
 export default CircleBucket;

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -227,6 +227,6 @@ class FillBucket implements Bucket {
     }
 }
 
-register(FillBucket, {omit: ['layers', 'patternFeatures']});
+register(FillBucket, 'FillBucket', {omit: ['layers', 'patternFeatures']});
 
 export default FillBucket;

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -560,8 +560,8 @@ class FillExtrusionBucket implements Bucket {
     }
 }
 
-register(FillExtrusionBucket, {omit: ['layers', 'features']});
-register(PartMetadata);
+register(FillExtrusionBucket, 'FillExtrusionBucket', {omit: ['layers', 'features']});
+register(PartMetadata, 'PartMetadata');
 
 export default FillExtrusionBucket;
 

--- a/src/data/bucket/heatmap_bucket.js
+++ b/src/data/bucket/heatmap_bucket.js
@@ -12,6 +12,6 @@ class HeatmapBucket extends CircleBucket<HeatmapStyleLayer> {
     layers: Array<HeatmapStyleLayer>;
 }
 
-register(HeatmapBucket, {omit: ['layers']});
+register(HeatmapBucket, 'HeatmapBucket', {omit: ['layers']});
 
 export default HeatmapBucket;

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -659,6 +659,6 @@ class LineBucket implements Bucket {
     }
 }
 
-register(LineBucket, {omit: ['layers', 'patternFeatures']});
+register(LineBucket, 'LineBucket', {omit: ['layers', 'patternFeatures']});
 
 export default LineBucket;

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -234,7 +234,7 @@ export class SymbolBuffers {
     }
 }
 
-register(SymbolBuffers);
+register(SymbolBuffers, 'SymbolBuffers');
 
 class CollisionBuffers {
     layoutVertexArray: StructArray;
@@ -280,7 +280,7 @@ class CollisionBuffers {
     }
 }
 
-register(CollisionBuffers);
+register(CollisionBuffers, 'CollisionBuffers');
 
 /**
  * Unlike other buckets, which simply implement #addFeature with type-specific
@@ -1036,7 +1036,7 @@ class SymbolBucket implements Bucket {
     }
 }
 
-register(SymbolBucket, {
+register(SymbolBucket, 'SymbolBucket', {
     omit: ['layers', 'collisionBoxArray', 'features', 'compareText']
 });
 

--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -176,5 +176,5 @@ export default class DEMData {
     }
 }
 
-register(DEMData);
-register(DemMinMaxQuadTree, {omit: ['dem']});
+register(DEMData, 'DEMData');
+register(DemMinMaxQuadTree, 'DemMinMaxQuadTree', {omit: ['dem']});

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -311,7 +311,7 @@ class FeatureIndex {
     }
 }
 
-register(FeatureIndex, {omit: ['rawTileData', 'sourceLayerCoder']});
+register(FeatureIndex, 'FeatureIndex', {omit: ['rawTileData', 'sourceLayerCoder']});
 
 export default FeatureIndex;
 

--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -126,4 +126,4 @@ function swap(arr, i, j) {
     arr[j] = tmp;
 }
 
-register(FeaturePositionMap);
+register(FeaturePositionMap, 'FeaturePositionMap');

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -704,10 +704,10 @@ function layoutType(property, type, binderType) {
     return (layoutException && layoutException[binderType]) || defaultLayouts[type][binderType];
 }
 
-register(ConstantBinder);
-register(CrossFadedConstantBinder);
-register(SourceExpressionBinder);
-register(CrossFadedCompositeBinder);
-register(CompositeExpressionBinder);
-register(ProgramConfiguration, {omit: ['_buffers']});
-register(ProgramConfigurationSet);
+register(ConstantBinder, 'ConstantBinder');
+register(CrossFadedConstantBinder, 'CrossFadedConstantBinder');
+register(SourceExpressionBinder, 'SourceExpressionBinder');
+register(CrossFadedCompositeBinder, 'CrossFadedCompositeBinder');
+register(CompositeExpressionBinder, 'CompositeExpressionBinder');
+register(ProgramConfiguration, 'ProgramConfiguration', {omit: ['_buffers']});
+register(ProgramConfigurationSet, 'ProgramConfigurationSet');

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -72,5 +72,5 @@ class SegmentVector {
  */
 SegmentVector.MAX_VERTEX_ARRAY_LENGTH = Math.pow(2, 16) - 1;
 
-register(SegmentVector);
+register(SegmentVector, 'SegmentVector');
 export default SegmentVector;

--- a/src/render/glyph_atlas.js
+++ b/src/render/glyph_atlas.js
@@ -76,4 +76,4 @@ export default class GlyphAtlas {
     }
 }
 
-register(GlyphAtlas);
+register(GlyphAtlas, 'GlyphAtlas');

--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -143,5 +143,5 @@ export default class ImageAtlas {
 
 }
 
-register(ImagePosition);
-register(ImageAtlas);
+register(ImagePosition, 'ImagePosition');
+register(ImageAtlas, 'ImageAtlas');

--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -215,6 +215,6 @@ class LineAtlas {
     }
 }
 
-register(LineAtlas);
+register(LineAtlas, 'LineAtlas');
 
 export default LineAtlas;

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -191,5 +191,5 @@ function getQuadkey(z, x, y) {
     return quadkey;
 }
 
-register(CanonicalTileID);
-register(OverscaledTileID, {omit: ['projMatrix']});
+register(CanonicalTileID, 'CanonicalTileID');
+register(OverscaledTileID, 'OverscaledTileID', {omit: ['projMatrix']});

--- a/src/style/format_section_override.js
+++ b/src/style/format_section_override.js
@@ -54,4 +54,4 @@ export default class FormatSectionOverride<T> implements Expression {
     }
 }
 
-register(FormatSectionOverride, {omit: ['defaultValue']});
+register(FormatSectionOverride, 'FormatSectionOverride', {omit: ['defaultValue']});

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -765,8 +765,8 @@ export class Properties<Props: Object> {
     }
 }
 
-register(DataDrivenProperty);
-register(DataConstantProperty);
-register(CrossFadedDataDrivenProperty);
-register(CrossFadedProperty);
-register(ColorRampProperty);
+register(DataDrivenProperty, 'DataDrivenProperty');
+register(DataConstantProperty, 'DataConstantProperty');
+register(CrossFadedDataDrivenProperty, 'CrossFadedDataDrivenProperty');
+register(CrossFadedProperty, 'CrossFadedProperty');
+register(ColorRampProperty, 'ColorRampProperty');

--- a/src/symbol/anchor.js
+++ b/src/symbol/anchor.js
@@ -23,6 +23,6 @@ class Anchor extends Point {
     }
 }
 
-register(Anchor);
+register(Anchor, 'Anchor');
 
 export default Anchor;

--- a/src/symbol/opacity_state.js
+++ b/src/symbol/opacity_state.js
@@ -22,6 +22,6 @@ class OpacityState {
     }
 }
 
-register(OpacityState);
+register(OpacityState, 'OpacityState');
 
 export default OpacityState;

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -144,5 +144,5 @@ export class RGBAImage {
     }
 }
 
-register(AlphaImage);
-register(RGBAImage);
+register(AlphaImage, 'AlphaImage');
+register(RGBAImage, 'RGBAImage');

--- a/src/util/struct_array.js.ejs
+++ b/src/util/struct_array.js.ejs
@@ -94,4 +94,4 @@ if (useComponentGetters) {
 -%>
 }
 
-register(<%=StructArrayClass%>);
+register(<%=StructArrayClass%>, '<%=StructArrayClass%>');

--- a/src/util/struct_array_layout.js.ejs
+++ b/src/util/struct_array_layout.js.ejs
@@ -95,4 +95,4 @@ for (const member of members) {
 }
 
 <%=StructArrayLayoutClass%>.prototype.bytesPerElement = <%= size %>;
-register(<%=StructArrayLayoutClass%>);
+register(<%=StructArrayLayoutClass%>, '<%=StructArrayLayoutClass%>');

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -52,17 +52,20 @@ const registry: Registry = {};
  *
  * @private
  */
-export function register<T: any>(klass: Class<T>, options: RegisterOptions<T> = {}) {
-    const name = klass.name;
+export function register<T: any>(klass: Class<T>, name: string, options: RegisterOptions<T> = {}) {
     assert(name, 'Can\'t register a class without a name.');
     assert(!registry[name], `${name} is already registered.`);
+    (Object.defineProperty: any)(klass, '_classRegistryKey', {
+        value: name,
+        writeable: false
+    });
     registry[name] = {
         klass,
         omit: options.omit || []
     };
 }
 
-register(Object);
+register(Object, 'Object');
 
 type SerializedGrid = { buffer: ArrayBuffer };
 
@@ -80,21 +83,21 @@ type SerializedGrid = { buffer: ArrayBuffer };
 
 Object.defineProperty(Grid, 'name', {value: 'Grid'});
 
-register(Grid);
+register(Grid, 'Grid');
 
-register(Color);
-register(Error);
-register(AJAXError);
-register(ResolvedImage);
+register(Color, 'Color');
+register(Error, 'Error');
+register(AJAXError, 'AJAXError');
+register(ResolvedImage, 'ResolvedImage');
 
-register(StylePropertyFunction);
-register(StyleExpression, {omit: ['_evaluator']});
+register(StylePropertyFunction, 'StylePropertyFunction');
+register(StyleExpression, 'StyleExpression', {omit: ['_evaluator']});
 
-register(ZoomDependentExpression);
-register(ZoomConstantExpression);
-register(CompoundExpression, {omit: ['_evaluate']});
+register(ZoomDependentExpression, 'ZoomDependentExpression');
+register(ZoomConstantExpression, 'ZoomConstantExpression');
+register(CompoundExpression, 'CompoundExpression', {omit: ['_evaluate']});
 for (const name in expressions) {
-    if (!registry[expressions[name].name]) register(expressions[name]);
+    if (!registry[expressions[name]._classRegistryKey]) register(expressions[name], `Expression${name}`);
 }
 
 function isArrayBuffer(val: any): boolean {
@@ -167,10 +170,11 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
 
     if (typeof input === 'object') {
         const klass = (input.constructor: any);
-        const name = klass.name;
-        if (!registry[name]) {
+        const name = klass._classRegistryKey;
+        if (!name) {
             throw new Error(`can't serialize object of unregistered class ${name}`);
         }
+        assert(registry[name]);
 
         const properties: SerializedObject = klass.serialize ?
             // (Temporary workaround) allow a class to provide static

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -89,7 +89,6 @@ register(Color, 'Color');
 register(Error, 'Error');
 register(AJAXError, 'AJAXError');
 register(ResolvedImage, 'ResolvedImage');
-
 register(StylePropertyFunction, 'StylePropertyFunction');
 register(StyleExpression, 'StyleExpression', {omit: ['_evaluator']});
 
@@ -97,7 +96,7 @@ register(ZoomDependentExpression, 'ZoomDependentExpression');
 register(ZoomConstantExpression, 'ZoomConstantExpression');
 register(CompoundExpression, 'CompoundExpression', {omit: ['_evaluate']});
 for (const name in expressions) {
-    if (!registry[expressions[name]._classRegistryKey]) register(expressions[name], `Expression${name}`);
+    if (!registry[(expressions[name]: any)._classRegistryKey]) register(expressions[name], `Expression${name}`);
 }
 
 function isArrayBuffer(val: any): boolean {

--- a/test/unit/util/web_worker_transfer.test.js
+++ b/test/unit/util/web_worker_transfer.test.js
@@ -26,7 +26,7 @@ test('round trip', (t) => {
         }
     }
 
-    register(Foo, {omit: ['_cached']});
+    register(Foo, 'Foo', {omit: ['_cached']});
 
     const foo = new Foo(10);
     const transferables = [];
@@ -64,7 +64,7 @@ test('custom serialization', (t) => {
         }
     }
 
-    register(Bar);
+    register(Bar, 'Bar');
 
     const bar = new Bar('a');
     t.assert(!bar._deserialized);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5709,18 +5709,18 @@ gl-matrix@^3.4.3:
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.3.tgz#fc1191e8320009fd4d20e9339595c6041ddc22c9"
   integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
 
-gl@^4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/gl/-/gl-4.9.2.tgz#dd31cdaec7d3c4b6761648111e55531f86137821"
-  integrity sha512-lLYaicQxsRPxOnKWX9pIGmtKRuw0epvI089yl9uBvemYxR9xE01eRuXJgje1U0/06Df7bdOmmcW87IPOsu52Ow==
+gl@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/gl/-/gl-4.9.0.tgz#0695cb0c0a5a4f38aa67e92643a4f0c54dee795a"
+  integrity sha512-5Qz8fM4kO4xTo/Ofv80hq/iXEGNlMxOCSo1+9cvT9CX/j84tIFBsbFLXkBVFZiKulA3H2VPQGSs0qZIMwv3KEA==
   dependencies:
     bindings "^1.5.0"
     bit-twiddle "^1.0.2"
     glsl-tokenizer "^2.0.2"
-    nan "^2.15.0"
-    node-abi "^2.30.1"
-    node-gyp "^7.1.2"
-    prebuild-install "^5.3.6"
+    nan "^2.14.1"
+    node-abi "^2.18.0"
+    node-gyp "^7.1.0"
+    prebuild-install "^5.3.5"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -8158,7 +8158,7 @@ mustache@^3.0.0:
   resolved "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz"
   integrity sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==
 
-nan@^2.15.0:
+nan@^2.14.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
@@ -8221,7 +8221,7 @@ nise@^4.0.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-abi@^2.30.1:
+node-abi@^2.18.0:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
   integrity sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
@@ -8254,7 +8254,7 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-gyp@^7.1.2:
+node-gyp@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
   integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
@@ -9512,7 +9512,7 @@ potpack@^1.0.2:
   resolved "https://registry.yarnpkg.com/potpack/-/potpack-1.0.2.tgz#23b99e64eb74f5741ffe7656b5b5c4ddce8dfc14"
   integrity sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==
 
-prebuild-install@^5.3.6:
+prebuild-install@^5.3.5:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
   integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==


### PR DESCRIPTION
Fixes #11764 by essentially reverting #11511, because it turned out that the optimization had edge cases beyond our control (like the CSP build being re-minified on user end).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix an issue where CSP build was unusable after minification in a bundling setup.</changelog>`
