### PR TITLE
Adding image dimensions to `map.updateImage` error message and fixing incorrect example

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -89,6 +89,7 @@ function getPerspectiveTransform(w, h, x1, y1, x2, y2, x3, y3, x4, y4) {
  *
  * map.removeSource('some id');  // remove
  * @see [Example: Add an image](https://www.mapbox.com/mapbox-gl-js/example/image-on-a-map/)
+ * @see [Example: Animate a series of images](http://localhost:8080/mapbox-gl-js/example/animate-images/)
  */
 class ImageSource extends Evented implements Source {
     type: string;

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -89,7 +89,7 @@ function getPerspectiveTransform(w, h, x1, y1, x2, y2, x3, y3, x4, y4) {
  *
  * map.removeSource('some id');  // remove
  * @see [Example: Add an image](https://www.mapbox.com/mapbox-gl-js/example/image-on-a-map/)
- * @see [Example: Animate a series of images](http://localhost:8080/mapbox-gl-js/example/animate-images/)
+ * @see [Example: Animate a series of images](https://www.mapbox.com/mapbox-gl-js/example/animate-images/)
  */
 class ImageSource extends Evented implements Source {
     type: string;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2115,13 +2115,17 @@ class Map extends Camera {
      * or [`line-pattern`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-line-line-pattern).
      *
      * @param {string} id The ID of the image.
-     * @param {HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: (Uint8Array | Uint8ClampedArray)} | StyleImageInterface} image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
+     * @param {HTMLImageElement | ImageBitmap | ImageData | StyleImageInterface} image The image as an `HTMLImageElement`, [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData), [`ImageBitmap`](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap) or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.
      *
      * @example
-     * // If an image with the ID 'cat' already exists in the style's sprite,
-     * // replace that image with a new image, 'other-cat-icon.png'.
-     * if (map.hasImage('cat')) map.updateImage('cat', './other-cat-icon.png');
+    * // Load an image from an external URL.
+     * map.loadImage('http://placekitten.com/50/50', (error, image) => {
+     *     if (error) throw error;
+     *     // If an image with the ID 'cat' already exists in the style's sprite,
+     *     // replace that image with a new image, 'other-cat-icon.png'.
+     *     if (map.hasImage('cat')) map.updateImage('cat', image);
+     * });
      */
     updateImage(id: string,
         image: HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: Uint8Array | Uint8ClampedArray} | StyleImageInterface) {
@@ -2146,7 +2150,9 @@ class Map extends Camera {
 
         if (width !== existingImage.data.width || height !== existingImage.data.height) {
             this.fire(new ErrorEvent(new Error(
-                'The width and height of the updated image must be that same as the previous version of the image')));
+                `The width and height of the updated image (${width}, ${height})
+                must be that same as the previous version of the image
+                (${existingImage.data.width}, ${existingImage.data.height})`)));
             return;
         }
 


### PR DESCRIPTION
- It's challenging to fix this error without knowing the image dimensions, this error message will make resolving the problem easier.

- The example currently uses a string as the image argument, which throws an error when run (likely introduced by confusion with the unrelated function`ImageSource.updateImage`). I've updated it to correctly use `loadImage()` and verified that it runs.

- Other minor fixes:
  - `StyleImageInterface` is the same as ` {width: number, height: number, data: (Uint8Array | Uint8ClampedArray)}` so I've cut out the latter.
  - Added example to `ImageSource` docs