### PR TITLE
Adding unit test ensuring `mapboxgl.version` is valid regex

### DIFF
--- a/test/unit/mapbox-gl.js
+++ b/test/unit/mapbox-gl.js
@@ -4,11 +4,13 @@ import mapboxgl from '../../src/index.js';
 test('mapboxgl', (t) => {
     t.test('version', (t) => {
         t.ok(mapboxgl.version);
+        t.match(mapboxgl.version, /^2\.[0-9]+\.[0-9]+(-dev|-beta\.[1-9])?$/);
         t.end();
     });
 
     t.test('workerCount', (t) => {
         t.ok(typeof mapboxgl.workerCount === 'number');
+        t.same(mapboxgl.workerCount, 2); // Test that workerCount defaults to 2
         t.end();
     });
     t.end();


### PR DESCRIPTION
Adding a regex test to ensure version is valid, also expanding test for workerCount