### PR TITLE
Add boxzoomcancel unit tests

### DIFF
--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -38,6 +38,25 @@ test('BoxZoomHandler fires boxzoomstart and boxzoomend events at appropriate tim
     t.end();
 });
 
+test('BoxZoomHandler fires boxzoomcancel events at the appropriate time', (t) => {
+    const map = createMap(t);
+
+    const boxzoomcancel = t.spy();
+
+    map.on('boxzoomcancel', boxzoomcancel);
+
+    simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
+    map._renderTaskQueue.run();
+
+    simulate.mouseup(map.getCanvas(), {shiftKey: false, clientX: 0, clientY: 0});
+    map._renderTaskQueue.run();
+
+    t.equal(boxzoomcancel.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
 test('BoxZoomHandler avoids conflicts with DragPanHandler when disabled and reenabled (#2237)', (t) => {
     const map = createMap(t);
 
@@ -108,29 +127,35 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
     t.end();
 });
 
-test('BoxZoomHandler does not begin a box zoom on spurious mousemove events', (t) => {
+test('BoxZoomHandler does cancels box zoom on spurious mousemove events', (t) => {
     const map = createMap(t);
 
     const boxzoomstart = t.spy();
     const boxzoomend   = t.spy();
+    const boxzoomcancel = t.spy();
 
     map.on('boxzoomstart', boxzoomstart);
     map.on('boxzoomend',   boxzoomend);
+    map.on('boxzoomcancel', boxzoomcancel);
 
     simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
     map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);
+    t.equal(boxzoomcancel.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
     map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);
+    t.equal(boxzoomcancel.callCount, 0);
 
     simulate.mouseup(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
     map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);
+    t.equal(boxzoomcancel.callCount, 1);
+
 
     map.remove();
     t.end();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -47,10 +47,10 @@ test('BoxZoomHandler fires boxzoomcancel events at the appropriate time', (t) =>
 
     simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
     map._renderTaskQueue.run();
+    t.equal(boxzoomcancel.callCount, 0);
 
     simulate.mouseup(map.getCanvas(), {shiftKey: false, clientX: 0, clientY: 0});
     map._renderTaskQueue.run();
-
     t.equal(boxzoomcancel.callCount, 1);
 
     map.remove();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -127,7 +127,7 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
     t.end();
 });
 
-test('BoxZoomHandler cancels box zoom on spurious mousemove events', (t) => {
+test('BoxZoomHandler cancels a box zoom on spurious mousemove events', (t) => {
     const map = createMap(t);
 
     const boxzoomstart = t.spy();
@@ -155,7 +155,6 @@ test('BoxZoomHandler cancels box zoom on spurious mousemove events', (t) => {
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);
     t.equal(boxzoomcancel.callCount, 1);
-
 
     map.remove();
     t.end();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -127,7 +127,7 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
     t.end();
 });
 
-test('BoxZoomHandler does cancels box zoom on spurious mousemove events', (t) => {
+test('BoxZoomHandler cancels box zoom on spurious mousemove events', (t) => {
     const map = createMap(t);
 
     const boxzoomstart = t.spy();


### PR DESCRIPTION
During the globe view audit, it was noted that `boxzoomcancel` did not have any test in the gl-js repo. This PR adds a couple unit tests in test/unit/ui/handler/box_zoom.test.js for `boxzoomcancel`

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
