### PR TITLE
Prevent incorrect display of circles and heatmaps during globe-mercator transition

### DIFF
--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -70,7 +70,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
 
         const tile = sourceCache.getTile(coord);
         const bucket: ?CircleBucket<*> = (tile.getBucket(layer): any);
-        if (!bucket) continue;
+        if (!bucket || bucket.projection !== tr.projection.name) continue;
 
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const definesValues = circleDefinesValues(layer);

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -56,7 +56,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
 
             const tile = sourceCache.getTile(coord);
             const bucket: ?HeatmapBucket = (tile.getBucket(layer): any);
-            if (!bucket) continue;
+            if (!bucket || bucket.projection !== tr.projection.name) continue;
 
             const programConfiguration = bucket.programConfigurations.get(layer.id);
             const program = painter.useProgram('heatmap', programConfiguration, definesValues);


### PR DESCRIPTION
Small fix to https://github.com/mapbox/gl-js-team/issues/376 (refer https://github.com/mapbox/mapbox-gl-js/issues/11476#issuecomment-1034485083) which seems to be an overlook for these layers. This issue happens during the transition where the bucket projection may mismatch current runtime projection. We can skip rendering these buckets when that happens, with the trade-off of having them disappear for a few frames. The fix matches what happens with other non-drapeable layers, such as symbols and fill-extrusions.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
