### PR TITLE
include performance timelines with performance metrics

### DIFF
--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -19,7 +19,7 @@ export const plugins = ({minified, production, test, bench, keepClassNames}) => 
     json({
         exclude: 'src/style-spec/reference/v8.json'
     }),
-    production ? strip({
+    (production && !bench) ? strip({
         sourceMap: true,
         functions: ['PerformanceUtils.*', 'WorkerPerformanceUtils.*', 'Debug.*']
     }) : false,

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -21,7 +21,7 @@ export const plugins = ({minified, production, test, bench, keepClassNames}) => 
     }),
     (production && !bench) ? strip({
         sourceMap: true,
-        functions: ['PerformanceUtils.*', 'WorkerPerformanceUtils.*', 'Debug.*']
+        functions: ['PerformanceUtils.*', 'WorkerPerformanceUtils.*', 'Debug.*', 'performance.mark']
     }) : false,
     production || bench ? unassert() : false,
     test ? replace({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,8 +6,8 @@ import {fileURLToPath} from 'url';
 
 const {BUILD, MINIFY} = process.env;
 const minified = MINIFY === 'true';
-const production = BUILD === 'production';
 const bench = BUILD === 'bench';
+const production = BUILD === 'production' || bench;
 
 function buildType(build, minified) {
     switch (build) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+import {PerformanceUtils} from './util/performance.js';
+
 import assert from 'assert';
 import {supported} from '@mapbox/mapbox-gl-supported';
 
@@ -26,7 +28,6 @@ import WorkerPool from './util/worker_pool.js';
 import {prewarm, clearPrewarmedResources} from './util/global_worker_pool.js';
 import {clearTileCache} from './util/tile_request_cache.js';
 import {WorkerPerformanceUtils} from './util/worker_performance_utils.js';
-import {PerformanceUtils} from './util/performance.js';
 import {FreeCameraOptions} from './ui/free_camera.js';
 import browser from './util/browser.js';
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2927,6 +2927,8 @@ class Map extends Camera {
      * @private
      */
     _render(paintStartTimeStamp: number) {
+        const m = PerformanceUtils.beginMeasure('render');
+
         let gpuTimer;
         const extTimerQuery = this.painter.context.extTimerQuery;
         const frameStartTime = browser.now();
@@ -2934,8 +2936,6 @@ class Map extends Camera {
             gpuTimer = extTimerQuery.createQueryEXT();
             extTimerQuery.beginQueryEXT(extTimerQuery.TIME_ELAPSED_EXT, gpuTimer);
         }
-
-        const m = PerformanceUtils.beginMeasure('render');
 
         // A custom layer may have used the context asynchronously. Mark the state as dirty.
         this.painter.context.setDirty();
@@ -3051,7 +3051,7 @@ class Map extends Camera {
             this.style._releaseSymbolFadeTiles();
         }
 
-        if (this.listens('gpu-timing-frame')) {
+        if (gpuTimer) {
             const renderCPUTime = browser.now() - frameStartTime;
             extTimerQuery.endQueryEXT(extTimerQuery.TIME_ELAPSED_EXT, gpuTimer);
             setTimeout(() => {
@@ -3061,6 +3061,12 @@ class Map extends Camera {
                     cpuTime: renderCPUTime,
                     gpuTime: renderGPUTime
                 }));
+                performance.mark('frame-gpu', {
+                    startTime: frameStartTime,
+                    detail: {
+                        gpuTime: renderGPUTime
+                    }
+                });
             }, 50); // Wait 50ms to give time for all GPU calls to finish before querying
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3061,7 +3061,7 @@ class Map extends Camera {
                     cpuTime: renderCPUTime,
                     gpuTime: renderGPUTime
                 }));
-                performance.mark('frame-gpu', {
+                window.performance.mark('frame-gpu', {
                     startTime: frameStartTime,
                     detail: {
                         gpuTime: renderGPUTime

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -103,7 +103,7 @@ export const PerformanceUtils = {
 
     getWorkerPerformanceMetrics(): { timeOrigin: string, measures: Array<PerformanceEntry> } {
         const entries = performance.getEntries().map(entry => {
-            const result = JSON.parse(JSON.stringify(entry));
+            const result = entry.toJSON();
             if (entry.detail) {
                 Object.assign(result, {
                     detail: entry.detail

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -111,11 +111,11 @@ export const PerformanceUtils = {
             }
             return result;
         });
-        return JSON.parse(JSON.stringify({
+        return {
             scope: isWorker() ? 'Worker' : 'Window',
             timeOrigin: performance.timeOrigin,
             entries
-        }));
+        };
     }
 };
 

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -8,11 +8,9 @@ performance.mark('library-evaluate');
 import {isWorker} from '../util/util.js';
 import type {RequestParameters} from '../util/ajax.js';
 
-
 export type PerformanceMetrics = {
     loadTime: number,
     fullLoadTime: number,
-    fps: number,
     percentDroppedFrames: number,
     parseTile: number,
     parseTile1: number,
@@ -22,7 +20,8 @@ export type PerformanceMetrics = {
     workerEvaluateScript: number,
     workerIdle: number,
     workerIdlePercent: number,
-    placementTime: number
+    placementTime: number,
+    timelines: Array<Object>
 };
 
 export type PerformanceMark = {mark: string, name: string};
@@ -33,23 +32,8 @@ export const PerformanceMarkers = {
     fullLoad: 'fullLoad'
 };
 
-let lastFrameTime = null;
 let fullLoadFinished = false;
-let frameTimes = [];
 let placementTime = 0;
-const frameSequences = [frameTimes];
-let i = 0;
-
-// The max milliseconds we should spend to render a single frame.
-// This value may need to be tweaked. I chose 14 by increasing frame
-// times with busy work and measuring the number of dropped frames.
-// On a page with only a map, more frames started being dropped after
-// going above 14ms. We might want to lower this to leave more room
-// for other work.
-const CPU_FRAME_BUDGET = 14;
-
-const framerateTarget = 60;
-const frameTimeTarget = 1000 / framerateTarget;
 
 export const PerformanceUtils = {
     mark(marker: $Keys<typeof PerformanceMarkers>) {
@@ -63,7 +47,7 @@ export const PerformanceUtils = {
         performance.measure(name, begin, end);
     },
     beginMeasure(name: string): PerformanceMark {
-        const mark = name;// + i++;
+        const mark = name;
         performance.mark(mark);
         return {
             mark,
@@ -88,23 +72,8 @@ export const PerformanceUtils = {
                 isRenderFrame
             }
         });
-        const currTimestamp = timestamp;
-        if (lastFrameTime != null) {
-            const frameTime = currTimestamp - lastFrameTime;
-            frameTimes.push(frameTime);
-        }
-
-        if (isRenderFrame) {
-            lastFrameTime = currTimestamp;
-        } else {
-            lastFrameTime = null;
-            frameTimes = [];
-            frameSequences.push(frameTimes);
-        }
     },
     clearMetrics() {
-        lastFrameTime = null;
-        frameTimes = [];
         placementTime = 0;
         fullLoadFinished = false;
 
@@ -125,58 +94,6 @@ export const PerformanceUtils = {
         const measures = performance.getEntriesByType('measure');
         for (const measure of measures) {
             metrics[measure.name] = (metrics[measure.name] || 0) + measure.duration;
-        }
-
-        // We don't have a perfect way of measuring the actual number of dropped frames.
-        // The best way of determining when frames happen is the timestamp passed to
-        // requestAnimationFrame. In Chrome and Firefox the timestamps are generally
-        // multiples of 1000/60ms (+-2ms).
-        //
-        // The differences between the timestamps vary a lot more in Safari.
-        // It's not uncommon to see a 24ms difference followedd by a 8ms difference.
-        // I'm not sure, but I think these might not be dropped frames (due to multiple
-        // buffering?).
-        //
-        // For Safari, I think comparing the number of expected frames with the number of actual
-        // frames is a more accurate way of measuring dropped frames than comparing
-        // individual frame time differences to a target time. In Firefox and Chrome
-        // both approaches produce the same result most of the time.
-        let droppedFrames = 0;
-        let totalFrameTimeSum = 0;
-        let totalFrames = 0;
-        metrics.jank = 0;
-
-        for (const frameTimes of frameSequences) {
-            if (!frameTimes.length) continue;
-            const frameTimeSum = frameTimes.reduce((prev, curr) => prev + curr, 0);
-            const expectedFrames = Math.max(1, Math.round(frameTimeSum / frameTimeTarget));
-            droppedFrames += expectedFrames - frameTimes.length;
-            totalFrameTimeSum += frameTimeSum;
-            totalFrames += frameTimes.length;
-
-            // Jank is a change in the frame rate.
-            // Count the number of times a frame has a worse rate than the previous frame.
-            // A consistent rate does not increase jank even if it is continuosly dropping frames.
-            // A one-off frame does not increase jank even if it is really long.
-            //
-            // This is not that accurate in Safari because the differences between animation frame
-            // times is not as close to a multiple of 1000/60ms.
-            const roundedTimes = frameTimes.map(frameTime => Math.max(1, Math.round(frameTime / frameTimeTarget)));
-            for (let n = 0; n < roundedTimes.length - 1; n++) {
-                if (roundedTimes[n + 1] > roundedTimes[n]) {
-                    metrics.jank++;
-                }
-            }
-        }
-        const avgFrameTime = totalFrameTimeSum / totalFrames / 1000;
-        metrics.fps = 1 / avgFrameTime;
-        metrics.droppedFrames = droppedFrames;
-        metrics.percentDroppedFrames = (droppedFrames / (totalFrames + droppedFrames)) * 100;
-
-        metrics.cpuFrameBudgetExceeded = 0;
-        const renderFrames = performance.getEntriesByName('render');
-        for (const renderFrame of renderFrames) {
-            metrics.cpuFrameBudgetExceeded += Math.max(0, renderFrame.duration - CPU_FRAME_BUDGET);
         }
 
         metrics.placementTime = placementTime;

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -101,7 +101,7 @@ export const PerformanceUtils = {
         return metrics;
     },
 
-    getWorkerPerformanceMetrics(): { timeOrigin: string, measures: Array<PerformanceEntry> } {
+    getWorkerPerformanceMetrics(): { timeOrigin: string, entries: Array<Object>, scope: string } {
         const entries = performance.getEntries().map(entry => {
             const result = entry.toJSON();
             if (entry.detail) {

--- a/src/util/worker_performance_utils.js
+++ b/src/util/worker_performance_utils.js
@@ -25,7 +25,8 @@ export const WorkerPerformanceUtils = {
             const sums = {};
 
             for (const result of results) {
-                for (const measure of result.measures) {
+                const measures = result.entries.filter(e => e.entryType === 'measure');
+                for (const measure of measures) {
                     sums[measure.name] = (sums[measure.name] || 0) + measure.duration;
                 }
 
@@ -40,6 +41,8 @@ export const WorkerPerformanceUtils = {
             metrics.workerIdlePercent = metrics.workerIdle / metrics.loadTime;
 
             metrics.parseTile = metrics.parseTile1 + metrics.parseTile2;
+
+            metrics.timelines = [PerformanceUtils.getWorkerPerformanceMetrics()].concat(results);
 
             return callback(undefined, metrics);
         });

--- a/src/util/worker_performance_utils.js
+++ b/src/util/worker_performance_utils.js
@@ -25,8 +25,8 @@ export const WorkerPerformanceUtils = {
             const sums = {};
 
             for (const result of results) {
-                const measures = result.entries.filter(e => e.entryType === 'measure');
-                for (const measure of measures) {
+                for (const measure of result.entries) {
+                    if (measure.entryType !== 'measure') continue;
                     sums[measure.name] = (sums[measure.name] || 0) + measure.duration;
                 }
 
@@ -42,7 +42,7 @@ export const WorkerPerformanceUtils = {
 
             metrics.parseTile = metrics.parseTile1 + metrics.parseTile2;
 
-            metrics.timelines = [PerformanceUtils.getWorkerPerformanceMetrics()].concat(results);
+            metrics.timelines = [PerformanceUtils.getWorkerPerformanceMetrics(), ...results];
 
             return callback(undefined, metrics);
         });

--- a/test/browser/performance_metrics.test.js
+++ b/test/browser/performance_metrics.test.js
@@ -1,0 +1,40 @@
+import {test} from '../util/test.js';
+import browser from './util/browser.js';
+
+test("performance metrics", async t => {
+    const {driver} = browser;
+
+    await t.test("double click at the center", async t => {
+        const canvas = await browser.getMapCanvas(`${browser.basePath}/test/browser/fixtures/land.html`);
+
+        // Double-click on the center of the map.
+        await driver.executeScript(browser.doubleClick, canvas);
+
+        // Wait until the map has settled, then report the zoom level back.
+        const performance = await driver.executeAsyncScript(callback => {
+            /* eslint-disable no-undef */
+            map.once('idle', () => {
+                mapboxgl.getPerformanceMetricsAsync((_, result) => callback(result));
+            });
+        });
+
+        const timelines = performance.timelines;
+        t.equal(timelines.length, 3);
+        t.equal(timelines[0].scope, 'Window');
+        t.equal(timelines[1].scope, 'Worker');
+        t.equal(timelines[2].scope, 'Worker');
+
+        const find = name => timelines[0].entries.find(e => e.name === name);
+
+        t.ok(timelines[0].entries.every(e => {
+            return !isNaN(e.startTime) && !isNaN(e.duration);
+        }));
+
+        t.ok(find('library-evaluate'));
+        t.ok(find('frame'));
+        t.ok(find('create'));
+        t.ok(find('load'));
+        t.ok(find('fullLoad'));
+        t.equal(timelines[0].entries.filter(e => e.entryType === 'resource').length, 3);
+    });
+});


### PR DESCRIPTION
Changes the data returned by `mapboxgl.getPerformanceMetricsAsync(...)`. This method is not public, and is only available in the debug build.

The results now include a serialized version of the performance timeline. This includes timing for each individual frame, and data on each network request made. These can be used to calculate more detailed metrics. I also removed some of the rendering metrics from gl-js. They are now calculated elsewhere to keep them in sync across versions.

The mapbox-gl-bench.js build is now minified.

There is no public impact of this pr.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
