### PR TITLE
Resolve zoom on terrain with exaggeration 0

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -141,7 +141,7 @@ class Transform {
     _distanceTileDataCache: {[_: number]: FeatureDistanceData};
     _camera: FreeCamera;
     _centerAltitude: number;
-    _centerAltitudeValidForExaggeration: number;
+    _centerAltitudeValidForExaggeration: ?number;
     _horizonShift: number;
     _projectionScaler: number;
     _nearZ: number;
@@ -177,7 +177,6 @@ class Transform {
         this._distanceTileDataCache = {};
         this._camera = new FreeCamera();
         this._centerAltitude = 0;
-        this._centerAltitudeValidForExaggeration = 0;
         this._averageElevation = 0;
         this.cameraElevationReference = "ground";
         this._projectionScaler = 1.0;
@@ -396,7 +395,7 @@ class Transform {
             // Elevation data not loaded yet, reset
             this._centerAltitude = 0;
             this._seaLevelZoom = null;
-            this._centerAltitudeValidForExaggeration = 0;
+            this._centerAltitudeValidForExaggeration = undefined;
             return;
         }
         const elevation: Elevation = this._elevation;
@@ -406,7 +405,7 @@ class Transform {
     }
 
     _updateSeaLevelZoom() {
-        if (this._centerAltitudeValidForExaggeration === 0) {
+        if (this._centerAltitudeValidForExaggeration === undefined) {
             return;
         }
         const height = this.cameraToCenterDistance;

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -773,6 +773,14 @@ test('transform', (t) => {
         transform.updateElevation(false);
         t.equal(transform._centerAltitude, 150);
         t.equal(fixedNum(cameraAltitude()), 155);
+        transform.elevation._exaggeration = 0;
+        transform.updateElevation(false);
+        t.equal(fixedNum(cameraAltitude()), 5);
+        // zoom out to 10 meters and back to 5
+        transform.zoom = transform._zoomFromMercatorZ(altitudeZ * 2);
+        t.equal(fixedNum(cameraAltitude()), 10);
+        transform.zoom = zoom;
+        t.equal(fixedNum(cameraAltitude()), 5);
 
         transform.elevation = null;
         t.ok(cameraAltitude() < 10);
@@ -799,7 +807,7 @@ test('transform', (t) => {
 
         transform.elevation = createCollisionElevationNoData();
 
-        t.equal(transform._centerAltitudeValidForExaggeration, 0);
+        t.equal(transform._centerAltitudeValidForExaggeration, undefined);
 
         const transformBefore = transform.clone();
 
@@ -810,7 +818,7 @@ test('transform', (t) => {
         // Apply zoom
         transform.zoom = zoom;
 
-        t.equal(transform._centerAltitudeValidForExaggeration, 0);
+        t.equal(transform._centerAltitudeValidForExaggeration, undefined);
         t.equal(transform._seaLevelZoom, transformBefore._seaLevelZoom);
 
         t.end();


### PR DESCRIPTION
The regression is originally noticed in mobile SDK https://github.com/mapbox/mapbox-maps-ios/issues/1279, where the same approach is ported from https://github.com/mapbox/mapbox-gl-js/pull/11578.
It was incorrect to (mis)use exaggeration 0 with semantics of invalid exaggeration value. Using undefined instead.

Changelog:

<changelog>Resolve zoom on terrain when terrain exaggeration gets set to 0.</changelog>

Issue was also reproducible using fog.html debug page



https://user-images.githubusercontent.com/549216/165457126-4b23be23-d55d-431f-b922-5e739bf6c230.mov


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
