### PR TITLE
Fix edge cases for popup occlusion

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -649,11 +649,12 @@ export default class Popup extends Evented {
     }
 
     _setOpacity(opacity: number) {
+        if (this._container) {
+            this._container.style.opacity = `${opacity}`;
+        }
         if (this._content) {
-            this._content.style.opacity = `${opacity}`;
             this._content.style.pointerEvents = opacity ? 'auto' : 'none';
         }
-        if (this._tip)  this._tip.style.opacity = `${opacity}`;
     }
 }
 

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -563,17 +563,17 @@ test('Popup is positioned and occluded correctly on globe', (t) => {
         .addTo(map);
 
     t.same(popup._pos, map.project([45, 0]));
-    t.same(popup._content.style.opacity, 1);
+    t.same(popup._container.style.opacity, 1);
     t.same(popup._content.style.pointerEvents, 'auto');
 
     popup.setLngLat([270, 0]);
     t.same(popup._pos, map.project([270, 0]));
-    t.same(popup._content.style.opacity, 0);
+    t.same(popup._container.style.opacity, 0);
     t.same(popup._content.style.pointerEvents, 'none');
 
     popup.setLngLat([0, 45]);
     t.same(popup._pos, map.project([0, 45]));
-    t.same(popup._content.style.opacity, 1);
+    t.same(popup._container.style.opacity, 1);
     t.same(popup._content.style.pointerEvents, 'auto');
 
     t.end();


### PR DESCRIPTION
#11658 introduced occlusion for popups by changing transparency of the `_content` and `_tip` elements. In this PR I move the transparency change to the parent element. This ensures that additional elements or CSS psuedoelements added to the popup will be correctly occluded.

 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] manually test the debug page
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
