### PR TITLE
Update source URIs of query tests

### DIFF
--- a/test/integration/query-tests/globe/antimeridian/box-cross-from-left/style.json
+++ b/test/integration/query-tests/globe/antimeridian/box-cross-from-left/style.json
@@ -28,7 +28,7 @@
     },
     "places": {
       "type": "geojson",
-      "data": "/test/integration/data/places.geojson"
+      "data": "local://data/places.geojson"
     }
   },
   "layers": [

--- a/test/integration/query-tests/globe/antimeridian/box-cross-from-right/style.json
+++ b/test/integration/query-tests/globe/antimeridian/box-cross-from-right/style.json
@@ -28,7 +28,7 @@
     },
     "places": {
       "type": "geojson",
-      "data": "/test/integration/data/places.geojson"
+      "data": "local://data/places.geojson"
     }
   },
   "layers": [

--- a/test/integration/query-tests/globe/circle/opposite-side-over-north-pole/style.json
+++ b/test/integration/query-tests/globe/circle/opposite-side-over-north-pole/style.json
@@ -28,7 +28,7 @@
     },
     "places": {
       "type": "geojson",
-      "data": "/test/integration/data/places.geojson"
+      "data": "local://data/places.geojson"
     }
   },
   "layers": [


### PR DESCRIPTION
Fix ill-formed URIs used in some of the query tests added as part of https://github.com/mapbox/mapbox-gl-js/pull/11663. This is required for the tests to run in gl-native.