### PR TITLE
Do not create stars if star intensity is zero

### DIFF
--- a/src/shaders/atmosphere.fragment.glsl
+++ b/src/shaders/atmosphere.fragment.glsl
@@ -116,18 +116,20 @@ void main() {
     // Accumulate star field
     float star_field = 0.0;
 
-    // Create stars of various scales and offset to improve randomness
-    star_field += stars(D, 1.2, vec2(0.0, 0.0));
-    star_field += stars(D, 1.0, vec2(1.0, 0.0));
-    star_field += stars(D, 0.8, vec2(0.0, 1.0));
-    star_field += stars(D, 0.6, vec2(1.0, 1.0));
+    if (u_star_intensity > 0.0) {
+        // Create stars of various scales and offset to improve randomness
+        star_field += stars(D, 1.2, vec2(0.0, 0.0));
+        star_field += stars(D, 1.0, vec2(1.0, 0.0));
+        star_field += stars(D, 0.8, vec2(0.0, 1.0));
+        star_field += stars(D, 0.6, vec2(1.0, 1.0));
 
-    // Fade stars as they get closer to horizon to
-    // give the feeling of an atmosphere with thickness
-    star_field *= (1.0 - pow(t, 0.25 + (1.0 - u_high_color.a) * 0.75));
+        // Fade stars as they get closer to horizon to
+        // give the feeling of an atmosphere with thickness
+        star_field *= (1.0 - pow(t, 0.25 + (1.0 - u_high_color.a) * 0.75));
 
-    // Additive star field
-    c += star_field * alpha_2;
+        // Additive star field
+        c += star_field * alpha_2;
+    }
 
     // Dither
     c = dither(c, gl_FragCoord.xy + u_temporal_offset);


### PR DESCRIPTION
Some of the test runner bots on the gl-native CI seems to render stars even if `u_star_intensity` is set to zero. In these cases they are also rendered as rectangles. Returning earlier fixes the issue, however I'm not fully sure about the root cause, maybe it's a precision issue.

<img width="1107" alt="Screenshot 2022-04-29 at 16 44 02" src="https://user-images.githubusercontent.com/2576246/165957179-5f70f167-b057-45e7-897f-7213720486e2.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
