### PR TITLE
Use high precision atmosphere related shader operations

### DIFF
--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -45,14 +45,14 @@ float fog_opacity(float t) {
 }
 
 float globe_glow_progress() {
-    vec2 uv = gl_FragCoord.xy / u_viewport;
-    vec3 ray_dir = mix(
+    highp vec2 uv = gl_FragCoord.xy / u_viewport;
+    highp vec3 ray_dir = mix(
         mix(u_frustum_tl, u_frustum_tr, uv.x),
         mix(u_frustum_bl, u_frustum_br, uv.x),
         1.0 - uv.y);
-    vec3 dir = normalize(ray_dir);
-    vec3 closest_point = dot(u_globe_pos, dir) * dir;
-    float sdf = length(closest_point - u_globe_pos) / u_globe_radius;
+    highp vec3 dir = normalize(ray_dir);
+    highp vec3 closest_point = dot(u_globe_pos, dir) * dir;
+    highp float sdf = length(closest_point - u_globe_pos) / u_globe_radius;
     return sdf + PI * 0.5;
 }
 

--- a/src/shaders/atmosphere.fragment.glsl
+++ b/src/shaders/atmosphere.fragment.glsl
@@ -14,7 +14,7 @@ uniform mat4 u_rotation_matrix;
 varying highp vec3 v_ray_dir;
 varying highp vec3 v_horizon_dir;
 
-float random(vec3 p) {
+highp float random(highp vec3 p) {
     p = fract(p * vec3(23.2342, 97.1231, 91.2342));
     p += dot(p.zxy, p.yxz + 123.1234);
     return fract(p.x * p.y);
@@ -114,7 +114,7 @@ void main() {
     vec3 D = vec3(uv_remap, 1.0);
 
     // Accumulate star field
-    float star_field = 0.0;
+    highp float star_field = 0.0;
 
     if (u_star_intensity > 0.0) {
         // Create stars of various scales and offset to improve randomness


### PR DESCRIPTION
The high precision qualifiers are required to use the shaders on iOS with OpenGL, otherwise the globe was rendered blank and the star field was not scattered.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
