### PR TITLE
account for global padding in popup auto-anchoring

### DIFF
--- a/debug/popup.html
+++ b/debug/popup.html
@@ -25,6 +25,13 @@ var map = window.map = new mapboxgl.Map({
     style: 'mapbox://styles/mapbox/streets-v10',
     hash: true
 });
+map.showPadding = true;
+map.setPadding({
+    left: 10,
+    right: 20,
+    top: 30,
+    bottom: 40
+});
 
 var popup = new mapboxgl.Popup({closeButton: false, closeOnClick: false})
     .trackPointer()

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -555,10 +555,10 @@ export default class Popup extends Evented {
         const width = container.offsetWidth;
         const height = container.offsetHeight;
 
-        const isTop = pos.y + bottomY < height;
-        const isBottom = pos.y > map.transform.height - height;
-        const isLeft = pos.x < width / 2;
-        const isRight = pos.x > map.transform.width - width / 2;
+        const isTop = pos.y + bottomY < height + map.transform.padding.top;
+        const isBottom = pos.y > map.transform.height - height - map.transform.padding.bottom;
+        const isLeft = pos.x < width / 2 + map.transform.padding.left;
+        const isRight = pos.x > map.transform.width - width / 2 - map.transform.padding.right;
 
         if (isTop) {
             if (isLeft) return 'top-left';


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
Popup auto anchoring will now account for the map padding.

 - [x] include before/after visuals or gifs if this PR includes visual changes

before:
![2022-05-04_15-58](https://user-images.githubusercontent.com/117278/166629446-95cbc961-fd51-43f2-8497-8947210bcc37.png)

after:
![2022-05-04_15-57](https://user-images.githubusercontent.com/117278/166629450-a7c84618-3667-45ec-9fb9-2e714a4ea148.png)

 - [ ] write tests for all new functionality
 
TODO

 - [ ] document any changes to public APIs
 - [x] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
