### PR TITLE
Revert stencil mask skipping optimization

### DIFF
--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1153,7 +1153,7 @@ export class Terrain extends Elevation {
             // 1. overlap is handled by proxy render to texture tiles (there is no overlap there)
             // 2. here we handle only brief zoom out semi-transparent color intensity flickering
             //    and that is avoided fine by stenciling primitives as part of drawing (instead of additional tile quad step).
-            this._overlapStencilMode.ref = this.painter._tileClippingMaskIDs.get(id.key) || 0;
+            this._overlapStencilMode.ref = this.painter._tileClippingMaskIDs[id.key];
         } // else this._overlapStencilMode.ref is set to a single value used per proxy tile, in _setupStencil.
         return this._overlapStencilMode;
     }
@@ -1162,15 +1162,14 @@ export class Terrain extends Elevation {
         const painter = this.painter;
         const context = this.painter.context;
         const gl = context.gl;
-        painter._tileClippingMaskIDs.clear();
+        painter._tileClippingMaskIDs = {};
         context.setColorMode(ColorMode.disabled);
         context.setDepthMode(DepthMode.disabled);
 
         const program = painter.useProgram('clippingMask');
 
         for (const tileID of proxiedCoords) {
-            const id = --ref;
-            painter._tileClippingMaskIDs.set(tileID.key, id);
+            const id = painter._tileClippingMaskIDs[tileID.key] = --ref;
             program.draw(context, gl.TRIANGLES, DepthMode.disabled,
                 // Tests will always pass, and ref value will be written to stencil buffer.
                 new StencilMode({func: gl.ALWAYS, mask: 0}, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE),


### PR DESCRIPTION
Reverts: https://github.com/mapbox/mapbox-gl-js/pull/11542 and https://github.com/mapbox/mapbox-gl-js/pull/11546

Fixes an issue which was [originally reported in gl-native](https://github.com/mapbox/mapbox-gl-native-internal/issues/3374), however it was also reproducible in gl-js and seems to be caused by the optimization above.

The exact root cause of the issue is still not fully clear, but it seems to happen with styles that have a large amount of line layers. It appears the flickering happens when the 256 limit of the stencil IDs is reached, so most likely the stencils are not correctly rendered with the optimization after clearing.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes an issue which causes line layers to flicker occasionally</changelog>`
