### PR TITLE
Relax atmosphere check to slightly increase globe radius for 0 `horizon-blend` values

### DIFF
--- a/src/render/draw_atmosphere.js
+++ b/src/render/draw_atmosphere.js
@@ -44,12 +44,13 @@ function drawAtmosphere(painter: Painter, fog: Fog) {
     const starIntensity = mapValue(fog.properties.get('star-intensity'), 0.0, 1.0, 0.0, 0.25);
     // https://www.desmos.com/calculator/oanvvpr36d
     // Ensure horizon blend is 0-exclusive to prevent division by 0 in the shader
-    const horizonBlend = mapValue(fog.properties.get('horizon-blend'), 0.0, 1.0, 0.0005, 0.25);
+    const minHorizonBlend = 0.0005;
+    const horizonBlend = mapValue(fog.properties.get('horizon-blend'), 0.0, 1.0, minHorizonBlend, 0.25);
 
     // Use a slightly smaller size of the globe to account for custom
     // antialiasing that reduces the size of the globe of two pixels
     // https://www.desmos.com/calculator/xpgmzghc37
-    const globeRadius = globeUseCustomAntiAliasing(painter, context, tr) ?
+    const globeRadius = globeUseCustomAntiAliasing(painter, context, tr) && horizonBlend === minHorizonBlend ?
         tr.worldSize / (2.0 * Math.PI * 1.025) - 1.0 : tr.globeRadius;
 
     const temporalOffset = (painter.frameCounter / 1000.0) % 1;


### PR DESCRIPTION
In #11646 a check was added to very slightly increase the size of the globe when used with custom antialiasing. This prevents a harsh white line of a few pixels for `horizon-blend` with 0 value. This check needs to be relaxed and only be done when the value is actually the minimum `horizon-blend` value, it's currently incorrectly enabled for all the `horizon-blend` value.