### PR TITLE
Ensure unsupported APIs are no-op when used with globe projection

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -866,7 +866,7 @@ class Camera extends Evented {
      * Pans, rotates and zooms the map to to fit the box made by points p0 and p1
      * once the map is rotated to the specified bearing. To zoom without rotating,
      * pass in the current map bearing.
-     * This API isn't supported with globe projection.
+     * This function isn't supported with globe projection.
      *
      * @memberof Map#
      * @param {PointLike} p0 First point on screen, in pixel coordinates.

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -545,6 +545,7 @@ class Camera extends Evented {
      * Returns a {@link CameraOptions} object for the highest zoom level
      * up to and including `Map#getMaxZoom()` that fits the bounds
      * in the viewport at the specified bearing.
+     * This API isn't supported with globe projection.
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Calculate the center for these bounds in the viewport and use
@@ -564,6 +565,11 @@ class Camera extends Evented {
      * });
      */
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): ?EasingOptions {
+        if (this.transform.projection.name === 'globe') {
+            warnOnce('Globe projection does not support cameraForBounds API');
+            return;
+        }
+
         bounds = LngLatBounds.convert(bounds);
         const bearing = (options && options.bearing) || 0;
         return this._cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), bearing, options);
@@ -783,6 +789,7 @@ class Camera extends Evented {
      * Pans and zooms the map to contain its visible area within the specified geographical bounds.
      * This function will also reset the map's bearing to 0 if bearing is nonzero.
      * If a padding is set on the map, the bounds are fit to the inset.
+     * This API isn't supported with globe projection.
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
@@ -799,7 +806,7 @@ class Camera extends Evented {
      * @fires Map.event:movestart
      * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
-	 * @example
+     * @example
      * const bbox = [[-79, 43], [-73, 45]];
      * map.fitBounds(bbox, {
      *     padding: {top: 10, bottom:25, left: 15, right: 5}
@@ -807,6 +814,11 @@ class Camera extends Evented {
      * @see [Example: Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */
     fitBounds(bounds: LngLatBoundsLike, options?: EasingOptions, eventData?: Object): this {
+        if (this.transform.projection.name === 'globe') {
+            warnOnce('Globe projection does not support fitBounds API');
+            return this;
+        }
+
         return this._fitInternal(
             this.cameraForBounds(bounds, options),
             options,
@@ -854,6 +866,7 @@ class Camera extends Evented {
      * Pans, rotates and zooms the map to to fit the box made by points p0 and p1
      * once the map is rotated to the specified bearing. To zoom without rotating,
      * pass in the current map bearing.
+     * This API isn't supported with globe projection.
      *
      * @memberof Map#
      * @param {PointLike} p0 First point on screen, in pixel coordinates.
@@ -871,7 +884,7 @@ class Camera extends Evented {
      * @fires Map.event:movestart
      * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
-	 * @example
+     * @example
      * const p0 = [220, 400];
      * const p1 = [500, 900];
      * map.fitScreenCoordinates(p0, p1, map.getBearing(), {
@@ -880,6 +893,11 @@ class Camera extends Evented {
      * @see Used by {@link BoxZoomHandler}
      */
     fitScreenCoordinates(p0: PointLike, p1: PointLike, bearing: number, options?: EasingOptions, eventData?: Object): this {
+        if (this.transform.projection.name === 'globe') {
+            warnOnce('Globe projection does not support fitScreenCoordinates API');
+            return this;
+        }
+
         let lngLat0, lngLat1, minAltitude, maxAltitude;
         const point0 = Point.convert(p0);
         const point1 = Point.convert(p1);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -789,7 +789,7 @@ class Camera extends Evented {
      * Pans and zooms the map to contain its visible area within the specified geographical bounds.
      * This function will also reset the map's bearing to 0 if bearing is nonzero.
      * If a padding is set on the map, the bounds are fit to the inset.
-     * This API isn't supported with globe projection.
+     * This function isn't supported with globe projection.
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -545,7 +545,7 @@ class Camera extends Evented {
      * Returns a {@link CameraOptions} object for the highest zoom level
      * up to and including `Map#getMaxZoom()` that fits the bounds
      * in the viewport at the specified bearing.
-     * This API isn't supported with globe projection.
+     * This function isn't supported with globe projection.
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Calculate the center for these bounds in the viewport and use

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -789,12 +789,17 @@ class Map extends Camera {
      * Returns the map's geographical bounds. When the bearing or pitch is non-zero, the visible region is not
      * an axis-aligned rectangle, and the result is the smallest bounds that encompasses the visible region.
      * If a padding is set on the map, the bounds returned are for the inset.
+     * This API isn't supported with globe projection.
      *
      * @returns {LngLatBounds} The geographical bounds of the map as {@link LngLatBounds}.
      * @example
      * const bounds = map.getBounds();
      */
-    getBounds(): LngLatBounds {
+    getBounds(): LngLatBounds | null {
+        if (this.transform.projection.name === 'globe') {
+            warnOnce('Globe projection does not support getBounds API');
+            return null;
+        }
         return this.transform.getBounds();
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -789,7 +789,7 @@ class Map extends Camera {
      * Returns the map's geographical bounds. When the bearing or pitch is non-zero, the visible region is not
      * an axis-aligned rectangle, and the result is the smallest bounds that encompasses the visible region.
      * If a padding is set on the map, the bounds returned are for the inset.
-     * This API isn't supported with globe projection.
+     * This function isn't supported with globe projection.
      *
      * @returns {LngLatBounds} The geographical bounds of the map as {@link LngLatBounds}.
      * @example

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -22,7 +22,7 @@ test('camera', (t) => {
     function createCamera(options) {
         options = options || {};
 
-        const transform = new Transform(0, 20, 0, 85, options.renderWorldCopies);
+        const transform = new Transform(0, 20, 0, 85, options.renderWorldCopies, options.projection);
         transform.resize(512, 512);
 
         const camera = attachSimulateFrame(new Camera(transform, {}))
@@ -2028,6 +2028,17 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('no-op with globe', (t) => {
+            t.stub(console, 'warn');
+            const camera = createCamera({projection: {name: 'globe'}});
+            const bb = [[-133, 16], [-68, 50]];
+
+            const transform = camera.cameraForBounds(bb);
+            t.equal(transform, undefined);
+            t.ok(console.warn.calledOnce);
+            t.end();
+        });
+
         t.test('bearing positive number', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
@@ -2137,6 +2148,26 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('no-op with globe', (t) => {
+            t.stub(console, 'warn');
+            const camera = createCamera({projection: {name: 'globe'}});
+            const bb = [[-133, 16], [-68, 50]];
+
+            const prevBearing = camera.getBearing();
+            const prevPitch = camera.getPitch();
+            const prevZoom = camera.getZoom();
+            const prevCenter = camera.getCenter();
+
+            const this_ = camera.fitBounds(bb, {duration:0});
+            t.equal(this_, camera);
+            t.ok(console.warn.calledOnce);
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), prevCenter);
+            t.equal(fixedNum(camera.getZoom(), 3), prevZoom);
+            t.equal(camera.getBearing(), prevBearing);
+            t.equal(camera.getPitch(), prevPitch);
+            t.end();
+        });
+
         t.test('padding number', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
@@ -2196,6 +2227,29 @@ test('camera', (t) => {
             t.equal(fixedNum(camera.getZoom(), 3), 0.915); // 0.915 ~= log2(4*sqrt(2)/3)
             t.equal(camera.getBearing(), -135);
             t.equal(camera.getPitch(), 0);
+            t.end();
+        });
+
+        t.test('no-op with globe', (t) => {
+            t.stub(console, 'warn');
+            const camera = createCamera({projection: {name: 'globe'}});
+            const p0 = [128, 128];
+            const p1 = [256, 384];
+            const bearing = 225;
+
+            const prevBearing = camera.getBearing();
+            const prevPitch = camera.getPitch();
+            const prevZoom = camera.getZoom();
+            const prevCenter = camera.getCenter();
+
+            const this_ = camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
+
+            t.equal(this_, camera);
+            t.ok(console.warn.calledOnce);
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), prevCenter);
+            t.equal(fixedNum(camera.getZoom(), 3), prevZoom);
+            t.equal(camera.getBearing(), prevBearing);
+            t.equal(camera.getPitch(), prevPitch);
             t.end();
         });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1136,6 +1136,17 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('no-op with globe', (t) => {
+            t.stub(console, 'warn');
+            const map = createMap(t, {zoom: 0, skipCSSStub: true});
+            map.setProjection('globe');
+            const bounds = map.getBounds();
+
+            t.equal(bounds, null);
+            t.ok(console.warn.calledOnce);
+            t.end();
+        });
+
         t.test('padded bounds', (t) => {
             const map = createMap(t, {zoom: 1, bearing: 45, skipCSSStub: true});
 


### PR DESCRIPTION
Fix for https://github.com/mapbox/gl-js-team/issues/436, refer discussion from https://github.com/mapbox/mapbox-gl-js/issues/11795.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
