### PR TITLE
Fix to map-aligned markers on globe ignoring marker rotation

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -509,7 +509,7 @@ export default class Marker extends Evented {
                 const north = map.project(new LngLat(this._lngLat.lng, this._lngLat.lat + .001));
                 const south = map.project(new LngLat(this._lngLat.lng, this._lngLat.lat - .001));
                 const diff = south.sub(north);
-                return radToDeg(Math.atan2(diff.y, diff.x)) - 90;
+                return this._rotation + radToDeg(Math.atan2(diff.y, diff.x)) - 90;
             }
             return this._rotation - this._map.getBearing();
         }


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/14878684/168180124-bc30def1-cfce-40b8-ab5a-ba7a8edec123.mov


After:

https://user-images.githubusercontent.com/14878684/168179992-9444195c-d4b6-40cc-8d3a-60172a165a93.mov


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
