### PR TITLE
Fix line-trim-offset precision loss issue

### DIFF
--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -1,6 +1,6 @@
 uniform lowp float u_device_pixel_ratio;
 uniform float u_alpha_discard_threshold;
-uniform vec2 u_trim_offset;
+uniform highp vec2 u_trim_offset;
 
 varying vec2 v_width2;
 varying vec2 v_normal;
@@ -55,14 +55,14 @@ void main() {
 #ifdef RENDER_LINE_GRADIENT
     // For gradient lines, v_uv.xy are the coord specify where the texture will be simpled.
     // v_uv[2] and v_uv[3] are specifying the original clip range that the vertex is located in.
-    vec4 out_color = texture2D(u_gradient_image, v_uv.xy);
-    float start = v_uv[2];
-    float end = v_uv[3];
-    float trim_start = u_trim_offset[0];
-    float trim_end = u_trim_offset[1];
+    highp vec4 out_color = texture2D(u_gradient_image, v_uv.xy);
+    highp float start = v_uv[2];
+    highp float end = v_uv[3];
+    highp float trim_start = u_trim_offset[0];
+    highp float trim_end = u_trim_offset[1];
     // v_uv.x is the relative prorgress based on each clip. Calculate the absolute progress based on
     // the whole line by combining the clip start and end value.
-    float line_progress = (start + (v_uv.x) * (end - start));
+    highp float line_progress = (start + (v_uv.x) * (end - start));
     // Mark the pixel to be transparent when:
     // 1. trim_offset range is valid
     // 2. line_progress is within trim_offset range

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -12,7 +12,7 @@ attribute vec4 a_data;
 #ifdef RENDER_LINE_GRADIENT
 // Includes in order: a_uv_x, a_split_index, a_clip_start, a_clip_end
 // to reduce attribute count on older devices
-attribute vec4 a_packed;
+attribute highp vec4 a_packed;
 #endif
 
 #ifdef RENDER_LINE_DASH
@@ -112,8 +112,8 @@ void main() {
 #ifdef RENDER_LINE_GRADIENT
     float a_uv_x = a_packed[0];
     float a_split_index = a_packed[1];
-    float a_clip_start = a_packed[2];
-    float a_clip_end = a_packed[3];
+    highp float a_clip_start = a_packed[2];
+    highp float a_clip_end = a_packed[3];
     highp float texel_height = 1.0 / u_image_height;
     highp float half_texel_height = 0.5 * texel_height;
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a bug that `line-trim-offset` input may lose precision via shader calculation.</changelog>`
