### PR TITLE
Add minimum/maximum definitions for center/parallels

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4118,6 +4118,8 @@
       "length": 2,
       "value": "number",
       "property-type": "data-constant",
+      "minimum": [-180, -90],
+      "maximum": [180, 90],
       "transition": false,
       "doc": "The reference longitude and latitude of the projection. `center` takes the form of [lng, lat]. This property is only configurable for conic projections (Albers and Lambert Conformal Conic). All other projections are centered on [0, 0].",
       "example": [
@@ -4143,6 +4145,8 @@
       "length": 2,
       "value": "number",
       "property-type": "data-constant",
+      "minimum": [-90, -90],
+      "maximum": [90, 90],
       "transition": false,
       "doc":  "The standard parallels of the projection, denoting the desired latitude range with minimal distortion. `parallels` takes the form of [lat0, lat1]. This property is only configurable for conic projections (Albers and Lambert Conformal Conic).",
       "example": [


### PR DESCRIPTION
Updates the style spec to include `minimum` & `maximum` definitions for projection `center` & `parallels`.
