### PR TITLE
Modify sprite can't be written in relative path("sprite": "css/sprite").

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -103,11 +103,10 @@ export class RequestManager {
     }
 
     normalizeSpriteURL(url: string, format: string, extension: string, accessToken?: string): string {
-        const urlObject = parseUrl(url);
         if (!isMapboxURL(url)) {
-            urlObject.path += `${format}${extension}`;
-            return formatUrl(urlObject);
+            return `${url}${format}${extension}`;
         }
+        const urlObject = parseUrl(url);
         urlObject.path = `/styles/v1${urlObject.path}/sprite${format}${extension}`;
         return this._makeAPIURL(urlObject, this._customAccessToken || accessToken);
     }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`


Modify sprite can't be written in relative path("sprite": "css/sprite") (#884).