### PR TITLE
Fix sprite can't be written in relative path("sprite": "css/sprite").

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -103,10 +103,14 @@ export class RequestManager {
     }
 
     normalizeSpriteURL(url: string, format: string, extension: string, accessToken?: string): string {
-        const urlObject = parseUrl(url);
+        const urlObject = parseUrl2(url);
         if (!isMapboxURL(url)) {
-            urlObject.path += `${format}${extension}`;
-            return formatUrl(urlObject);
+            if (urlObject.protocol === undefined) {
+                return `${url}${format}${extension}`;
+            } else {
+                urlObject.path += `${format}${extension}`;
+                return formatUrl(urlObject);
+            }
         }
         urlObject.path = `/styles/v1${urlObject.path}/sprite${format}${extension}`;
         return this._makeAPIURL(urlObject, this._customAccessToken || accessToken);
@@ -254,6 +258,21 @@ function parseUrl(url: string): UrlObject {
         authority: parts[2],
         path: parts[3] || '/',
         params: parts[4] ? parts[4].split('&') : []
+    };
+}
+
+const urlRe2 = /^((\w+):\/\/)?([^/?]*)(\/[^?]+)?\??(.+)?/;
+
+function parseUrl2(url: string): UrlObject {
+    const parts = url.match(urlRe2);
+    if (!parts) {
+        throw new Error('Unable to parse URL object');
+    }
+    return {
+        protocol: parts[2],
+        authority: parts[3],
+        path: parts[4] || '/',
+        params: parts[5] ? parts[5].split('&') : []
     };
 }
 


### PR DESCRIPTION

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

Briefly describe:
Fix sprite can't be written in relative path("sprite": "css/sprite") (#884).

Changelog: 
<changelog>
### Bug fixes 🐞
Fix sprite can't be written in relative path("sprite": "css/sprite") (#884).
</changelog>
