### PR TITLE
Fix potential flickering on image source updates

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -136,8 +136,8 @@ class ImageSource extends Evented implements Source {
         this.options = options;
     }
 
-    load(newCoordinates?: Coordinates) {
-        this._loaded = false;
+    load(newCoordinates?: Coordinates, loaded?: boolean) {
+        this._loaded = loaded || false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
 
         this.url = this.options.url;
@@ -206,7 +206,7 @@ class ImageSource extends Evented implements Source {
             return this;
         }
         this.options.url = options.url;
-        this.load(options.coordinates);
+        this.load(options.coordinates, this._loaded);
         return this;
     }
 

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -163,5 +163,23 @@ test('ImageSource', (t) => {
         t.end();
     });
 
+    t.test('reloading image retains loaded status', (t) => {
+        const source = createSource({url : '/image.png'});
+        const map = new StubMap();
+        const coordinates = [[0, 0], [-1, 0], [-1, -1], [0, -1]];
+        source.onAdd(map);
+        t.ok(!source.loaded());
+        respond();
+        t.ok(source.loaded());
+        source.updateImage({url: '/image2.png', coordinates});
+        respond();
+        t.ok(source.loaded());
+        source.updateImage({url: '/image.png', coordinates});
+        respond();
+        t.ok(source.loaded());
+        source.updateImage({url: '/image2.png', coordinates});
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Fix image source flickering on image updates by retaining the `_loaded` status. When updating image sources, we may introduce an issue where tiles are marked as unloaded, which leads to tiles not rendering when they still have data to render. By retaining their loaded status, we allow these tiles to keep rendering until the new image is loaded. This issue is particularly visible on globe when draping is enabled.

Fixes #11776 

https://user-images.githubusercontent.com/7061573/170041507-9719ff27-91ca-4aaa-9c64-76e63e2d3e0e.mov

https://user-images.githubusercontent.com/7061573/170041843-6c579213-d789-4aee-97be-79a1b1e88191.mov

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix potential flickering on on image source updates</changelog>`
