### PR TITLE
Skip redundant call to `map._updateProjection` on style change

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -662,8 +662,8 @@ class Style extends Evented {
         }
 
         changes.forEach((op) => {
-            if (op.command === 'setTransition') {
-                // `transition` is always read directly off of
+            if (op.command === 'setTransition' || op.command === 'setProjection') {
+                // `transition` and `projection` are always read directly from
                 // `this.stylesheet`, which we update below
                 return;
             }


### PR DESCRIPTION
Previously made to fix https://github.com/mapbox/mapbox-gl-js/issues/11916, this change still removes an unnecessary function call.

Currently , projection updates are triggered twice within `style.setState`. First, this loop calls `setProjection`:
```js
changes.forEach((op) => {
   ...
    (this: any)[op.command].apply(this, op.args);
});
```
And immediately after:
```js
this.stylesheet = nextState;
this._updateMapProjection();
 ```

Since projections are read directly from the style sheet, the latter projection update needs to happen after the style sheet update. The first call serves no purpose, so here I remove it.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
