### PR TITLE
Clone stylesheet to allow toggling different styles with `setStyle`

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1500,7 +1500,7 @@ class Style extends Evented {
 
             for (const name of Object.keys(styleSpec.terrain)) {
                 // Fallback to use default style specification when the properties wasn't set
-                if (!terrainOptions.hasOwnProperty(name) && styleSpec.terrain[name].default) {
+                if (!terrainOptions.hasOwnProperty(name) && !!styleSpec.terrain[name].default) {
                     terrainOptions[name] = styleSpec.terrain[name].default;
                 }
             }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1441,7 +1441,7 @@ class Style extends Evented {
         }
         if (!_update) return;
 
-        const parameters = this._setTransitionParameters({duration: 0, delay: 300});
+        const parameters = this._setTransitionParameters({duration: 300, delay: 0});
 
         this.light.setLight(lightOptions, options);
         this.light.updateTransitions(parameters);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1499,7 +1499,15 @@ class Style extends Evented {
                     terrainOptions[name] = styleSpec.terrain[name].default;
                 }
             }
-            this._updateStyleSpec('terrain', terrainOptions, currSpec);
+            for (const key in terrainOptions) {
+                if (!deepEqual(terrainOptions[key], currSpec[key])) {
+                    terrain.set(terrainOptions);
+                    this.stylesheet.terrain = terrainOptions;
+                    const parameters = this._setTransitionParameters({duration: 0});
+                    terrain.updateTransitions(parameters);
+                    break;
+                }
+            }
         }
 
         this._updateDrapeFirstLayers();
@@ -1546,7 +1554,15 @@ class Style extends Evented {
             // Updating fog
             const fog = this.fog;
             const currSpec = fog.get();
-            this._updateStyleSpec('fog', fogOptions, currSpec);
+            for (const key in fogOptions) {
+                if (!deepEqual(fogOptions[key], currSpec[key])) {
+                    fog.set(fogOptions, currSpec);
+                    this.stylesheet.fog = fogOptions;
+                    const parameters = this._setTransitionParameters({duration: 0});
+                    fog.updateTransitions(parameters);
+                    break;
+                }
+            }
         }
 
         this._markersNeedUpdate = true;
@@ -1559,17 +1575,6 @@ class Style extends Evented {
                 transitionOptions,
                 this.stylesheet.transition)
         };
-    }
-
-    _updateStyleSpec(property: Object, newSpec: Object, currSpec: Object) {
-        for (const name in newSpec) {
-            if (!deepEqual(newSpec[name], currSpec[name])) {
-                property.set(newSpec, currSpec);
-                this.stylesheet[property] = newSpec;
-                const parameters = this._setTransitionParameters({duration: 0});
-                property.updateTransitions(parameters);
-            }
-        }
     }
 
     _updateDrapeFirstLayers() {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -309,7 +309,7 @@ class Style extends Evented {
         }
 
         this._loaded = true;
-        this.stylesheet = json;
+        this.stylesheet = extend({}, json);
         this._updateMapProjection();
 
         for (const id in json.sources) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -309,7 +309,7 @@ class Style extends Evented {
         }
 
         this._loaded = true;
-        this.stylesheet = extend({}, json);
+        this.stylesheet = clone(json);
         this._updateMapProjection();
 
         for (const id in json.sources) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -86,6 +86,7 @@ import type {QueryFeature} from '../util/vectortile_to_geojson.js';
 import type {FeatureStates} from '../source/source_state.js';
 import type {PointLike} from '@mapbox/point-geometry';
 import type {Source} from '../source/source.js';
+import type {TransitionParameters} from './properties.js';
 
 const supportedDiffOperations = pick(diffOperations, [
     'addLayer',
@@ -1440,7 +1441,7 @@ class Style extends Evented {
         }
         if (!_update) return;
 
-        const parameters = this._setTransitionParameters(300);
+        const parameters = this._setTransitionParameters({duration: 0, delay: 300});
 
         this.light.setLight(lightOptions, options);
         this.light.updateTransitions(parameters);
@@ -1503,7 +1504,7 @@ class Style extends Evented {
                 if (!deepEqual(terrainOptions[key], currSpec[key])) {
                     terrain.set(terrainOptions);
                     this.stylesheet.terrain = terrainOptions;
-                    const parameters = this._setTransitionParameters();
+                    const parameters = this._setTransitionParameters({duration: 0});
                     terrain.updateTransitions(parameters);
                     break;
                 }
@@ -1517,7 +1518,7 @@ class Style extends Evented {
     _createFog(fogOptions: FogSpecification) {
         const fog = this.fog = new Fog(fogOptions, this.map.transform);
         this.stylesheet.fog = fogOptions;
-        const parameters = this._setTransitionParameters();
+        const parameters = this._setTransitionParameters({duration: 0});
         fog.updateTransitions(parameters);
     }
 
@@ -1554,12 +1555,12 @@ class Style extends Evented {
             // Updating fog
             const fog = this.fog;
             const currSpec = fog.get();
+
             for (const key in fogOptions) {
                 if (!deepEqual(fogOptions[key], currSpec[key])) {
                     fog.set(fogOptions, currSpec);
                     this.stylesheet.fog = fogOptions;
-                    const parameters = this._setTransitionParameters();
-
+                    const parameters = this._setTransitionParameters({duration: 0});
                     fog.updateTransitions(parameters);
                     break;
                 }
@@ -1591,17 +1592,16 @@ class Style extends Evented {
         this.stylesheet.terrain = terrainOptions;
         this.dispatcher.broadcast('enableTerrain', !this.terrainSetForDrapingOnly());
         this._force3DLayerUpdate();
-        const parameters = this._setTransitionParameters();
+        const parameters = this._setTransitionParameters({duration: 0});
         terrain.updateTransitions(parameters);
     }
 
-    _setTransitionParameters(duration: number = 0, delay: number = 0) {
+    _setTransitionParameters(transitionOptions: Object): TransitionParameters {
         return {
             now: browser.now(),
-            transition: extend({
-                duration,
-                delay
-            }, this.stylesheet.transition)
+            transition: extend(
+                transitionOptions,
+                this.stylesheet.transition)
         };
     }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1499,7 +1499,9 @@ class Style extends Evented {
             const currSpec = terrain.get();
 
             // Add in terrain default values if it was not set in style
-            if (!terrainOptions.hasOwnProperty('exaggeration')) terrainOptions.exaggeration = 1;
+            if (!terrainOptions.hasOwnProperty('exaggeration') && !!currSpec.hasOwnProperty('exaggeration')) {
+                terrainOptions.exaggeration = 1;
+            }
 
             for (const key in terrainOptions) {
                 if (!deepEqual(terrainOptions[key], currSpec[key])) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1498,8 +1498,12 @@ class Style extends Evented {
             const terrain = this.terrain;
             const currSpec = terrain.get();
 
-            // Add in terrain default values if it was not set in style
-            if (!terrainOptions.hasOwnProperty('exaggeration')) terrainOptions.exaggeration = 1;
+            for (const name of Object.keys(styleSpec.terrain)) {
+                // Fallback to use default style specification when the properties wasn't set
+                if (terrainOptions && !terrainOptions[name] && styleSpec.terrain[name].default) {
+                    terrainOptions[name] = styleSpec.terrain[name].default;
+                }
+            }
 
             for (const key in terrainOptions) {
                 if (!deepEqual(terrainOptions[key], currSpec[key])) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1499,16 +1499,7 @@ class Style extends Evented {
                     terrainOptions[name] = styleSpec.terrain[name].default;
                 }
             }
-
-            for (const key in terrainOptions) {
-                if (!deepEqual(terrainOptions[key], currSpec[key])) {
-                    terrain.set(terrainOptions);
-                    this.stylesheet.terrain = terrainOptions;
-                    const parameters = this._setTransitionParameters({duration: 0});
-                    terrain.updateTransitions(parameters);
-                    break;
-                }
-            }
+            this._updateStyleSpec('terrain', terrainOptions, currSpec);
         }
 
         this._updateDrapeFirstLayers();
@@ -1555,19 +1546,30 @@ class Style extends Evented {
             // Updating fog
             const fog = this.fog;
             const currSpec = fog.get();
-
-            for (const key in fogOptions) {
-                if (!deepEqual(fogOptions[key], currSpec[key])) {
-                    fog.set(fogOptions, currSpec);
-                    this.stylesheet.fog = fogOptions;
-                    const parameters = this._setTransitionParameters({duration: 0});
-                    fog.updateTransitions(parameters);
-                    break;
-                }
-            }
+            this._updateStyleSpec('fog', fogOptions, currSpec);
         }
 
         this._markersNeedUpdate = true;
+    }
+
+    _setTransitionParameters(transitionOptions: Object): TransitionParameters {
+        return {
+            now: browser.now(),
+            transition: extend(
+                transitionOptions,
+                this.stylesheet.transition)
+        };
+    }
+
+    _updateStyleSpec(property: Object, newSpec: Object, currSpec: Object) {
+        for (const name in newSpec) {
+            if (!deepEqual(newSpec[name], currSpec[name])) {
+                property.set(newSpec, currSpec);
+                this.stylesheet[property] = newSpec;
+                const parameters = this._setTransitionParameters({duration: 0});
+                property.updateTransitions(parameters);
+            }
+        }
     }
 
     _updateDrapeFirstLayers() {
@@ -1594,15 +1596,6 @@ class Style extends Evented {
         this._force3DLayerUpdate();
         const parameters = this._setTransitionParameters({duration: 0});
         terrain.updateTransitions(parameters);
-    }
-
-    _setTransitionParameters(transitionOptions: Object): TransitionParameters {
-        return {
-            now: browser.now(),
-            transition: extend(
-                transitionOptions,
-                this.stylesheet.transition)
-        };
     }
 
     _force3DLayerUpdate() {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1499,9 +1499,7 @@ class Style extends Evented {
             const currSpec = terrain.get();
 
             // Add in terrain default values if it was not set in style
-            if (!terrainOptions.hasOwnProperty('exaggeration') && currSpec.hasOwnProperty('exaggeration')) {
-                terrainOptions.exaggeration = 1;
-            }
+            if (!terrainOptions.hasOwnProperty('exaggeration')) terrainOptions.exaggeration = 1;
 
             for (const key in terrainOptions) {
                 if (!deepEqual(terrainOptions[key], currSpec[key])) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1500,7 +1500,7 @@ class Style extends Evented {
 
             for (const name of Object.keys(styleSpec.terrain)) {
                 // Fallback to use default style specification when the properties wasn't set
-                if (terrainOptions && !terrainOptions[name] && styleSpec.terrain[name].default) {
+                if (!terrainOptions.hasOwnProperty(name) && styleSpec.terrain[name].default) {
                     terrainOptions[name] = styleSpec.terrain[name].default;
                 }
             }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1497,6 +1497,10 @@ class Style extends Evented {
         } else { // Updating
             const terrain = this.terrain;
             const currSpec = terrain.get();
+
+            // Add in terrain default values if it was not set in style
+            if (!terrainOptions.hasOwnProperty('exaggeration')) terrainOptions.exaggeration = 1;
+
             for (const key in terrainOptions) {
                 if (!deepEqual(terrainOptions[key], currSpec[key])) {
                     terrain.set(terrainOptions);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1440,13 +1440,7 @@ class Style extends Evented {
         }
         if (!_update) return;
 
-        const parameters = {
-            now: browser.now(),
-            transition: extend({
-                duration: 300,
-                delay: 0
-            }, this.stylesheet.transition)
-        };
+        const parameters = this._setTransitionParameters(300);
 
         this.light.setLight(lightOptions, options);
         this.light.updateTransitions(parameters);
@@ -1509,13 +1503,7 @@ class Style extends Evented {
                 if (!deepEqual(terrainOptions[key], currSpec[key])) {
                     terrain.set(terrainOptions);
                     this.stylesheet.terrain = terrainOptions;
-                    const parameters = {
-                        now: browser.now(),
-                        transition: extend({
-                            duration: 0
-                        }, this.stylesheet.transition)
-                    };
-
+                    const parameters = this._setTransitionParameters();
                     terrain.updateTransitions(parameters);
                     break;
                 }
@@ -1529,13 +1517,7 @@ class Style extends Evented {
     _createFog(fogOptions: FogSpecification) {
         const fog = this.fog = new Fog(fogOptions, this.map.transform);
         this.stylesheet.fog = fogOptions;
-        const parameters = {
-            now: browser.now(),
-            transition: extend({
-                duration: 0
-            }, this.stylesheet.transition)
-        };
-
+        const parameters = this._setTransitionParameters();
         fog.updateTransitions(parameters);
     }
 
@@ -1576,12 +1558,7 @@ class Style extends Evented {
                 if (!deepEqual(fogOptions[key], currSpec[key])) {
                     fog.set(fogOptions, currSpec);
                     this.stylesheet.fog = fogOptions;
-                    const parameters = {
-                        now: browser.now(),
-                        transition: extend({
-                            duration: 0
-                        }, this.stylesheet.transition)
-                    };
+                    const parameters = this._setTransitionParameters();
 
                     fog.updateTransitions(parameters);
                     break;
@@ -1614,14 +1591,18 @@ class Style extends Evented {
         this.stylesheet.terrain = terrainOptions;
         this.dispatcher.broadcast('enableTerrain', !this.terrainSetForDrapingOnly());
         this._force3DLayerUpdate();
-        const parameters = {
+        const parameters = this._setTransitionParameters();
+        terrain.updateTransitions(parameters);
+    }
+
+    _setTransitionParameters(duration: number = 0, delay: number = 0) {
+        return {
             now: browser.now(),
             transition: extend({
-                duration: 0
+                duration,
+                delay
             }, this.stylesheet.transition)
         };
-
-        terrain.updateTransitions(parameters);
     }
 
     _force3DLayerUpdate() {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1499,7 +1499,7 @@ class Style extends Evented {
             const currSpec = terrain.get();
 
             // Add in terrain default values if it was not set in style
-            if (!terrainOptions.hasOwnProperty('exaggeration') && !!currSpec.hasOwnProperty('exaggeration')) {
+            if (!terrainOptions.hasOwnProperty('exaggeration') && currSpec.hasOwnProperty('exaggeration')) {
                 terrainOptions.exaggeration = 1;
             }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -504,7 +504,9 @@ test('Map', (t) => {
 
                     styleWithTerrain['sources']["mapbox-dem"] = {
                         "type": "raster-dem",
-                        "tiles": ['http://example.com/{z}/{x}/{y}.png']
+                        "tiles": ['http://example.com/{z}/{x}/{y}.png'],
+                        "tileSize": 256,
+                        "maxzoom": 14
                     };
                     styleWithTerrain['terrain'] = {
                         "source": "mapbox-dem"

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -545,9 +545,11 @@ test('Map', (t) => {
                 map.setStyle(styleWithoutTerrainExaggeration);
                 t.equal(map.style.terrain.properties._values.exaggeration, 1);
 
+                map.setStyle(styleWithTerrainExaggeration);
+                t.equal(map.style.terrain.properties._values.exaggeration, 500);
+
                 t.equal(styleWithoutTerrainExaggeration.sources.terrain.exaggeration, undefined);
                 t.equal(styleWithTerrainExaggeration.sources.terrain.exaggeration, 500);
-
                 t.end();
             });
 
@@ -572,9 +574,11 @@ test('Map', (t) => {
                 map.setStyle(styleWithGlobe);
                 t.equal(map.getProjection().name, 'globe');
 
+                map.setStyle(styleWithWinkelTripel);
+                t.equal(map.getProjection().name, 'winkelTripel');
+
                 t.equal(styleWithGlobe.projection.name, 'globe');
                 t.equal(styleWithWinkelTripel.projection.name, 'winkelTripel');
-
                 t.end();
             });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -435,8 +435,8 @@ test('Map', (t) => {
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
                 t.equal(map.getTerrain(), null);
-                t.ok(style.terrain);
-                t.equal(style.terrain.source, '');
+                // Should not overwrite style: https://github.com/mapbox/mapbox-gl-js/issues/11939
+                t.equal(style.terrain, undefined);
                 map.remove();
 
                 map = new Map({style, container: div, testMode: true});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -551,7 +551,7 @@ test('Map', (t) => {
                 'layers': []
             };
 
-            const map = createMap(t, {style: extend(createStyle(), styleWithTerrainExaggeration)});
+            const map = createMap(t, {style: styleWithTerrainExaggeration});
 
             map.on('style.load', () => {
                 t.equal(map.getTerrain().exaggeration, 500);
@@ -583,7 +583,7 @@ test('Map', (t) => {
                 'layers': []
             };
 
-            const map = createMap(t, {style: extend(createStyle(), styleWithWinkelTripel)});
+            const map = createMap(t, {style: styleWithWinkelTripel});
 
             map.on('style.load', () => {
                 t.equal(map.getProjection().name, 'winkelTripel');

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -525,13 +525,6 @@ test('Map', (t) => {
 
         t.test('should apply different styles when toggling setStyle (https://github.com/mapbox/mapbox-gl-js/issues/11939)', (t) => {
             const styleWithTerrainExaggeration = {
-                'sources': {
-                    'mapbox-dem': {
-                        'tiles': ['http://example.com/{z}/{x}/{y}.png'],
-                        'type': 'raster-dem',
-                        'tileSize': 512
-                    }
-                },
                 'terrain': {
                     'source': 'mapbox-dem',
                     'exaggeration': 500
@@ -539,13 +532,6 @@ test('Map', (t) => {
             };
 
             const styleWithoutTerrainExaggeration = {
-                'sources': {
-                    'mapbox-dem': {
-                        'tiles': ['http://example.com/{z}/{x}/{y}.png'],
-                        'type': 'raster-dem',
-                        'tileSize': 512
-                    }
-                },
                 'terrain': {
                     'source': 'mapbox-dem'
                 }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -554,17 +554,45 @@ test('Map', (t) => {
             const map = createMap(t, {style: extend(createStyle(), styleWithTerrainExaggeration)});
 
             map.on('load', () => {
-                t.ok(map.style.terrain.properties._values.exaggeration, 500);
+                t.equal(map.style.terrain.properties._values.exaggeration, 500);
 
                 map.setStyle(styleWithoutTerrainExaggeration);
-
                 t.equal(map.style.terrain.properties._values.exaggeration, 1);
+
                 t.equal(styleWithoutTerrainExaggeration.sources.terrain.exaggeration, undefined);
                 t.equal(styleWithTerrainExaggeration.sources.terrain.exaggeration, 500);
 
                 t.end();
             });
 
+            map.remove();
+            t.end();
+        });
+
+        t.test('should apply different projections when toggling setStyle (https://github.com/mapbox/mapbox-gl-js/issues/11916)', (t) => {
+            const styleWithWinkelTripel = {
+                'projection': {'name': 'winkelTripel'}
+            };
+
+            const styleWithGlobe = {
+                'projection': {'name': 'globe'}
+            };
+
+            const map = createMap(t, {style: extend(createStyle(), styleWithWinkelTripel)});
+
+            map.on('load', () => {
+                t.equal(map.getProjection().name, 'winkelTripel');
+
+                map.setStyle(styleWithGlobe);
+                t.equal(map.getProjection().name, 'globe');
+
+                t.equal(styleWithGlobe.projection.name, 'globe');
+                t.equal(styleWithWinkelTripel.projection.name, 'winkelTripel');
+
+                t.end();
+            });
+
+            map.remove();
             t.end();
         });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -504,9 +504,7 @@ test('Map', (t) => {
 
                     styleWithTerrain['sources']["mapbox-dem"] = {
                         "type": "raster-dem",
-                        "tiles": ['http://example.com/{z}/{x}/{y}.png'],
-                        "tileSize": 256,
-                        "maxzoom": 14
+                        "tiles": ['http://example.com/{z}/{x}/{y}.png']
                     };
                     styleWithTerrain['terrain'] = {
                         "source": "mapbox-dem"
@@ -525,50 +523,69 @@ test('Map', (t) => {
 
         t.test('should apply different styles when toggling setStyle (https://github.com/mapbox/mapbox-gl-js/issues/11939)', (t) => {
             const styleWithTerrainExaggeration = {
+                'version': 8,
+                'sources': {
+                    'mapbox-dem': {
+                        'type': 'raster-dem',
+                        'tiles': ['http://example.com/{z}/{x}/{y}.png']
+                    }
+                },
                 'terrain': {
                     'source': 'mapbox-dem',
                     'exaggeration': 500
-                }
+                },
+                'layers': []
             };
 
             const styleWithoutTerrainExaggeration = {
+                'version': 8,
+                'sources': {
+                    'mapbox-dem': {
+                        'type': 'raster-dem',
+                        'tiles': ['http://example.com/{z}/{x}/{y}.png']
+                    }
+                },
                 'terrain': {
                     'source': 'mapbox-dem'
-                }
+                },
+                'layers': []
             };
 
             const map = createMap(t, {style: extend(createStyle(), styleWithTerrainExaggeration)});
 
-            map.on('load', () => {
-                t.equal(map.style.terrain.properties._values.exaggeration, 500);
+            map.on('style.load', () => {
+                t.equal(map.getTerrain().exaggeration, 500);
 
                 map.setStyle(styleWithoutTerrainExaggeration);
-                t.equal(map.style.terrain.properties._values.exaggeration, 1);
+                t.equal(map.getTerrain().exaggeration, 1);
 
                 map.setStyle(styleWithTerrainExaggeration);
-                t.equal(map.style.terrain.properties._values.exaggeration, 500);
+                t.equal(map.getTerrain().exaggeration, 500);
 
-                t.equal(styleWithoutTerrainExaggeration.sources.terrain.exaggeration, undefined);
-                t.equal(styleWithTerrainExaggeration.sources.terrain.exaggeration, 500);
+                t.equal(styleWithoutTerrainExaggeration.terrain.exaggeration, undefined);
+                t.equal(styleWithTerrainExaggeration.terrain.exaggeration, 500);
                 t.end();
             });
-
-            map.remove();
-            t.end();
         });
 
         t.test('should apply different projections when toggling setStyle (https://github.com/mapbox/mapbox-gl-js/issues/11916)', (t) => {
             const styleWithWinkelTripel = {
-                'projection': {'name': 'winkelTripel'}
+                'version': 8,
+                'sources': {},
+                'projection': {'name': 'winkelTripel'},
+                'layers': []
             };
 
             const styleWithGlobe = {
-                'projection': {'name': 'globe'}
+                'version': 8,
+                'sources': {},
+                'projection': {'name': 'globe'},
+                'layers': []
             };
 
             const map = createMap(t, {style: extend(createStyle(), styleWithWinkelTripel)});
 
-            map.on('load', () => {
+            map.on('style.load', () => {
                 t.equal(map.getProjection().name, 'winkelTripel');
 
                 map.setStyle(styleWithGlobe);
@@ -581,9 +598,6 @@ test('Map', (t) => {
                 t.equal(styleWithWinkelTripel.projection.name, 'winkelTripel');
                 t.end();
             });
-
-            map.remove();
-            t.end();
         });
 
         t.test('updating fog results in correct transitions', (t) => {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -523,6 +523,51 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('should apply different styles when toggling setStyle (https://github.com/mapbox/mapbox-gl-js/issues/11939)', (t) => {
+            const styleWithTerrainExaggeration = {
+                'sources': {
+                    'mapbox-dem': {
+                        'tiles': ['http://example.com/{z}/{x}/{y}.png'],
+                        'type': 'raster-dem',
+                        'tileSize': 512
+                    }
+                },
+                'terrain': {
+                    'source': 'mapbox-dem',
+                    'exaggeration': 500
+                }
+            };
+
+            const styleWithoutTerrainExaggeration = {
+                'sources': {
+                    'mapbox-dem': {
+                        'tiles': ['http://example.com/{z}/{x}/{y}.png'],
+                        'type': 'raster-dem',
+                        'tileSize': 512
+                    }
+                },
+                'terrain': {
+                    'source': 'mapbox-dem'
+                }
+            };
+
+            const map = createMap(t, {style: extend(createStyle(), styleWithTerrainExaggeration)});
+
+            map.on('load', () => {
+                t.ok(map.style.terrain.properties._values.exaggeration, 500);
+
+                map.setStyle(styleWithoutTerrainExaggeration);
+
+                t.equal(map.style.terrain.properties._values.exaggeration, 1);
+                t.equal(styleWithoutTerrainExaggeration.sources.terrain.exaggeration, undefined);
+                t.equal(styleWithTerrainExaggeration.sources.terrain.exaggeration, 500);
+
+                t.end();
+            });
+
+            t.end();
+        });
+
         t.test('updating fog results in correct transitions', (t) => {
             t.test('sets fog with transition', (t) => {
                 const fog = new Fog({


### PR DESCRIPTION
Closes #11939 and #11916

Previously, we would overwrite the stylesheet. However, this prevents successfully toggling between two styles using `setStyle` as it overwrites some of the properties. See both issues above in which terrain and projections are overwritten.

In addition, updating a terrain source did not account for using default values in the style. Currently, `exaggeration` is the only property of terrain with a default value.

Before (see [codepen](https://codepen.io/avpeery/pen/OJQzmrG) for example, toggling style changes the stylesheet exaggeration of style a):

https://user-images.githubusercontent.com/42715836/170626252-376b9a92-db96-4b10-9198-58cb48234729.mov

After (style exaggeration is not impacted, toggling is successful between style a and style b):

https://user-images.githubusercontent.com/42715836/170626288-eda9f3bb-5cc0-49d8-980b-10ed67945511.mov



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Copy stylesheet to allow toggling different styles using setStyle without overwriting some of the properties</changelog>`
