### PR TITLE
Bump minimist to 1.2.6 as per #11944

### DIFF
--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -45,7 +45,7 @@
     "@mapbox/unitbezier": "^0.0.0",
     "csscolorparser": "~1.0.2",
     "json-stringify-pretty-compact": "^2.0.0",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "rw": "^1.3.3",
     "sort-object": "^0.3.2"
   },


### PR DESCRIPTION
Bumping dependency as mentioned in https://github.com/mapbox/mapbox-gl-js/issues/11944.