### PR TITLE
Do not set the map language to the user's preferred language by default

### DIFF
--- a/src/source/load_tilejson.js
+++ b/src/source/load_tilejson.js
@@ -26,8 +26,24 @@ export default function(options: any, requestManager: RequestManager, language: 
                 result.vectorLayerIds = result.vectorLayers.map((layer) => { return layer.id; });
             }
 
-            if (tileJSON.language) {
+            /**
+             * A tileset supports language localization if the TileJSON contains
+             * a `language_options` object in the response.
+             */
+            if (tileJSON.language_options) {
+                result.languageOptions = tileJSON.language_options;
+            }
+
+            if (tileJSON.language && tileJSON.language[tileJSON.id]) {
                 result.language = tileJSON.language[tileJSON.id];
+            }
+
+            /**
+             * A tileset supports different worldviews if the TileJSON contains
+             * a `worldview_options` object in the repsonse as well as a `worldview_default` key.
+             */
+            if (tileJSON.worldview_options) {
+                result.worldviewOptions = tileJSON.worldview_options;
             }
 
             if (tileJSON.worldview) {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -90,7 +90,7 @@ class VectorTileSource extends Evented implements Source {
         this.isTileClipped = true;
         this._loaded = false;
 
-        extend(this, pick(options, ['url', 'scheme', 'tileSize', 'promoteId', 'language', 'languageOptions', 'worldview', 'worldviewOptions']));
+        extend(this, pick(options, ['url', 'scheme', 'tileSize', 'promoteId']));
         this._options = extend({type: 'vector'}, options);
 
         this._collectResourceTiming = options.collectResourceTiming;

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -22,25 +22,6 @@ import type {VectorSourceSpecification, PromoteIdSpecification} from '../style-s
 import type Actor from '../util/actor.js';
 import type {LoadVectorTileResult} from './vector_tile_worker_source.js';
 
-// Tileset metadata is available via the TileJSON endpoint.
-export type LocalizedSourceSpecification = {
-    /**
-     * A tileset supports language localization if the response contains a language_options object in the response.
-     */
-    languageOptions: ?{[string]: string};
-    /**
-     * A tileset supports different worldviews if the response contains a worldview_options object in the repsonse as well as a worldview_default key.
-     */
-    worldviewOptions: ?{[string]: string};
-    worldview_default: ?string;
-    /**
-     * If the request includes the language and/or worldview query parameters, the response object will include dynamic language and/or worldview keys
-     * that intend to provide information about the resolution of your requests. Use these objects to ask whether a language/worldview is supported of a tileset or not.
-     */
-    language: ?string;
-    worldview: ?string;
-};
-
 /**
  * A source containing vector tiles in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/reference/).
  * See the [Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector) for detailed documentation of options.
@@ -95,7 +76,7 @@ class VectorTileSource extends Evented implements Source {
     worldview: ?string;
     worldviewOptions: ?{[string]: string};
 
-    constructor(id: string, options: VectorSourceSpecification & LocalizedSourceSpecification & {collectResourceTiming: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
+    constructor(id: string, options: VectorSourceSpecification & {collectResourceTiming: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;
         this.dispatcher = dispatcher;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -79,7 +79,7 @@ type IControl = {
     onRemove(map: Map): void;
 
     +getDefaultPosition?: () => ControlPosition;
-    +_setLanguage?: (language: string) => void;
+    +_setLanguage?: (language: ?string) => void;
 }
 /* eslint-enable no-use-before-define */
 
@@ -256,10 +256,11 @@ const defaultOptions = {
  * @param {number} [options.pitch=0] The initial [pitch](https://docs.mapbox.com/help/glossary/camera#pitch) (tilt) of the map, measured in degrees away from the plane of the screen (0-85). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {LngLatBoundsLike} [options.bounds=null] The initial bounds of the map. If `bounds` is specified, it overrides `center` and `zoom` constructor options.
  * @param {Object} [options.fitBoundsOptions] A {@link Map#fitBounds} options object to use _only_ when fitting the initial `bounds` provided above.
- * @param {string} [options.language] A string representing the language used for the map's data and UI components. Languages can only be set on Mapbox vector tile sources.
+ * @param {string} [options.language=null] A string representing the language used for the map's data and UI components. Languages can only be set on Mapbox vector tile sources.
+ *   By default, GL JS will not set a language so that the language of Mapbox tiles will be determined by the vector tile source's TileJSON.
  *   Valid language strings must be a [BCP-47 language code](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_subtags). Unsupported BCP-47 codes will not include any translations. Invalid codes will result in an recoverable error.
  *   If a label has no translation for the selected language, it will display in the label's local language.
- *   By default, GL JS will select a user's preferred language as determined by the browser's `window.navigator.language` property.
+ *   If option is set to `auto`, GL JS will select a user's preferred language as determined by the browser's `window.navigator.language` property.
  *   If the `locale` property is not set separately, this language will also be used to localize the UI for supported languages.
  * @param {string} [options.worldview] Sets the map's worldview. A worldview determines the way that certain disputed boundaries
      * are rendered. By default, GL JS will not set a worldview so that the worldview of Mapbox tiles will be determined by the vector tile source's TileJSON.
@@ -384,7 +385,7 @@ class Map extends Camera {
     _averageElevation: EasedVariable;
     _containerWidth: number;
     _containerHeight: number;
-    _language: string;
+    _language: ?string;
     _worldview: ?string;
 
     // `_explicitProjection represents projection as set by a call to map.setProjection()
@@ -1070,13 +1071,17 @@ class Map extends Camera {
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setLanguage('es');
+     *
+     * @example
+     * map.setLanguage('auto');
      */
     setLanguage(language?: ?string): this {
-        this._language = language || window.navigator.language;
+        this._language = language === 'auto' ? window.navigator.language : language;
+
         if (this.style) {
             for (const id in this.style._sourceCaches) {
                 const source = this.style._sourceCaches[id]._source;
-                if (source.language && source.language !== this._language && source._setLanguage) {
+                if (source._setLanguage) {
                     source._setLanguage(this._language);
                 }
             }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1120,7 +1120,7 @@ class Map extends Camera {
         if (this.style) {
             for (const id in this.style._sourceCaches) {
                 const source = this.style._sourceCaches[id]._source;
-                if (source.worldview && source.worldview !== worldview && source._setWorldview) {
+                if (source._setWorldview) {
                     source._setWorldview(worldview);
                 }
             }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -490,7 +490,7 @@ class Map extends Camera {
         this._crossFadingFactor = 1;
         this._collectResourceTiming = options.collectResourceTiming;
         this._optimizeForTerrain = options.optimizeForTerrain;
-        this._language = options.language || window.navigator.language;
+        this._language = options.language === 'auto' ? window.navigator.language : options.language;
         this._worldview = options.worldview;
         this._renderTaskQueue = new TaskQueue();
         this._domRenderTaskQueue = new TaskQueue();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -70,7 +70,7 @@ test('Map', (t) => {
         t.ok(map.keyboard.isEnabled());
         t.ok(map.scrollZoom.isEnabled());
         t.ok(map.touchZoomRotate.isEnabled());
-        t.equal(map._language, window.navigator.language);
+        t.notok(map._language);
         t.notok(map._worldview);
         t.throws(() => {
             new Map({
@@ -2354,6 +2354,14 @@ test('Map', (t) => {
             });
         });
 
+        t.test('can instantiate map with the preferred language of the user', (t) => {
+            const map = createMap(t, {language: 'auto'});
+            map.on('style.load', () => {
+                t.equal(map.getLanguage(), window.navigator.language);
+                t.end();
+            });
+        });
+
         t.test('sets and gets language property', (t) => {
             const map = createMap(t);
             map.on('style.load', () => {
@@ -2368,8 +2376,10 @@ test('Map', (t) => {
             map.on('style.load', () => {
                 map.setLanguage('es');
                 t.equal(map.getLanguage(), 'es');
-                map.setLanguage();
+                map.setLanguage('auto');
                 t.equal(map.getLanguage(), window.navigator.language);
+                map.setLanguage();
+                t.equal(map.getLanguage(), undefined);
                 t.end();
             });
         });


### PR DESCRIPTION
This PR reverts the behavior introduced in #11666 which was setting the map language to the user's preferred language (`window.navigator.language`) by default.

It also provides the `auto` value for the `language` option, which allows setting the map language to the user's preferred language.

/cc @alexshalamov 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
