### PR TITLE
Reload tiles after TileJSON is loaded in VectorTileSource#setSourceProperty

### DIFF
--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -105,11 +105,11 @@ class VectorTileSource extends Evented implements Source {
         this._deduped = new DedupedRequest();
     }
 
-    load() {
+    load(callback?: Callback<void>) {
         this._loaded = false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
-        const language = this.map._language;
-        const worldview = this.map._worldview;
+        const language = this.language || this.map._language;
+        const worldview = this.worldview || this.map._worldview;
         this._tileJSONRequest = loadTileJSON(this._options, this.map._requestManager, language, worldview, (err, tileJSON) => {
             this._tileJSONRequest = null;
             this._loaded = true;
@@ -129,6 +129,8 @@ class VectorTileSource extends Evented implements Source {
                 this.fire(new Event('data', {dataType: 'source', sourceDataType: 'metadata'}));
                 this.fire(new Event('data', {dataType: 'source', sourceDataType: 'content'}));
             }
+
+            if (callback) callback(err);
         });
     }
 
@@ -152,11 +154,13 @@ class VectorTileSource extends Evented implements Source {
 
         callback();
 
-        const sourceCaches = this.map.style._getSourceCaches(this.id);
-        for (const sourceCache of sourceCaches) {
-            sourceCache.clearTiles();
-        }
-        this.load();
+        // Reload current tiles after TileJSON is loaded
+        this.load(() => {
+            const sourceCaches = this.map.style._getSourceCaches(this.id);
+            for (const sourceCache of sourceCaches) {
+                sourceCache.clearTiles();
+            }
+        });
     }
 
     /**

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -216,10 +216,6 @@ class VectorTileSource extends Evented implements Source {
 
     _setLanguage(language?: ?string): this {
         if (language === this.language) return this;
-        if (this.languageOptions && language && !this.languageOptions[language]) {
-            console.warn(`Vector tile source "${this.id}" does not support language "${language}".`);
-            return this;
-        }
 
         this.setSourceProperty(() => {
             this.language = language;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1056,6 +1056,7 @@ class Map extends Camera {
     /**
      * Returns the code for the map's language which is used for translating map labels.
      *
+     * @private
      * @returns {string} Returns the map's language code.
      * @example
      * const language = map.getLanguage();
@@ -1067,6 +1068,7 @@ class Map extends Camera {
     /**
      * Sets the map's language.
      *
+     * @private
      * @param {string} language A string representing the desired language. `undefined` or `null` will remove the current map language and reset the map to the default language as determined by `window.navigator.language`.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
@@ -1099,6 +1101,7 @@ class Map extends Camera {
     /**
      * Returns the code for the map's worldview.
      *
+     * @private
      * @returns {string} Returns the map's worldview code.
      * @example
      * const worldview = map.getWorldview();
@@ -1110,6 +1113,7 @@ class Map extends Camera {
     /**
      * Sets the map's worldview.
      *
+     * @private
      * @param {string} worldview A string representing the desired worldview. `undefined` or `null` will cause the map to fall back to the TileJSON's default worldview.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example


### PR DESCRIPTION
This PR postpones tiles reloading until TileJSON is loaded in `VectorTileSource#setSourceProperty`.

This fixes the race condition in #11952, when tiles are being requested with the old `language` and `worldview` options before the requested TileJSON updates the source's `tiles` property in `VectorTileSource#load`.

This PR also removes the language checks from client, see #11968

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
