### PR TITLE
Update s3 link to lower res video

### DIFF
--- a/debug/globe-with-video.html
+++ b/debug/globe-with-video.html
@@ -41,7 +41,7 @@ var videoStyle = {
     "sources": {
         "video": {
             "type": "video",
-            "urls": [ "ozone.mp4", "https://static-assets.mapbox.com/mapbox-gl-js/ozone.mp4"],
+            "urls": [ "ozone.mp4", "https://static-assets.mapbox.com/mapbox-gl-js/ozone2.mp4"],
             "coordinates": [
                 [-180.0, 85.0511287798066],
                 [180.0, 85.0511287798066],


### PR DESCRIPTION
Updating s3 link to lower res video. FPS was slow on some machines. Can't rename objects in s3 itself due to restrictions. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
