### PR TITLE
Add extra constrain to avoid unnecessary line shader calculations if 'line-trim-offset' is not set

### DIFF
--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -17,6 +17,7 @@ import type Tile from '../../source/tile.js';
 import type LineStyleLayer from '../../style/style_layer/line_style_layer.js';
 import type Painter from '../painter.js';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters.js';
+import StyleLayerIndex from '../../style/style_layer_index.js';
 
 export type LineUniformsType = {|
     'u_matrix': UniformMatrix4f,
@@ -45,7 +46,7 @@ export type LinePatternUniformsType = {|
     'u_alpha_discard_threshold': Uniform1f
 |};
 
-export type LineDefinesType = 'RENDER_LINE_GRADIENT' | 'RENDER_LINE_DASH' | 'RENDER_LINE_ALPHA_DISCARD' | 'RENDER_LINE_METRICS_ENABLED';
+export type LineDefinesType = 'RENDER_LINE_GRADIENT' | 'RENDER_LINE_DASH' | 'RENDER_LINE_ALPHA_DISCARD' | 'RENDER_LINE_TRIM_OFFSET';
 
 const lineUniforms = (context: Context, locations: UniformLocations): LineUniformsType => ({
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
@@ -157,6 +158,7 @@ const lineDefinesValues = (layer: LineStyleLayer): LineDefinesType[] => {
     const values = [];
     if (hasDash(layer)) values.push('RENDER_LINE_DASH');
     if (layer.paint.get('line-gradient')) values.push('RENDER_LINE_GRADIENT');
+    if (layer.paint.get('line-trim-offset')) values.push('RENDER_LINE_TRIM_OFFSET');
 
     const hasPattern = layer.paint.get('line-pattern').constantOr((1: any));
     const hasOpacity = layer.paint.get('line-opacity').constantOr(1.0) !== 1.0;

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -17,7 +17,6 @@ import type Tile from '../../source/tile.js';
 import type LineStyleLayer from '../../style/style_layer/line_style_layer.js';
 import type Painter from '../painter.js';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters.js';
-import StyleLayerIndex from '../../style/style_layer_index.js';
 
 export type LineUniformsType = {|
     'u_matrix': UniformMatrix4f,

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -45,7 +45,7 @@ export type LinePatternUniformsType = {|
     'u_alpha_discard_threshold': Uniform1f
 |};
 
-export type LineDefinesType = 'RENDER_LINE_GRADIENT' | 'RENDER_LINE_DASH' | 'RENDER_LINE_ALPHA_DISCARD';
+export type LineDefinesType = 'RENDER_LINE_GRADIENT' | 'RENDER_LINE_DASH' | 'RENDER_LINE_ALPHA_DISCARD' | 'RENDER_LINE_METRICS_ENABLED';
 
 const lineUniforms = (context: Context, locations: UniformLocations): LineUniformsType => ({
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -59,6 +59,7 @@ void main() {
     vec4 out_color = color;
 #endif
 
+#ifdef RENDER_LINE_METRICS_ENABLED
     // v_uv[2] and v_uv[3] are specifying the original clip range that the vertex is located in.
     highp float start = v_uv[2];
     highp float end = v_uv[3];
@@ -73,6 +74,7 @@ void main() {
     if (trim_end > trim_start && (line_progress <= trim_end && line_progress >= trim_start)) {
         out_color = vec4(0, 0, 0, 0);
     }
+#endif
 
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -59,7 +59,7 @@ void main() {
     vec4 out_color = color;
 #endif
 
-#ifdef RENDER_LINE_METRICS_ENABLED
+#ifdef RENDER_LINE_TRIM_OFFSET
     // v_uv[2] and v_uv[3] are specifying the original clip range that the vertex is located in.
     highp float start = v_uv[2];
     highp float end = v_uv[3];

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -9,8 +9,9 @@
 attribute vec2 a_pos_normal;
 attribute vec4 a_data;
 // Includes in order: a_uv_x, a_split_index, a_clip_start, a_clip_end
-// to reduce attribute count on older devices
-#ifdef RENDER_LINE_TRIM_OFFSET
+// to reduce attribute count on older devices.
+// Only line-gradient and line-trim-offset will requires a_packed info.
+#if defined(RENDER_LINE_GRADIENT) || defined(RENDER_LINE_TRIM_OFFSET)
 attribute highp vec4 a_packed;
 #endif
 
@@ -108,12 +109,11 @@ void main() {
     v_gamma_scale = 1.0;
 #endif
 
-#ifdef RENDER_LINE_TRIM_OFFSET
+#if defined(RENDER_LINE_GRADIENT) || defined(RENDER_LINE_TRIM_OFFSET)
     float a_uv_x = a_packed[0];
     float a_split_index = a_packed[1];
     highp float a_clip_start = a_packed[2];
     highp float a_clip_end = a_packed[3];
-
 #ifdef RENDER_LINE_GRADIENT
     highp float texel_height = 1.0 / u_image_height;
     highp float half_texel_height = 0.5 * texel_height;
@@ -121,8 +121,8 @@ void main() {
     v_uv = vec4(a_uv_x, a_split_index * texel_height - half_texel_height, a_clip_start, a_clip_end);
 #else
     v_uv = vec4(a_uv_x, 0.0, a_clip_start, a_clip_end);
-#endif // #ifdef RENDER_LINE_GRADIENT
-#endif // #ifdef RENDER_LINE_TRIM_OFFSET
+#endif
+#endif
 
 #ifdef RENDER_LINE_DASH
     float tileZoomRatio = u_scale.x;

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -10,7 +10,9 @@ attribute vec2 a_pos_normal;
 attribute vec4 a_data;
 // Includes in order: a_uv_x, a_split_index, a_clip_start, a_clip_end
 // to reduce attribute count on older devices
+#ifdef RENDER_LINE_METRICS_ENABLED
 attribute highp vec4 a_packed;
+#endif
 
 #ifdef RENDER_LINE_DASH
 attribute float a_linesofar;
@@ -106,6 +108,7 @@ void main() {
     v_gamma_scale = 1.0;
 #endif
 
+#ifdef RENDER_LINE_METRICS_ENABLED
     float a_uv_x = a_packed[0];
     float a_split_index = a_packed[1];
     highp float a_clip_start = a_packed[2];
@@ -118,7 +121,8 @@ void main() {
     v_uv = vec4(a_uv_x, a_split_index * texel_height - half_texel_height, a_clip_start, a_clip_end);
 #else
     v_uv = vec4(a_uv_x, 0.0, a_clip_start, a_clip_end);
-#endif
+#endif // #ifdef RENDER_LINE_GRADIENT
+#endif // #ifdef RENDER_LINE_METRICS_ENABLED
 
 #ifdef RENDER_LINE_DASH
     float tileZoomRatio = u_scale.x;

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -10,7 +10,7 @@ attribute vec2 a_pos_normal;
 attribute vec4 a_data;
 // Includes in order: a_uv_x, a_split_index, a_clip_start, a_clip_end
 // to reduce attribute count on older devices
-#ifdef RENDER_LINE_METRICS_ENABLED
+#ifdef RENDER_LINE_TRIM_OFFSET
 attribute highp vec4 a_packed;
 #endif
 
@@ -108,7 +108,7 @@ void main() {
     v_gamma_scale = 1.0;
 #endif
 
-#ifdef RENDER_LINE_METRICS_ENABLED
+#ifdef RENDER_LINE_TRIM_OFFSET
     float a_uv_x = a_packed[0];
     float a_split_index = a_packed[1];
     highp float a_clip_start = a_packed[2];
@@ -122,7 +122,7 @@ void main() {
 #else
     v_uv = vec4(a_uv_x, 0.0, a_clip_start, a_clip_end);
 #endif // #ifdef RENDER_LINE_GRADIENT
-#endif // #ifdef RENDER_LINE_METRICS_ENABLED
+#endif // #ifdef RENDER_LINE_TRIM_OFFSET
 
 #ifdef RENDER_LINE_DASH
     float tileZoomRatio = u_scale.x;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add extra constrain to avoid unnecessary line shader calculations if 'line-trim-offset' is not set.</changelog>`
