### PR TITLE
Fix precision errors in pack/unpack depth

### DIFF
--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -15,10 +15,11 @@ vec3 dither(vec3 color, highp vec2 seed) {
 
 // Pack depth to RGBA. A piece of code copied in various libraries and WebGL
 // shadow mapping examples.
+// https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/
 highp vec4 pack_depth(highp float ndc_z) {
     highp float depth = ndc_z * 0.5 + 0.5;
-    const highp vec4 bit_shift = vec4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
-    const highp vec4 bit_mask  = vec4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
+    const highp vec4 bit_shift = vec4(255.0 * 255.0 * 255.0, 255.0 * 255.0, 255.0, 1.0);
+    const highp vec4 bit_mask  = vec4(0.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
     highp vec4 res = fract(depth * bit_shift);
     res -= res.xxyz * bit_mask;
     return res;

--- a/src/shaders/_prelude_terrain.vertex.glsl
+++ b/src/shaders/_prelude_terrain.vertex.glsl
@@ -112,9 +112,10 @@ float elevation(vec2 apos) {
 
 // Unpack depth from RGBA. A piece of code copied in various libraries and WebGL
 // shadow mapping examples.
+// https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/
 float unpack_depth(vec4 rgba_depth)
 {
-    const vec4 bit_shift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
+    const vec4 bit_shift = vec4(1.0 / (255.0 * 255.0 * 255.0), 1.0 / (255.0 * 255.0), 1.0 / 255.0, 1.0);
     return dot(rgba_depth, bit_shift) * 2.0 - 1.0;
 }
 


### PR DESCRIPTION
Current code is introducing precision errors in the pack/unpack depth functions by not using the correct range of values. When the packed_depth is written to R8G8B8A8 texture the maximum value it can store is 255 per channel, not 256. We were introducing errors in the third decimal in a range from 0..1. Seems this code was also wrong in three.js and other libraries, hence the confusion. Coded a godbolt to prove the issue (https://godbolt.org/z/8MrrhPh11).

Link to the original post: https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/

This fix also helps in gl-native terrain occlusion and others.

Tested manually that the problem addresed in [this commit](https://github.com/mapbox/mapbox-gl-js/commit/ff5783869fce7945031817a3790b971d7218871d) is still fixed. 

![outputB](https://user-images.githubusercontent.com/1784900/174055151-00f4c645-c50d-44d0-919d-23697baf620e.gif)

cc: @mapbox/gl-native

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix precision errors in depth pack/unpack</changelog>`
