### PR TITLE
Relaxed behavior for unsupported globe APIs

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -574,7 +574,6 @@ class Camera extends Evented {
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): ?EasingOptions {
         if (this.transform.projection.name === 'globe') {
             warnOnce('Globe projection does not support cameraForBounds API');
-            return;
         }
 
         bounds = LngLatBounds.convert(bounds);
@@ -823,7 +822,6 @@ class Camera extends Evented {
     fitBounds(bounds: LngLatBoundsLike, options?: EasingOptions, eventData?: Object): this {
         if (this.transform.projection.name === 'globe') {
             warnOnce('Globe projection does not support fitBounds API');
-            return this;
         }
 
         return this._fitInternal(
@@ -902,7 +900,6 @@ class Camera extends Evented {
     fitScreenCoordinates(p0: PointLike, p1: PointLike, bearing: number, options?: EasingOptions, eventData?: Object): this {
         if (this.transform.projection.name === 'globe') {
             warnOnce('Globe projection does not support fitScreenCoordinates API');
-            return this;
         }
 
         let lngLat0, lngLat1, minAltitude, maxAltitude;

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -573,7 +573,7 @@ class Camera extends Evented {
      */
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): ?EasingOptions {
         if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support cameraForBounds API');
+            warnOnce('Globe projection does not support cameraForBounds API, this API may behave unexpectedly."');
         }
 
         bounds = LngLatBounds.convert(bounds);
@@ -821,7 +821,7 @@ class Camera extends Evented {
      */
     fitBounds(bounds: LngLatBoundsLike, options?: EasingOptions, eventData?: Object): this {
         if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support fitBounds API');
+            warnOnce('Globe projection does not support fitBounds API, this API may behave unexpectedly.');
         }
 
         return this._fitInternal(
@@ -899,7 +899,7 @@ class Camera extends Evented {
      */
     fitScreenCoordinates(p0: PointLike, p1: PointLike, bearing: number, options?: EasingOptions, eventData?: Object): this {
         if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support fitScreenCoordinates API');
+            warnOnce('Globe projection does not support fitScreenCoordinates API, this API may behave unexpectedly.');
         }
 
         let lngLat0, lngLat1, minAltitude, maxAltitude;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -800,7 +800,7 @@ class Map extends Camera {
      */
     getBounds(): LngLatBounds | null {
         if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support getBounds API');
+            warnOnce('Globe projection does not support getBounds API, this API may behave unexpectedly."');
         }
         return this.transform.getBounds();
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -801,7 +801,6 @@ class Map extends Camera {
     getBounds(): LngLatBounds | null {
         if (this.transform.projection.name === 'globe') {
             warnOnce('Globe projection does not support getBounds API');
-            return null;
         }
         return this.transform.getBounds();
     }

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -2028,17 +2028,6 @@ test('camera', (t) => {
             t.end();
         });
 
-        t.test('no-op with globe', (t) => {
-            t.stub(console, 'warn');
-            const camera = createCamera({projection: {name: 'globe'}});
-            const bb = [[-133, 16], [-68, 50]];
-
-            const transform = camera.cameraForBounds(bb);
-            t.equal(transform, undefined);
-            t.ok(console.warn.calledOnce);
-            t.end();
-        });
-
         t.test('bearing positive number', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
@@ -2148,26 +2137,6 @@ test('camera', (t) => {
             t.end();
         });
 
-        t.test('no-op with globe', (t) => {
-            t.stub(console, 'warn');
-            const camera = createCamera({projection: {name: 'globe'}});
-            const bb = [[-133, 16], [-68, 50]];
-
-            const prevBearing = camera.getBearing();
-            const prevPitch = camera.getPitch();
-            const prevZoom = camera.getZoom();
-            const prevCenter = camera.getCenter();
-
-            const this_ = camera.fitBounds(bb, {duration:0});
-            t.equal(this_, camera);
-            t.ok(console.warn.calledOnce);
-            t.deepEqual(fixedLngLat(camera.getCenter(), 4), prevCenter);
-            t.equal(fixedNum(camera.getZoom(), 3), prevZoom);
-            t.equal(camera.getBearing(), prevBearing);
-            t.equal(camera.getPitch(), prevPitch);
-            t.end();
-        });
-
         t.test('padding number', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
@@ -2227,29 +2196,6 @@ test('camera', (t) => {
             t.equal(fixedNum(camera.getZoom(), 3), 0.915); // 0.915 ~= log2(4*sqrt(2)/3)
             t.equal(camera.getBearing(), -135);
             t.equal(camera.getPitch(), 0);
-            t.end();
-        });
-
-        t.test('no-op with globe', (t) => {
-            t.stub(console, 'warn');
-            const camera = createCamera({projection: {name: 'globe'}});
-            const p0 = [128, 128];
-            const p1 = [256, 384];
-            const bearing = 225;
-
-            const prevBearing = camera.getBearing();
-            const prevPitch = camera.getPitch();
-            const prevZoom = camera.getZoom();
-            const prevCenter = camera.getCenter();
-
-            const this_ = camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
-
-            t.equal(this_, camera);
-            t.ok(console.warn.calledOnce);
-            t.deepEqual(fixedLngLat(camera.getCenter(), 4), prevCenter);
-            t.equal(fixedNum(camera.getZoom(), 3), prevZoom);
-            t.equal(camera.getBearing(), prevBearing);
-            t.equal(camera.getPitch(), prevPitch);
             t.end();
         });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1216,17 +1216,6 @@ test('Map', (t) => {
             t.end();
         });
 
-        t.test('no-op with globe', (t) => {
-            t.stub(console, 'warn');
-            const map = createMap(t, {zoom: 0, skipCSSStub: true});
-            map.setProjection('globe');
-            const bounds = map.getBounds();
-
-            t.equal(bounds, null);
-            t.ok(console.warn.calledOnce);
-            t.end();
-        });
-
         t.test('padded bounds', (t) => {
             const map = createMap(t, {zoom: 1, bearing: 45, skipCSSStub: true});
 


### PR DESCRIPTION
Instead of returning `null` and issuing a warning, it's preferable to return the actual result, even if this result may not be correct. As it turns out that this behavior can break the external plugins such as the geocoder and geolocate controls (As mentioned in https://github.com/mapbox/mapbox-gl-js/issues/12007). Since the result may be correct after the globe mercator transition this is an overall better behavior.
