### PR TITLE
fix line-trim-offset shader

### DIFF
--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -159,7 +159,7 @@ const lineDefinesValues = (layer: LineStyleLayer): LineDefinesType[] => {
     if (layer.paint.get('line-gradient')) values.push('RENDER_LINE_GRADIENT');
 
     const trimOffset = layer.paint.get('line-trim-offset');
-    if (trimOffset[0] !== 0 && trimOffset[1] !== 0) {
+    if (trimOffset[0] !== 0 || trimOffset[1] !== 0) {
         values.push('RENDER_LINE_TRIM_OFFSET');
     }
 

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -157,7 +157,11 @@ const lineDefinesValues = (layer: LineStyleLayer): LineDefinesType[] => {
     const values = [];
     if (hasDash(layer)) values.push('RENDER_LINE_DASH');
     if (layer.paint.get('line-gradient')) values.push('RENDER_LINE_GRADIENT');
-    if (layer.paint.get('line-trim-offset')) values.push('RENDER_LINE_TRIM_OFFSET');
+
+    const trimOffset = layer.paint.get('line-trim-offset');
+    if (trimOffset[0] !== 0 && trimOffset[1] !== 0) {
+        values.push('RENDER_LINE_TRIM_OFFSET');
+    }
 
     const hasPattern = layer.paint.get('line-pattern').constantOr((1: any));
     const hasOpacity = layer.paint.get('line-opacity').constantOr(1.0) !== 1.0;

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -71,8 +71,13 @@ void main() {
     // Mark the pixel to be transparent when:
     // 1. trim_offset range is valid
     // 2. line_progress is within trim_offset range
-    if (trim_end > trim_start && (line_progress <= trim_end && line_progress >= trim_start)) {
-        out_color = vec4(0, 0, 0, 0);
+
+    // Nested conditionals fixes the issue
+    // https://github.com/mapbox/mapbox-gl-js/issues/12013
+    if (trim_end > trim_start) {
+        if (line_progress <= trim_end && line_progress >= trim_start) {
+            out_color = vec4(0, 0, 0, 0);
+        }
     }
 #endif
 


### PR DESCRIPTION
This PR fixes the line shader logic that was causing https://github.com/mapbox/mapbox-gl-js/issues/12013

**Before**

<img width="1004" alt="Screen Shot 2022-06-20 at 19 23 13" src="https://user-images.githubusercontent.com/533564/174644510-b4f9e524-70d2-492a-ba54-09604f346443.png">


**After**

<img width="1004" alt="Screen Shot 2022-06-20 at 19 22 45" src="https://user-images.githubusercontent.com/533564/174644535-4e006cd6-6915-4ec8-9637-adc10babc018.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix missing lines on Windows.</changelog>`

