### PR TITLE
Fix shadows PCF precision issues in android

### DIFF
--- a/src/shaders/_prelude_shadow.fragment.glsl
+++ b/src/shaders/_prelude_shadow.fragment.glsl
@@ -6,76 +6,76 @@ uniform float u_shadow_intensity;
 uniform float u_texel_size;
 uniform vec2 u_cascade_distances;
 
-float shadow_sample_1(vec2 uv, float compare) {
+highp float shadow_sample_1(highp vec2 uv, highp float compare) {
     return step(unpack_depth(texture2D(u_shadowmap_1, uv)), compare);
 }
 
-float shadow_sample_0(vec2 uv, float compare) {
+highp float shadow_sample_0(highp vec2 uv, highp float compare) {
     return step(unpack_depth(texture2D(u_shadowmap_0, uv)), compare);
 }
 
-float shadow_occlusion_1(vec4 pos, float bias) {
+highp float shadow_occlusion_1(highp vec4 pos, float bias) {
     pos.xyz /= pos.w;
     pos.xy = pos.xy * 0.5 + 0.5;
-    float fragDepth = min(pos.z, 0.999) - bias;
+    highp float fragDepth = min(pos.z, 0.999) - bias;
     return shadow_sample_1(pos.xy, fragDepth);
 }
 
-float shadow_occlusion_0(vec4 pos, float bias) {
+highp float shadow_occlusion_0(highp vec4 pos, float bias) {
     pos.xyz /= pos.w;
     pos.xy = pos.xy * 0.5 + 0.5;
-    float fragDepth = min(pos.z, 0.999) - bias;
-    vec2 uv = pos.xy;
+    highp float fragDepth = min(pos.z, 0.999) - bias;
+    highp vec2 uv = pos.xy;
 
-    vec2 texel = uv / u_texel_size - vec2(1.5);
-    vec2 f = fract(texel);
+    highp vec2 texel = uv / u_texel_size - vec2(1.5);
+    highp vec2 f = fract(texel);
 
-    float s = u_texel_size;
+    highp float s = u_texel_size;
 
     // Perform brute force percentage-closer filtering with a 4x4 sample grid.
     // Edge tap smoothing is used to weight each sample based on their contribution in the overall PCF kernel, i.e. `weight = clamp(kernel, texel.bounds).area / texel.area`
-    vec2 uv00 = (texel - f + 0.5) * s;
-    vec2 uv10 = uv00 + vec2(1.0 * s, 0);
-    vec2 uv20 = uv00 + vec2(2.0 * s, 0);
-    vec2 uv30 = uv00 + vec2(3.0 * s, 0);
+    highp vec2 uv00 = (texel - f + 0.5) * s;
+    highp vec2 uv10 = uv00 + vec2(1.0 * s, 0);
+    highp vec2 uv20 = uv00 + vec2(2.0 * s, 0);
+    highp vec2 uv30 = uv00 + vec2(3.0 * s, 0);
 
-    vec2 uv01 = uv00 + vec2(0.0, 1.0 * s);
-    vec2 uv11 = uv01 + vec2(1.0 * s, 0);
-    vec2 uv21 = uv01 + vec2(2.0 * s, 0);
-    vec2 uv31 = uv01 + vec2(3.0 * s, 0);
+    highp vec2 uv01 = uv00 + vec2(0.0, 1.0 * s);
+    highp vec2 uv11 = uv01 + vec2(1.0 * s, 0);
+    highp vec2 uv21 = uv01 + vec2(2.0 * s, 0);
+    highp vec2 uv31 = uv01 + vec2(3.0 * s, 0);
 
-    vec2 uv02 = uv01 + vec2(0.0, 1.0 * s);
-    vec2 uv12 = uv02 + vec2(1.0 * s, 0);
-    vec2 uv22 = uv02 + vec2(2.0 * s, 0);
-    vec2 uv32 = uv02 + vec2(3.0 * s, 0);
+    highp vec2 uv02 = uv01 + vec2(0.0, 1.0 * s);
+    highp vec2 uv12 = uv02 + vec2(1.0 * s, 0);
+    highp vec2 uv22 = uv02 + vec2(2.0 * s, 0);
+    highp vec2 uv32 = uv02 + vec2(3.0 * s, 0);
 
-    vec2 uv03 = uv02 + vec2(0.0, 1.0 * s);
-    vec2 uv13 = uv03 + vec2(1.0 * s, 0);
-    vec2 uv23 = uv03 + vec2(2.0 * s, 0);
-    vec2 uv33 = uv03 + vec2(3.0 * s, 0);
+    highp vec2 uv03 = uv02 + vec2(0.0, 1.0 * s);
+    highp vec2 uv13 = uv03 + vec2(1.0 * s, 0);
+    highp vec2 uv23 = uv03 + vec2(2.0 * s, 0);
+    highp vec2 uv33 = uv03 + vec2(3.0 * s, 0);
 
-    float o00 = shadow_sample_0(uv00, fragDepth);
-    float o10 = shadow_sample_0(uv10, fragDepth);
-    float o20 = shadow_sample_0(uv20, fragDepth);
-    float o30 = shadow_sample_0(uv30, fragDepth);
+    highp float o00 = shadow_sample_0(uv00, fragDepth);
+    highp float o10 = shadow_sample_0(uv10, fragDepth);
+    highp float o20 = shadow_sample_0(uv20, fragDepth);
+    highp float o30 = shadow_sample_0(uv30, fragDepth);
 
-    float o01 = shadow_sample_0(uv01, fragDepth);
-    float o11 = shadow_sample_0(uv11, fragDepth);
-    float o21 = shadow_sample_0(uv21, fragDepth);
-    float o31 = shadow_sample_0(uv31, fragDepth);
+    highp float o01 = shadow_sample_0(uv01, fragDepth);
+    highp float o11 = shadow_sample_0(uv11, fragDepth);
+    highp float o21 = shadow_sample_0(uv21, fragDepth);
+    highp float o31 = shadow_sample_0(uv31, fragDepth);
 
-    float o02 = shadow_sample_0(uv02, fragDepth);
-    float o12 = shadow_sample_0(uv12, fragDepth);
-    float o22 = shadow_sample_0(uv22, fragDepth);
-    float o32 = shadow_sample_0(uv32, fragDepth);
+    highp float o02 = shadow_sample_0(uv02, fragDepth);
+    highp float o12 = shadow_sample_0(uv12, fragDepth);
+    highp float o22 = shadow_sample_0(uv22, fragDepth);
+    highp float o32 = shadow_sample_0(uv32, fragDepth);
 
-    float o03 = shadow_sample_0(uv03, fragDepth);
-    float o13 = shadow_sample_0(uv13, fragDepth);
-    float o23 = shadow_sample_0(uv23, fragDepth);
-    float o33 = shadow_sample_0(uv33, fragDepth);
+    highp float o03 = shadow_sample_0(uv03, fragDepth);
+    highp float o13 = shadow_sample_0(uv13, fragDepth);
+    highp float o23 = shadow_sample_0(uv23, fragDepth);
+    highp float o33 = shadow_sample_0(uv33, fragDepth);
 
     // Edge tap smoothing
-    float value = 
+    highp float value = 
         (1.0 - f.x) * (1.0 - f.y) * o00 +
         (1.0 - f.y) * (o10 + o20) +
         f.x * (1.0 - f.y) * o30 +


### PR DESCRIPTION
PCF filtering was missing highp precision qualifiers that produced artifacts in android. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
