### PR TITLE
Optimize tile calculations for globe

### DIFF
--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -367,9 +367,8 @@ export function globeECEFOrigin(tileMatrix: Mat4, id: UnwrappedTileID): [number,
     return origin;
 }
 
-export function globeECEFNormalizationScale(bounds: Aabb): number {
-    const maxExt = Math.max(...vec3.sub([], bounds.max, bounds.min));
-    return GLOBE_NORMALIZATION_MASK / maxExt;
+export function globeECEFNormalizationScale({min, max}: Aabb): number {
+    return GLOBE_NORMALIZATION_MASK / Math.max(max[0] - min[0], max[1] - min[1], max[2] - min[2]);
 }
 
 export function globeNormalizeECEF(bounds: Aabb): Float64Array {

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -167,6 +167,7 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const batches = showWireframe ? [false, true] : [false];
     const sharedBuffers = painter.globeSharedBuffers;
     const viewport = [tr.width * browser.devicePixelRatio, tr.height * browser.devicePixelRatio];
+    const globeMatrix = Float32Array.from(tr.globeMatrix);
 
     batches.forEach(isWireframe => {
         // This code assumes the rendering is batched into mesh terrain and then wireframe
@@ -199,7 +200,6 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
                 extend(elevationOptions, {morphing: {srcDemTile: morph.from, dstDemTile: morph.to, phase: easeCubicInOut(morph.phase)}});
             }
 
-            const globeMatrix = Float32Array.from(tr.globeMatrix);
             const tileBounds = tileCornersToBounds(coord.canonical);
             const latitudinalLod = getLatitudinalLod(tileBounds.getCenter().lat);
             const gridMatrix = getGridMatrix(coord.canonical, tileBounds, latitudinalLod);

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -21,7 +21,7 @@ import {
     globeToMercatorTransition,
     globePoleMatrixForTile,
     getGridMatrix,
-    tileCornersInLatLng,
+    tileCornersToBounds,
     globeNormalizeECEF,
     globeTileBounds,
     globeUseCustomAntiAliasing,
@@ -200,10 +200,9 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
             }
 
             const globeMatrix = Float32Array.from(tr.globeMatrix);
-            const tileCornersLatLng = tileCornersInLatLng(coord.canonical);
-            const tileCenterLatitude = (tileCornersLatLng[0][0] + tileCornersLatLng[1][0]) / 2.0;
-            const latitudinalLod = getLatitudinalLod(tileCenterLatitude);
-            const gridMatrix = getGridMatrix(coord.canonical, tileCornersLatLng, latitudinalLod);
+            const tileBounds = tileCornersToBounds(coord.canonical);
+            const latitudinalLod = getLatitudinalLod(tileBounds.getCenter().lat);
+            const gridMatrix = getGridMatrix(coord.canonical, tileBounds, latitudinalLod);
             const normalizeMatrix = globeNormalizeECEF(globeTileBounds(coord.canonical));
             const uniformValues = globeRasterUniformValues(
                 tr.projMatrix, globeMatrix, globeMercatorMatrix, normalizeMatrix, globeToMercatorTransition(tr.zoom),


### PR DESCRIPTION
When profiling globe view, I noticed that `aabbForTileOnGlobe` takes ~5% of CPU time, and makes quite a lot of allocations for a hot path function that's called many times per frame. This PR eliminates most redundant allocations, bringing it below 1% in the profiler. See the two self-contained commits:

1. Instead of allocating a new scaled globe matrix every time, use transform's cached `globeMatrix` and scale things inline when calculating bounding volume corners.
2. Eliminate most temporary arrays that are immediately discarded. As a part of this, also clean up some function signatures so that `LngLat` corners of a bounding box are encapsulated in `LngLatBounds` which we designated for such cases.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve rendering performance on globe view</changelog>`
