### PR TITLE
Adjust ground shadow strength based on fog opacity

### DIFF
--- a/src/shaders/ground_shadow.fragment.glsl
+++ b/src/shaders/ground_shadow.fragment.glsl
@@ -6,7 +6,14 @@ varying vec4 v_pos_light_view_0;
 varying vec4 v_pos_light_view_1;
 varying float v_depth;
 
+#ifdef FOG
+varying float v_fog_opacity;
+#endif
+
 void main() {
     vec3 shadow = shadowed_color(vec3(1.0), v_pos_light_view_0, v_pos_light_view_1, v_depth);
+#ifdef FOG
+    shadow = mix(shadow, vec3(1.0), v_fog_opacity);
+#endif
     gl_FragColor = vec4(shadow, 1.0);
 }

--- a/src/shaders/ground_shadow.vertex.glsl
+++ b/src/shaders/ground_shadow.vertex.glsl
@@ -9,6 +9,10 @@ varying vec4 v_pos_light_view_0;
 varying vec4 v_pos_light_view_1;
 varying float v_depth;
 
+#ifdef FOG
+varying float v_fog_opacity;
+#endif
+
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);
 
@@ -16,4 +20,8 @@ void main() {
     v_pos_light_view_1 = u_light_matrix_1 * vec4(a_pos, 0.0, 1.0);
 
     v_depth = gl_Position.w;
+
+#ifdef FOG
+    v_fog_opacity = fog(fog_position(a_pos));
+#endif
 }


### PR DESCRIPTION
This PR changes the ground shadow shader to improve the visuals of shadows far away from the camera when fog is enabled and terrain is disabled. Shadow strength is decreased based on the fog opacity at that location.

The shader is currently only used in gl-native. @mapbox/gl-native

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
