### PR TITLE
Pass separate shadow direction to shaders

### DIFF
--- a/src/shaders/_prelude_shadow.fragment.glsl
+++ b/src/shaders/_prelude_shadow.fragment.glsl
@@ -5,6 +5,7 @@ uniform sampler2D u_shadowmap_1;
 uniform float u_shadow_intensity;
 uniform float u_texel_size;
 uniform vec2 u_cascade_distances;
+uniform vec3 u_shadow_direction;
 
 highp float shadow_sample_1(highp vec2 uv, highp float compare) {
     return step(unpack_depth(texture2D(u_shadowmap_1, uv)), compare);
@@ -90,8 +91,8 @@ highp float shadow_occlusion_0(highp vec4 pos, float bias) {
 }
 
 vec3 shadowed_color_normal(
-    vec3 color, vec3 N, vec3 L, vec4 light_view_pos0, vec4 light_view_pos1, float view_depth) {
-    float NDotL = dot(N, L);
+    vec3 color, vec3 N, vec4 light_view_pos0, vec4 light_view_pos1, float view_depth) {
+    float NDotL = dot(N, u_shadow_direction);
     if (NDotL < 0.0)
         return color * (1.0 - u_shadow_intensity);
 

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -31,8 +31,7 @@ void main() {
 #endif
 
 #ifdef RENDER_SHADOWS
-    color.xyz = shadowed_color_normal(color.xyz, normalize(v_normal), normalize(u_lightpos),
-        v_pos_light_view_0, v_pos_light_view_1, v_depth);
+    color.xyz = shadowed_color_normal(color.xyz, normalize(v_normal), v_pos_light_view_0, v_pos_light_view_1, v_depth);
 #endif
 
 #ifdef FOG


### PR DESCRIPTION
This PR changes shadow rendering in shaders so that the shadow direction is passed separately from the light position/direction. This allows gl-native to limit the range of values allowed for the light direction separately for the lighting calculation and the shadowing calculation.

PR includes shader changes @mapbox/gl-native

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
