### PR TITLE
Upgrade earcut to v2.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
     "csscolorparser": "~1.0.3",
-    "earcut": "^2.2.3",
+    "earcut": "^2.2.4",
     "geojson-vt": "^3.2.1",
     "gl-matrix": "^3.4.3",
     "grid-index": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,10 +4502,10 @@ duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.3.tgz#d44ced2ff5a18859568e327dd9c7d46b16f55cf4"
-  integrity sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==
+earcut@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
+  integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Upgrade Earcut (library responsible for triangulating polygons) to v2.2.4, bringing performance improvements (up to ~15%) and a fix for a race condition that could cause an infinite loop.

Should improve tile loading times on low zoom levels, particularly the globe view, because half of the worker time is spent triangulating complex water body polygons.