### PR TITLE
Fallback to hardcoded units in browsers without `NumberFormat` support in `ScaleControl`

### DIFF
--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -164,17 +164,17 @@ function legacySetScale(maxWidth: number, maxDistance: number, unit: string) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
 
-    const localizedUnit = {
-        kilometer: this._map._getUIString('ScaleControl.Kilometers'),
-        meter: this._map._getUIString('ScaleControl.Meters'),
-        mile: this._map._getUIString('ScaleControl.Miles'),
-        foot: this._map._getUIString('ScaleControl.Feet'),
-        'nautical-mile': this._map._getUIString('ScaleControl.NauticalMiles'),
+    const unitAbbr = {
+        kilometer: 'km',
+        meter: 'm',
+        mile: 'mi',
+        foot: 'ft',
+        'nautical-mile': 'nm',
     }[unit];
 
     this._map._requestDomTask(() => {
         this._container.style.width = `${maxWidth * ratio}px`;
-        this._container.innerHTML = `${distance}&nbsp;${localizedUnit}`;
+        this._container.innerHTML = `${distance}&nbsp;${unitAbbr}`;
     });
 }
 

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -43,6 +43,16 @@ class ScaleControl {
     constructor(options: Options) {
         this.options = extend({}, defaultOptions, options);
 
+        // Some old browsers (e.g., Safari < 14.1) don't support the "unit" style.
+        // This is a workaround to display the scale without proper internationalization support.
+        try {
+            // $FlowIgnore
+            new Intl.NumberFormat('en', {style: 'unit', unitDisplay: 'narrow', unit: 'meter'});
+        } catch {
+            // $FlowIgnore[cannot-write]
+            this._setScale = legacySetScale.bind(this);
+        }
+
         bindAll([
             '_update',
             'setUnit'
@@ -54,7 +64,56 @@ class ScaleControl {
     }
 
     _update() {
-        updateScale(this._map, this._container, this._language, this.options);
+        // A horizontal scale is imagined to be present at center of the map
+        // container with maximum length (Default) as 100px.
+        // Using spherical law of cosines approximation, the real distance is
+        // found between the two coordinates.
+        const maxWidth = this.options.maxWidth || 100;
+
+        const map = this._map;
+        const y = map._containerHeight / 2;
+        const x = (map._containerWidth / 2) - maxWidth / 2;
+        const left = map.unproject([x, y]);
+        const right = map.unproject([x + maxWidth, y]);
+        const maxMeters = left.distanceTo(right);
+        // The real distance corresponding to 100px scale length is rounded off to
+        // near pretty number and the scale length for the same is found out.
+        // Default unit of the scale is based on User's locale.
+        if (this.options.unit === 'imperial') {
+            const maxFeet = 3.2808 * maxMeters;
+            if (maxFeet > 5280) {
+                const maxMiles = maxFeet / 5280;
+                this._setScale(maxWidth, maxMiles, 'mile');
+            } else {
+                this._setScale(maxWidth, maxFeet, 'foot');
+            }
+        } else if (this.options.unit === 'nautical') {
+            const maxNauticals = maxMeters / 1852;
+            this._setScale(maxWidth, maxNauticals, 'nautical-mile');
+        } else if (maxMeters >= 1000) {
+            this._setScale(maxWidth, maxMeters / 1000, 'kilometer');
+        } else {
+            this._setScale(maxWidth, maxMeters, 'meter');
+        }
+    }
+
+    _setScale(maxWidth: number, maxDistance: number, unit: string) {
+        const distance = getRoundNum(maxDistance);
+        const ratio = distance / maxDistance;
+
+        this._map._requestDomTask(() => {
+            this._container.style.width = `${maxWidth * ratio}px`;
+
+            // Intl.NumberFormat doesn't support nautical-mile as a unit,
+            // so we are hardcoding `nm` as a unit symbol for all locales
+            if (unit === 'nautical-mile') {
+                this._container.innerHTML = `${distance}&nbsp;nm`;
+                return;
+            }
+
+            // $FlowFixMe — flow v0.142.0 doesn't support optional `locales` argument and `unit` style option
+            this._container.innerHTML = new Intl.NumberFormat(this._language, {style: 'unit', unitDisplay: 'narrow', unit}).format(distance);
+        });
     }
 
     onAdd(map: Map): HTMLElement {
@@ -93,46 +152,21 @@ class ScaleControl {
 
 export default ScaleControl;
 
-function updateScale(map, container, language, options) {
-    // A horizontal scale is imagined to be present at center of the map
-    // container with maximum length (Default) as 100px.
-    // Using spherical law of cosines approximation, the real distance is
-    // found between the two coordinates.
-    const maxWidth = (options && options.maxWidth) || 100;
-
-    const y = map._containerHeight / 2;
-    const x = (map._containerWidth / 2) - maxWidth / 2;
-    const left = map.unproject([x, y]);
-    const right = map.unproject([x + maxWidth, y]);
-    const maxMeters = left.distanceTo(right);
-    // The real distance corresponding to 100px scale length is rounded off to
-    // near pretty number and the scale length for the same is found out.
-    // Default unit of the scale is based on User's locale.
-    if (options && options.unit === 'imperial') {
-        const maxFeet = 3.2808 * maxMeters;
-        if (maxFeet > 5280) {
-            const maxMiles = maxFeet / 5280;
-            setScale(container, maxWidth, maxMiles, map._getUIString('ScaleControl.Miles'), map);
-        } else {
-            setScale(container, maxWidth, maxFeet, map._getUIString('ScaleControl.Feet'), map);
-        }
-    } else if (options && options.unit === 'nautical') {
-        const maxNauticals = maxMeters / 1852;
-        setScale(container, maxWidth, maxNauticals, map._getUIString('ScaleControl.NauticalMiles'), map);
-    } else if (maxMeters >= 1000) {
-        setScale(container, maxWidth, maxMeters / 1000, map._getUIString('ScaleControl.Kilometers'), map);
-    } else {
-        setScale(container, maxWidth, maxMeters, map._getUIString('ScaleControl.Meters'), map);
-    }
-}
-
-function setScale(container, maxWidth, maxDistance, unit, map) {
+function legacySetScale(maxWidth: number, maxDistance: number, unit: string) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
 
-    map._requestDomTask(() => {
-        container.style.width = `${maxWidth * ratio}px`;
-        container.innerHTML = `${distance}&nbsp;${unit}`;
+    const localizedUnit = {
+        kilometer: this._map._getUIString('ScaleControl.Kilometers'),
+        meter: this._map._getUIString('ScaleControl.Meters'),
+        mile: this._map._getUIString('ScaleControl.Miles'),
+        foot: this._map._getUIString('ScaleControl.Feet'),
+        'nautical-mile': this._map._getUIString('ScaleControl.NauticalMiles'),
+    }[unit];
+
+    this._map._requestDomTask(() => {
+        this._container.style.width = `${maxWidth * ratio}px`;
+        this._container.innerHTML = `${distance}&nbsp;${localizedUnit}`;
     });
 }
 

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -112,36 +112,27 @@ function updateScale(map, container, language, options) {
         const maxFeet = 3.2808 * maxMeters;
         if (maxFeet > 5280) {
             const maxMiles = maxFeet / 5280;
-            setScale(container, maxWidth, maxMiles, language, 'mile', map);
+            setScale(container, maxWidth, maxMiles, map._getUIString('ScaleControl.Miles'), map);
         } else {
-            setScale(container, maxWidth, maxFeet, language, 'foot', map);
+            setScale(container, maxWidth, maxFeet, map._getUIString('ScaleControl.Feet'), map);
         }
     } else if (options && options.unit === 'nautical') {
         const maxNauticals = maxMeters / 1852;
-        setScale(container, maxWidth, maxNauticals, language, 'nautical-mile', map);
+        setScale(container, maxWidth, maxNauticals, map._getUIString('ScaleControl.NauticalMiles'), map);
     } else if (maxMeters >= 1000) {
-        setScale(container, maxWidth, maxMeters / 1000, language, 'kilometer', map);
+        setScale(container, maxWidth, maxMeters / 1000, map._getUIString('ScaleControl.Kilometers'), map);
     } else {
-        setScale(container, maxWidth, maxMeters, language, 'meter', map);
+        setScale(container, maxWidth, maxMeters, map._getUIString('ScaleControl.Meters'), map);
     }
 }
 
-function setScale(container, maxWidth, maxDistance, language, unit, map) {
+function setScale(container, maxWidth, maxDistance, unit, map) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
 
     map._requestDomTask(() => {
         container.style.width = `${maxWidth * ratio}px`;
-
-        // Intl.NumberFormat doesn't support nautical-mile as a unit,
-        // so we are hardcoding `nm` as a unit symbol for all locales
-        if (unit === 'nautical-mile') {
-            container.innerHTML = `${distance}&nbsp;nm`;
-            return;
-        }
-
-        // $FlowFixMe — flow v0.142.0 doesn't support optional `locales` argument and `unit` style option
-        container.innerHTML = new Intl.NumberFormat(language, {style: 'unit', unitDisplay: 'narrow', unit}).format(distance);
+        container.innerHTML = `${distance}&nbsp;${unit}`;
     });
 }
 

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -45,16 +45,14 @@ class ScaleControl {
 
         // Some old browsers (e.g., Safari < 14.1) don't support the "unit" style.
         // This is a workaround to display the scale without proper internationalization support.
-        try {
-            // $FlowIgnore
-            new Intl.NumberFormat('en', {style: 'unit', unitDisplay: 'narrow', unit: 'meter'});
-        } catch {
+        if (!isNumberFormatSupported()) {
             // $FlowIgnore[cannot-write]
             this._setScale = legacySetScale.bind(this);
         }
 
         bindAll([
             '_update',
+            '_setScale',
             'setUnit'
         ], this);
     }
@@ -151,6 +149,16 @@ class ScaleControl {
 }
 
 export default ScaleControl;
+
+function isNumberFormatSupported() {
+    try {
+        // $FlowIgnore
+        new Intl.NumberFormat('en', {style: 'unit', unitDisplay: 'narrow', unit: 'meter'});
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
 
 function legacySetScale(maxWidth: number, maxDistance: number, unit: string) {
     const distance = getRoundNum(maxDistance);

--- a/src/ui/default_locale.js
+++ b/src/ui/default_locale.js
@@ -12,11 +12,6 @@ const defaultLocale = {
     'NavigationControl.ResetBearing': 'Reset bearing to north',
     'NavigationControl.ZoomIn': 'Zoom in',
     'NavigationControl.ZoomOut': 'Zoom out',
-    'ScaleControl.Feet': 'ft',
-    'ScaleControl.Meters': 'm',
-    'ScaleControl.Kilometers': 'km',
-    'ScaleControl.Miles': 'mi',
-    'ScaleControl.NauticalMiles': 'nm',
     'ScrollZoomBlocker.CtrlMessage': 'Use ctrl + scroll to zoom the map',
     'ScrollZoomBlocker.CmdMessage': 'Use ⌘ + scroll to zoom the map',
     'TouchPanBlocker.Message': 'Use two fingers to move the map'

--- a/src/ui/default_locale.js
+++ b/src/ui/default_locale.js
@@ -12,6 +12,11 @@ const defaultLocale = {
     'NavigationControl.ResetBearing': 'Reset bearing to north',
     'NavigationControl.ZoomIn': 'Zoom in',
     'NavigationControl.ZoomOut': 'Zoom out',
+    'ScaleControl.Feet': 'ft',
+    'ScaleControl.Meters': 'm',
+    'ScaleControl.Kilometers': 'km',
+    'ScaleControl.Miles': 'mi',
+    'ScaleControl.NauticalMiles': 'nm',
     'ScrollZoomBlocker.CtrlMessage': 'Use ctrl + scroll to zoom the map',
     'ScrollZoomBlocker.CmdMessage': 'Use ⌘ + scroll to zoom the map',
     'TouchPanBlocker.Message': 'Use two fingers to move the map'

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -38,6 +38,23 @@ test('ScaleControl should change unit of distance after calling setUnit', (t) =>
     t.end();
 });
 
+test('ScaleControl should change language after calling map.setLanguage', (t) => {
+    const map = createMap(t);
+    const scale = new ScaleControl();
+    const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
+    map.addControl(scale);
+    map._domRenderTaskQueue.run();
+
+    let contents = map.getContainer().querySelector(selector).innerHTML;
+    t.match(contents, /km/);
+
+    map.setLanguage('ru');
+    map._domRenderTaskQueue.run();
+    contents = map.getContainer().querySelector(selector).innerHTML;
+    t.match(contents, /км/);
+    t.end();
+});
+
 test('ScaleControl should respect the maxWidth regardless of the unit and actual scale', (t) => {
     const map = createMap(t);
     const maxWidth = 100;

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -38,23 +38,6 @@ test('ScaleControl should change unit of distance after calling setUnit', (t) =>
     t.end();
 });
 
-test('ScaleControl should change language after calling map.setLanguage', (t) => {
-    const map = createMap(t);
-    const scale = new ScaleControl();
-    const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
-    map.addControl(scale);
-    map._domRenderTaskQueue.run();
-
-    let contents = map.getContainer().querySelector(selector).innerHTML;
-    t.match(contents, /km/);
-
-    map.setLanguage('ru');
-    map._domRenderTaskQueue.run();
-    contents = map.getContainer().querySelector(selector).innerHTML;
-    t.match(contents, /км/);
-    t.end();
-});
-
 test('ScaleControl should respect the maxWidth regardless of the unit and actual scale', (t) => {
     const map = createMap(t);
     const maxWidth = 100;

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -103,3 +103,27 @@ test('ScaleControl should support different projections', (t) => {
 
     t.end();
 });
+
+test('ScaleControl should work in legacy safari', (t) => {
+    const realNumberFormat = Intl.NumberFormat;
+    Intl.NumberFormat = function(arg, options) {
+        if (options && options.style === 'unit') {
+            throw new Error('not supported');
+        }
+        return realNumberFormat.call(Intl, arg, options);
+    };
+    try {
+        const map = createMap(t);
+        const scale = new ScaleControl();
+        const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
+        map.addControl(scale);
+        map._domRenderTaskQueue.run();
+
+        const contents = map.getContainer().querySelector(selector).innerHTML;
+        t.match(contents, /km/);
+    } finally {
+        Intl.NumberFormat = realNumberFormat;
+    }
+    t.end();
+
+});


### PR DESCRIPTION
This PR reverts i18n support added in #11850 due to the lack of support in Safari <14.1 #12021
Closes #12021

![Screen Shot 2022-07-07 at 15 45 15](https://user-images.githubusercontent.com/533564/177782769-46d707cb-576d-454f-a22d-065a96b7a487.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add a workaround in ScaleControl to support localization in browsers without NumberFormat support</changelog>`
