### PR TITLE
Add missing highp qualifiers for correct shadow rendering in Android

### DIFF
--- a/src/shaders/_prelude_shadow.fragment.glsl
+++ b/src/shaders/_prelude_shadow.fragment.glsl
@@ -5,8 +5,8 @@ uniform sampler2D u_shadowmap_1;
 uniform float u_shadow_intensity;
 uniform float u_texel_size;
 uniform vec2 u_cascade_distances;
-uniform vec3 u_shadow_direction;
-uniform vec3 u_shadow_bias;
+uniform highp vec3 u_shadow_direction;
+uniform highp vec3 u_shadow_bias;
 
 highp float shadow_sample_1(highp vec2 uv, highp float compare) {
     return step(unpack_depth(texture2D(u_shadowmap_1, uv)), compare);
@@ -16,14 +16,14 @@ highp float shadow_sample_0(highp vec2 uv, highp float compare) {
     return step(unpack_depth(texture2D(u_shadowmap_0, uv)), compare);
 }
 
-highp float shadow_occlusion_1(highp vec4 pos, float bias) {
+highp float shadow_occlusion_1(highp vec4 pos, highp float bias) {
     pos.xyz /= pos.w;
     pos.xy = pos.xy * 0.5 + 0.5;
     highp float fragDepth = min(pos.z, 0.999) - bias;
     return shadow_sample_1(pos.xy, fragDepth);
 }
 
-highp float shadow_occlusion_0(highp vec4 pos, float bias) {
+highp float shadow_occlusion_0(highp vec4 pos, highp float bias) {
     pos.xyz /= pos.w;
     pos.xy = pos.xy * 0.5 + 0.5;
     highp float fragDepth = min(pos.z, 0.999) - bias;
@@ -92,15 +92,15 @@ highp float shadow_occlusion_0(highp vec4 pos, float bias) {
 }
 
 vec3 shadowed_color_normal(
-    vec3 color, vec3 N, vec4 light_view_pos0, vec4 light_view_pos1, float view_depth) {
-    float NDotL = dot(N, u_shadow_direction);
+    vec3 color, highp vec3 N, highp vec4 light_view_pos0, highp vec4 light_view_pos1, float view_depth) {
+    highp float NDotL = dot(N, u_shadow_direction);
     if (NDotL < 0.0)
         return color * (1.0 - u_shadow_intensity);
 
     NDotL = clamp(NDotL, 0.0, 1.0);
 
     // Slope scale based on http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/
-    float bias = u_shadow_bias.x + clamp(u_shadow_bias.y * tan(acos(NDotL)), 0.0, u_shadow_bias.z);
+    highp float bias = u_shadow_bias.x + clamp(u_shadow_bias.y * tan(acos(NDotL)), 0.0, u_shadow_bias.z);
     float occlusion = 0.0;
     if (view_depth < u_cascade_distances.x)
         occlusion = shadow_occlusion_0(light_view_pos0, bias);
@@ -113,7 +113,7 @@ vec3 shadowed_color_normal(
     return color;
 }
 
-vec3 shadowed_color(vec3 color, vec4 light_view_pos0, vec4 light_view_pos1, float view_depth) {
+vec3 shadowed_color(vec3 color, highp vec4 light_view_pos0, highp vec4 light_view_pos1, float view_depth) {
     float bias = 0.0;
     float occlusion = 0.0;
     if (view_depth < u_cascade_distances.x)

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -4,10 +4,10 @@ uniform lowp vec3 u_lightpos;
 varying vec4 v_color;
 
 #ifdef RENDER_SHADOWS
-varying vec4 v_pos_light_view_0;
-varying vec4 v_pos_light_view_1;
+varying highp vec4 v_pos_light_view_0;
+varying highp vec4 v_pos_light_view_1;
 varying float v_depth;
-varying vec3 v_normal;
+varying highp vec3 v_normal;
 #endif
 
 #ifdef FAUX_AO

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -1,3 +1,4 @@
+
 uniform mat4 u_matrix;
 uniform vec3 u_lightcolor;
 uniform lowp vec3 u_lightpos;
@@ -26,9 +27,9 @@ varying vec4 v_color;
 uniform mat4 u_light_matrix_0;
 uniform mat4 u_light_matrix_1;
 
-varying vec4 v_pos_light_view_0;
-varying vec4 v_pos_light_view_1;
-varying vec3 v_normal;
+varying highp vec4 v_pos_light_view_0;
+varying highp vec4 v_pos_light_view_1;
+varying highp vec3 v_normal;
 varying float v_depth;
 #endif
 


### PR DESCRIPTION
Missing highp qualifiers were producing shadow acne in some surfaces:

![image](https://user-images.githubusercontent.com/1784900/178200526-154e734a-b322-4548-a888-8a46955238d4.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x} apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
