### PR TITLE
Remove the code darkening backfacing surfaces for shadows

### DIFF
--- a/src/shaders/_prelude_shadow.fragment.glsl
+++ b/src/shaders/_prelude_shadow.fragment.glsl
@@ -94,8 +94,9 @@ highp float shadow_occlusion_0(highp vec4 pos, highp float bias) {
 vec3 shadowed_color_normal(
     vec3 color, highp vec3 N, highp vec4 light_view_pos0, highp vec4 light_view_pos1, float view_depth) {
     highp float NDotL = dot(N, u_shadow_direction);
+    // early return if the fragment is backfacing
     if (NDotL < 0.0)
-        return color * (1.0 - u_shadow_intensity);
+        return color;
 
     NDotL = clamp(NDotL, 0.0, 1.0);
 
@@ -107,8 +108,6 @@ vec3 shadowed_color_normal(
     else if (view_depth < u_cascade_distances.y)
         occlusion = shadow_occlusion_1(light_view_pos1, bias);
 
-    float backfacing = 1.0 - smoothstep(0.0, 0.1, NDotL);
-    occlusion = mix(occlusion, 1.0, backfacing);
     color *= 1.0 - (u_shadow_intensity * occlusion);
     return color;
 }

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -4,10 +4,10 @@ uniform lowp vec3 u_lightpos;
 varying vec4 v_color;
 
 #ifdef RENDER_SHADOWS
-varying highp vec4 v_pos_light_view_0;
-varying highp vec4 v_pos_light_view_1;
+varying highp vec3 v_pos;
 varying float v_depth;
 varying highp vec3 v_normal;
+uniform highp mat4 u_normal_matrix;
 #endif
 
 #ifdef FAUX_AO
@@ -31,7 +31,8 @@ void main() {
 #endif
 
 #ifdef RENDER_SHADOWS
-    color.xyz = shadowed_color_normal(color.xyz, normalize(v_normal), v_pos_light_view_0, v_pos_light_view_1, v_depth);
+    highp vec4 ws_normal = u_normal_matrix * vec4(v_normal, 1.0);
+    color.xyz = shadowed_color_normal(color.xyz, normalize(ws_normal.xyz), v_pos, v_depth);
 #endif
 
 #ifdef FOG

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -24,11 +24,10 @@ uniform float u_height_lift;
 varying vec4 v_color;
 
 #ifdef RENDER_SHADOWS
-uniform mat4 u_light_matrix_0;
-uniform mat4 u_light_matrix_1;
 
-varying highp vec4 v_pos_light_view_0;
-varying highp vec4 v_pos_light_view_1;
+uniform mat4 u_normal_matrix;
+
+varying highp vec3 v_pos;
 varying highp vec3 v_normal;
 varying float v_depth;
 #endif
@@ -98,8 +97,9 @@ void main() {
     gl_Position = mix(u_matrix * vec4(pos, 1), AWAY, hidden);
 
 #ifdef RENDER_SHADOWS
-    v_pos_light_view_0 = u_light_matrix_0 * vec4(pos, 1);
-    v_pos_light_view_1 = u_light_matrix_1 * vec4(pos, 1);
+
+
+    v_pos = pos;
     v_normal = normal;
     v_depth = gl_Position.w;
 #endif


### PR DESCRIPTION
Remove the trick that was done to prevent artifacts in backfacing surfaces due to self shadowing. A correct bias tweaking make this trick innecessary and also avoids the issue it created: backfacing surfaces were being darkened twice.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
