### PR TITLE
Fix GeolocateControl in Safari

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -172,7 +172,7 @@ class GeolocateControl extends Evented {
                 callback(this._supportsGeolocation);
             });
         } else {
-            this._supportsGeolocation = !!this.geolocation;
+            this._supportsGeolocation = !!this.options.geolocation;
             callback(this._supportsGeolocation);
         }
     }

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -29,10 +29,13 @@ function lngLatAsFixed(lngLat, digits) {
 
 test('GeolocateControl with no options', (t) => {
     const map = createMap(t);
-    t.plan(0);
+    t.plan(1);
 
     const geolocate = new GeolocateControl();
     map.addControl(geolocate);
+
+    t.equal(geolocate._geolocateButton.disabled, false);
+
     t.end();
 });
 


### PR DESCRIPTION
Closes #12074. Turns out #11614 broke `GeolocateControl` in Safari, because the latter doesn't support the [location permissions API](https://caniuse.com/permissions-api), and the fallback route wasn't checked / caught by tests. I updated the unit test so that it fails without the fix, not sure if there's a better way to cover this...

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix GeolocateControl not working in Safari</changelog>`
