### PR TITLE
Blend shadow between cascades and fade out at distance

### DIFF
--- a/src/shaders/_prelude_shadow.fragment.glsl
+++ b/src/shaders/_prelude_shadow.fragment.glsl
@@ -19,14 +19,14 @@ highp float shadow_sample_0(highp vec2 uv, highp float compare) {
 highp float shadow_occlusion_1(highp vec4 pos, highp float bias) {
     pos.xyz /= pos.w;
     pos.xy = pos.xy * 0.5 + 0.5;
-    highp float fragDepth = min(pos.z, 0.999) - bias;
-    return shadow_sample_1(pos.xy, fragDepth);
+    highp float compare1 = min(pos.z, 0.999) - bias;
+    return shadow_sample_1(pos.xy, compare1);
 }
 
 highp float shadow_occlusion_0(highp vec4 pos, highp float bias) {
     pos.xyz /= pos.w;
     pos.xy = pos.xy * 0.5 + 0.5;
-    highp float fragDepth = min(pos.z, 0.999) - bias;
+    highp float compare0 = min(pos.z, 0.999) - bias;
     highp vec2 uv = pos.xy;
 
     highp vec2 texel = uv / u_texel_size - vec2(1.5);
@@ -56,25 +56,25 @@ highp float shadow_occlusion_0(highp vec4 pos, highp float bias) {
     highp vec2 uv23 = uv03 + vec2(2.0 * s, 0);
     highp vec2 uv33 = uv03 + vec2(3.0 * s, 0);
 
-    highp float o00 = shadow_sample_0(uv00, fragDepth);
-    highp float o10 = shadow_sample_0(uv10, fragDepth);
-    highp float o20 = shadow_sample_0(uv20, fragDepth);
-    highp float o30 = shadow_sample_0(uv30, fragDepth);
+    highp float o00 = shadow_sample_0(uv00, compare0);
+    highp float o10 = shadow_sample_0(uv10, compare0);
+    highp float o20 = shadow_sample_0(uv20, compare0);
+    highp float o30 = shadow_sample_0(uv30, compare0);
 
-    highp float o01 = shadow_sample_0(uv01, fragDepth);
-    highp float o11 = shadow_sample_0(uv11, fragDepth);
-    highp float o21 = shadow_sample_0(uv21, fragDepth);
-    highp float o31 = shadow_sample_0(uv31, fragDepth);
+    highp float o01 = shadow_sample_0(uv01, compare0);
+    highp float o11 = shadow_sample_0(uv11, compare0);
+    highp float o21 = shadow_sample_0(uv21, compare0);
+    highp float o31 = shadow_sample_0(uv31, compare0);
 
-    highp float o02 = shadow_sample_0(uv02, fragDepth);
-    highp float o12 = shadow_sample_0(uv12, fragDepth);
-    highp float o22 = shadow_sample_0(uv22, fragDepth);
-    highp float o32 = shadow_sample_0(uv32, fragDepth);
+    highp float o02 = shadow_sample_0(uv02, compare0);
+    highp float o12 = shadow_sample_0(uv12, compare0);
+    highp float o22 = shadow_sample_0(uv22, compare0);
+    highp float o32 = shadow_sample_0(uv32, compare0);
 
-    highp float o03 = shadow_sample_0(uv03, fragDepth);
-    highp float o13 = shadow_sample_0(uv13, fragDepth);
-    highp float o23 = shadow_sample_0(uv23, fragDepth);
-    highp float o33 = shadow_sample_0(uv33, fragDepth);
+    highp float o03 = shadow_sample_0(uv03, compare0);
+    highp float o13 = shadow_sample_0(uv13, compare0);
+    highp float o23 = shadow_sample_0(uv23, compare0);
+    highp float o33 = shadow_sample_0(uv33, compare0);
 
     // Edge tap smoothing
     highp float value = 
@@ -91,6 +91,30 @@ highp float shadow_occlusion_0(highp vec4 pos, highp float bias) {
     return clamp(value / 9.0, 0.0, 1.0);
 }
 
+float shadow_occlusion(highp vec4 light_view_pos0, highp vec4 light_view_pos1, float view_depth, highp float bias) {
+    const float cascadeFadeRange = 0.05;
+    const float endFadeRange = 0.25;
+
+    float occlusion = 0.0;
+    if (view_depth < u_cascade_distances.x) {
+        occlusion = shadow_occlusion_0(light_view_pos0, bias);
+    }
+    if (view_depth > u_cascade_distances.x * (1.0 - cascadeFadeRange) && view_depth < u_cascade_distances.y) {
+        float occlusion1 = shadow_occlusion_1(light_view_pos1, bias);
+
+        // If view_depth is within cascade 0 depth, mix the results
+        occlusion = (view_depth >= u_cascade_distances.x) ? occlusion1 :
+            mix(occlusion1, occlusion, (u_cascade_distances.x - view_depth) / (u_cascade_distances.x * cascadeFadeRange));
+        
+        // If view_depth is within end fade range, fade out
+        if (view_depth > u_cascade_distances.y * (1.0 - endFadeRange)) {
+            occlusion *= (u_cascade_distances.y - view_depth) / (u_cascade_distances.y * endFadeRange);
+        }
+    }
+
+    return occlusion;
+}
+
 vec3 shadowed_color_normal(
     vec3 color, highp vec3 N, highp vec4 light_view_pos0, highp vec4 light_view_pos1, float view_depth) {
     highp float NDotL = dot(N, u_shadow_direction);
@@ -101,11 +125,7 @@ vec3 shadowed_color_normal(
 
     // Slope scale based on http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/
     highp float bias = u_shadow_bias.x + clamp(u_shadow_bias.y * tan(acos(NDotL)), 0.0, u_shadow_bias.z);
-    float occlusion = 0.0;
-    if (view_depth < u_cascade_distances.x)
-        occlusion = shadow_occlusion_0(light_view_pos0, bias);
-    else if (view_depth < u_cascade_distances.y)
-        occlusion = shadow_occlusion_1(light_view_pos1, bias);
+    float occlusion = shadow_occlusion(light_view_pos0, light_view_pos1, view_depth, bias);
 
     float backfacing = 1.0 - smoothstep(0.0, 0.1, NDotL);
     occlusion = mix(occlusion, 1.0, backfacing);
@@ -115,11 +135,7 @@ vec3 shadowed_color_normal(
 
 vec3 shadowed_color(vec3 color, highp vec4 light_view_pos0, highp vec4 light_view_pos1, float view_depth) {
     float bias = 0.0;
-    float occlusion = 0.0;
-    if (view_depth < u_cascade_distances.x)
-        occlusion = shadow_occlusion_0(light_view_pos0, bias);
-    else if (view_depth < u_cascade_distances.y)
-        occlusion = shadow_occlusion_1(light_view_pos1, bias);
+    float occlusion = shadow_occlusion(light_view_pos0, light_view_pos1, view_depth, bias);
 
     color *= 1.0 - (u_shadow_intensity * occlusion);
     return color;


### PR DESCRIPTION
This PR improves the look of shadows by blending between the two shadow cascades and fades out at the end distance of the second cascade.

PR contains shader changes @mapbox/gl-native 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
