### PR TITLE
Optimize globe normalization matrices

### DIFF
--- a/flow-typed/gl-matrix.js
+++ b/flow-typed/gl-matrix.js
@@ -77,6 +77,7 @@ declare module "gl-matrix" {
         create(): Float32Array,
 
         fromScaling<T: Mat4>(T, Vec3): T,
+        fromTranslation<T: Mat4>(T, Vec3): T,
         fromQuat<T: Mat4>(T, Quat): T,
         ortho<T: Mat4>(T, number, number, number, number, number, number): T,
         perspective<T: Mat4>(T, number, number, number, number): T,

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -92,9 +92,7 @@ export default class Globe extends Mercator {
 
     createInversionMatrix(tr: Transform, id: CanonicalTileID): Float32Array {
         const {center} = tr;
-        const matrix = mat4.identity(new Float64Array(16));
-        const encode = globeNormalizeECEF(globeTileBounds(id));
-        mat4.multiply(matrix, matrix, encode);
+        const matrix = globeNormalizeECEF(globeTileBounds(id));
         mat4.rotateY(matrix, matrix, degToRad(center.lng));
         mat4.rotateX(matrix, matrix, degToRad(center.lat));
         mat4.scale(matrix, matrix, [tr._pixelsPerMercatorPixel, tr._pixelsPerMercatorPixel, 1.0]);

--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -418,20 +418,20 @@ export function globeECEFNormalizationScale({min, max}: Aabb): number {
     return GLOBE_NORMALIZATION_MASK / Math.max(max[0] - min[0], max[1] - min[1], max[2] - min[2]);
 }
 
+// avoid redundant allocations by sharing the same typed array for normalization/denormalization matrices;
+// we never use multiple instances of these at the same time, but this might change, so let's be careful here!
+const tempMatrix = new Float64Array(16);
+
 export function globeNormalizeECEF(bounds: Aabb): Float64Array {
-    const m = mat4.identity(new Float64Array(16));
     const scale = globeECEFNormalizationScale(bounds);
-    mat4.scale(m, m, [scale, scale, scale]);
-    mat4.translate(m, m, vec3.negate([], bounds.min));
-    return m;
+    const m = mat4.fromScaling(tempMatrix, [scale, scale, scale]);
+    return mat4.translate(m, m, vec3.negate([], bounds.min));
 }
 
 export function globeDenormalizeECEF(bounds: Aabb): Float64Array {
-    const m = mat4.identity(new Float64Array(16));
+    const m = mat4.fromTranslation(tempMatrix, bounds.min);
     const scale = 1.0 / globeECEFNormalizationScale(bounds);
-    mat4.translate(m, m, bounds.min);
-    mat4.scale(m, m, [scale, scale, scale]);
-    return m;
+    return mat4.scale(m, m, [scale, scale, scale]);
 }
 
 export function globeECEFUnitsToPixelScale(worldSize: number): number {


### PR DESCRIPTION
An attempt to reduce GC pressure by not allocating typed arrays when calculating normalization/denormalization matrices for globe, which are used temporarily anyway and never multiple values at the same time. It's hacky, but does seem to improve performance, although it's hard to measure for sure. 

The `globe-rendering` benchmark results are here: https://sites.mapbox.com/benchmap-js-results/runs/825

It shows a ~1% load time / speed index regression which might be a fluke, but on the other hand, there's a definite improvement on the `frameTimeAverage`. 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
