### PR TITLE
fix running in <iframe sandbox="allow-scripts">

### DIFF
--- a/debug/iframe-sandbox.html
+++ b/debug/iframe-sandbox.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+</head>
+
+<body>
+
+<iframe width="800" height="600" sandbox="allow-scripts" src="index.html"></iframe>
+
+</body>
+</html>

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -44,9 +44,20 @@ function getCacheName(url: string) {
     return cacheName;
 }
 
+function getCaches() {
+    try {
+        return window.caches;
+    } catch (e) {
+        // <iframe sandbox> triggers exceptions when trying to access window.caches
+        // Chrome: DOMException, Safari: SecurityError, Firefox: NS_ERROR_FAILURE
+        // Seems more robust to catch all exceptions instead of trying to match only these.
+    }
+}
+
 function cacheOpen(cacheName: string) {
-    if (window.caches && !sharedCaches[cacheName]) {
-        sharedCaches[cacheName] = window.caches.open(cacheName);
+    const caches = getCaches();
+    if (caches && !sharedCaches[cacheName]) {
+        sharedCaches[cacheName] = caches.open(cacheName);
     }
 }
 
@@ -204,9 +215,10 @@ export function enforceCacheSizeLimit(limit: number) {
 }
 
 export function clearTileCache(callback?: (err: ?Error) => void) {
+    const caches = getCaches();
     const promises = [];
     for (const cache in sharedCaches) {
-        promises.push(window.caches.delete(cache));
+        promises.push(caches.delete(cache));
         delete sharedCaches[cache];
     }
 

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -218,7 +218,7 @@ export function clearTileCache(callback?: (err: ?Error) => void) {
     const caches = getCaches();
     const promises = [];
     for (const cache in sharedCaches) {
-        promises.push(caches.delete(cache));
+        if (caches) promises.push(caches.delete(cache));
         delete sharedCaches[cache];
     }
 


### PR DESCRIPTION
Accessing `window.caches` throws an exception. Silence the exception and don't use the cache. 

We don't have an easy way to add this to CI right now but I created a new debug page to test this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix creating map in an iframe with sandbox attribute.</changelog>`
