### PR TITLE
is-supported-script is supported on iOS/macOS

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3736,7 +3736,9 @@
         "sdk-support": {
           "basic functionality": {
             "js": "0.45.0",
-            "android": "6.6.0"
+            "android": "6.6.0",
+            "ios": "4.1.0",
+            "macos": "0.8.0"
           }
         }
       },


### PR DESCRIPTION
Acknowledged longstanding support for `is-supported-script` on iOS and macOS in the style specification’s SDK support tables.

Fixes #12102.

/cc @mapbox/docs @astojilj