### PR TITLE
Improve performance of symbol placement with globe

### DIFF
--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -91,12 +91,17 @@ export default class Globe extends Mercator {
     }
 
     createInversionMatrix(tr: Transform, id: CanonicalTileID): Float32Array {
+        if (tr._globeMatrixCache[id.key]) {
+            return tr._globeMatrixCache[id.key];
+        }
         const {center} = tr;
         const matrix = globeNormalizeECEF(globeTileBounds(id));
         mat4.rotateY(matrix, matrix, degToRad(center.lng));
         mat4.rotateX(matrix, matrix, degToRad(center.lat));
         mat4.scale(matrix, matrix, [tr._pixelsPerMercatorPixel, tr._pixelsPerMercatorPixel, 1.0]);
-        return Float32Array.from(matrix);
+        const inversionMatrix = Float32Array.from(matrix);
+        tr._globeMatrixCache[id.key] = inversionMatrix;
+        return inversionMatrix;
     }
 
     pointCoordinate(tr: Transform, x: number, y: number, _: number): MercatorCoordinate {

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -91,17 +91,12 @@ export default class Globe extends Mercator {
     }
 
     createInversionMatrix(tr: Transform, id: CanonicalTileID): Float32Array {
-        if (tr._globeMatrixCache[id.key]) {
-            return tr._globeMatrixCache[id.key];
-        }
         const {center} = tr;
         const matrix = globeNormalizeECEF(globeTileBounds(id));
         mat4.rotateY(matrix, matrix, degToRad(center.lng));
         mat4.rotateX(matrix, matrix, degToRad(center.lat));
         mat4.scale(matrix, matrix, [tr._pixelsPerMercatorPixel, tr._pixelsPerMercatorPixel, 1.0]);
-        const inversionMatrix = Float32Array.from(matrix);
-        tr._globeMatrixCache[id.key] = inversionMatrix;
-        return inversionMatrix;
+        return Float32Array.from(matrix);
     }
 
     pointCoordinate(tr: Transform, x: number, y: number, _: number): MercatorCoordinate {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1376,7 +1376,7 @@ class Transform {
     _getBounds3D(): LngLatBounds {
         assert(this.elevation);
         const elevation = ((this.elevation: any): Elevation);
-        if (!elevation.visibleDemTiles.length || elevation._isMockSource()) { return this._getBounds(0, 0); }
+        if (!elevation.visibleDemTiles.length || elevation.isUsingMockSource()) { return this._getBounds(0, 0); }
         const minmax = elevation.visibleDemTiles.reduce((acc, t) => {
             if (t.dem) {
                 const tree = t.dem.tree;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1846,6 +1846,7 @@ class Transform {
         }
 
         this._projMatrixCache = {};
+        this._globeMatrixCache = {};
         this._alignedProjMatrixCache = {};
         this._pixelsToTileUnitsCache = {};
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -137,6 +137,7 @@ class Transform {
     _edgeInsets: EdgeInsets;
     _constraining: boolean;
     _projMatrixCache: {[_: number]: Float32Array};
+    _globeMatrixCache: {[_: number]: Float32Array};
     _alignedProjMatrixCache: {[_: number]: Float32Array};
     _pixelsToTileUnitsCache: {[_: number]: Float32Array};
     _fogTileMatrixCache: {[_: number]: Float32Array};

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -137,7 +137,6 @@ class Transform {
     _edgeInsets: EdgeInsets;
     _constraining: boolean;
     _projMatrixCache: {[_: number]: Float32Array};
-    _globeMatrixCache: {[_: number]: Float32Array};
     _alignedProjMatrixCache: {[_: number]: Float32Array};
     _pixelsToTileUnitsCache: {[_: number]: Float32Array};
     _fogTileMatrixCache: {[_: number]: Float32Array};
@@ -1847,7 +1846,6 @@ class Transform {
         }
 
         this._projMatrixCache = {};
-        this._globeMatrixCache = {};
         this._alignedProjMatrixCache = {};
         this._pixelsToTileUnitsCache = {};
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1376,7 +1376,7 @@ class Transform {
     _getBounds3D(): LngLatBounds {
         assert(this.elevation);
         const elevation = ((this.elevation: any): Elevation);
-        if (!elevation.visibleDemTiles.length) { return this._getBounds(0, 0); }
+        if (!elevation.visibleDemTiles.length || elevation._isMockSource()) { return this._getBounds(0, 0); }
         const minmax = elevation.visibleDemTiles.reduce((acc, t) => {
             if (t.dem) {
                 const tree = t.dem.tree;

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -227,6 +227,13 @@ export class Elevation {
         throw new Error('Pure virtual method called.');
     }
 
+    /*
+     * Whether the SourceCache instance is a mock source cache.
+     * This mock source cache is used solely for the Globe projection and with terrain disabled,
+     * where we only want to leverage the draping rendering pipeline without incurring DEM-tile
+     * download overhead. This function is useful to skip DEM processing as the mock data source
+     * placeholder contains only 0 height.
+     */
     _isMockSource(): boolean {
         throw new Error('Pure virtual method called.');
     }

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -37,7 +37,7 @@ export class Elevation {
      */
     isDataAvailableAtPoint(point: MercatorCoordinate): boolean {
         const sourceCache = this._source();
-        if (!sourceCache || point.y < 0.0 || point.y > 1.0) {
+        if (this._isMockSource() || !sourceCache || point.y < 0.0 || point.y > 1.0) {
             return false;
         }
 
@@ -74,6 +74,10 @@ export class Elevation {
      * Doesn't invoke network request to fetch the data.
      */
     getAtPoint(point: MercatorCoordinate, defaultIfNotLoaded: ?number, exaggerated: boolean = true): number | null {
+        if (this._isMockSource()) {
+            return null;
+        }
+
         // Force a cast to null for both null and undefined
         if (defaultIfNotLoaded == null) defaultIfNotLoaded = null;
 
@@ -133,6 +137,10 @@ export class Elevation {
      * Nearest filter sampling on dem data is done (no interpolation).
      */
     getForTilePoints(tileID: OverscaledTileID, points: Array<Vec3>, interpolated: ?boolean, useDemTile: ?Tile): boolean {
+        if (this._isMockSource()) {
+            return false;
+        }
+
         const helper = DEMSampler.create(this, tileID, useDemTile);
         if (!helper) { return false; }
 
@@ -148,8 +156,16 @@ export class Elevation {
      * @returns {?{min: number, max: number}} The min and max elevation.
      */
     getMinMaxForTile(tileID: OverscaledTileID): ?{min: number, max: number} {
+        if (this._isMockSource()) {
+            return null;
+        }
+
         const demTile = this.findDEMTileFor(tileID);
-        if (!(demTile && demTile.dem)) { return null; }
+
+        if (!(demTile && demTile.dem)) {
+            return null;
+        }
+
         const dem: DEMData = demTile.dem;
         const tree = dem.tree;
         const demTileID = demTile.tileID;
@@ -208,6 +224,10 @@ export class Elevation {
      * order to access already loaded cached tiles.
      */
     _source(): ?SourceCache {
+        throw new Error('Pure virtual method called.');
+    }
+
+    _isMockSource(): boolean {
         throw new Error('Pure virtual method called.');
     }
 

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -37,7 +37,7 @@ export class Elevation {
      */
     isDataAvailableAtPoint(point: MercatorCoordinate): boolean {
         const sourceCache = this._source();
-        if (this._isMockSource() || !sourceCache || point.y < 0.0 || point.y > 1.0) {
+        if (this.isUsingMockSource() || !sourceCache || point.y < 0.0 || point.y > 1.0) {
             return false;
         }
 
@@ -74,7 +74,7 @@ export class Elevation {
      * Doesn't invoke network request to fetch the data.
      */
     getAtPoint(point: MercatorCoordinate, defaultIfNotLoaded: ?number, exaggerated: boolean = true): number | null {
-        if (this._isMockSource()) {
+        if (this.isUsingMockSource()) {
             return null;
         }
 
@@ -137,7 +137,7 @@ export class Elevation {
      * Nearest filter sampling on dem data is done (no interpolation).
      */
     getForTilePoints(tileID: OverscaledTileID, points: Array<Vec3>, interpolated: ?boolean, useDemTile: ?Tile): boolean {
-        if (this._isMockSource()) {
+        if (this.isUsingMockSource()) {
             return false;
         }
 
@@ -156,7 +156,7 @@ export class Elevation {
      * @returns {?{min: number, max: number}} The min and max elevation.
      */
     getMinMaxForTile(tileID: OverscaledTileID): ?{min: number, max: number} {
-        if (this._isMockSource()) {
+        if (this.isUsingMockSource()) {
             return null;
         }
 
@@ -234,7 +234,7 @@ export class Elevation {
      * download overhead. This function is useful to skip DEM processing as the mock data source
      * placeholder contains only 0 height.
      */
-    _isMockSource(): boolean {
+    isUsingMockSource(): boolean {
         throw new Error('Pure virtual method called.');
     }
 

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1426,6 +1426,9 @@ export class Terrain extends Elevation {
     }
 
     findDEMTileFor(tileID: OverscaledTileID): ?Tile {
+        if (this._mockSourceCache) {
+            return null;
+        }
         return this.enabled ? this._findTileCoveringTileID(tileID, this.sourceCache) : null;
     }
 

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -397,6 +397,10 @@ export class Terrain extends Elevation {
         return this.enabled ? this.sourceCache : null;
     }
 
+    _isMockSource(): boolean {
+        return this.sourceCache === this._mockSourceCache;
+    }
+
     // Implements Elevation::exaggeration.
     exaggeration(): number {
         return this._exaggeration;
@@ -1426,9 +1430,6 @@ export class Terrain extends Elevation {
     }
 
     findDEMTileFor(tileID: OverscaledTileID): ?Tile {
-        if (this._mockSourceCache) {
-            return null;
-        }
         return this.enabled ? this._findTileCoveringTileID(tileID, this.sourceCache) : null;
     }
 

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -397,7 +397,7 @@ export class Terrain extends Elevation {
         return this.enabled ? this.sourceCache : null;
     }
 
-    _isMockSource(): boolean {
+    isUsingMockSource(): boolean {
         return this.sourceCache === this._mockSourceCache;
     }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -439,7 +439,7 @@ test('Map', (t) => {
                     t.equal(initStyleObj.setTerrain.callCount, 1);
                     t.ok(map.style.terrain);
                     t.equal(map.getTerrain(), null);
-                    t.true(map.painter._terrain._isMockSource());
+                    t.true(map.painter._terrain.isUsingMockSource());
                     t.equal(map.getStyle().terrain, undefined);
                     t.end();
                 });
@@ -617,13 +617,13 @@ test('Map', (t) => {
                     'maxzoom': 14
                 });
                 map.once('render', () => {
-                    t.true(map.painter._terrain._isMockSource());
+                    t.true(map.painter._terrain.isUsingMockSource());
                     map.setTerrain({'source': 'mapbox-dem'});
                     map.once('render', () => {
-                        t.false(map.painter._terrain._isMockSource());
+                        t.false(map.painter._terrain.isUsingMockSource());
                         map.setTerrain(null);
                         map.once('render', () => {
-                            t.true(map.painter._terrain._isMockSource());
+                            t.true(map.painter._terrain.isUsingMockSource());
                             t.end();
                         });
                     });
@@ -644,12 +644,12 @@ test('Map', (t) => {
                 });
                 map.setTerrain({'source': 'mapbox-dem'});
                 map.once('render', () => {
-                    t.false(map.painter._terrain._isMockSource());
+                    t.false(map.painter._terrain.isUsingMockSource());
                     map.setProjection('globe');
-                    t.false(map.painter._terrain._isMockSource());
+                    t.false(map.painter._terrain.isUsingMockSource());
                     map.setTerrain(null);
                     map.once('render', () => {
-                        t.true(map.painter._terrain._isMockSource());
+                        t.true(map.painter._terrain.isUsingMockSource());
                         t.end();
                     });
                 });


### PR DESCRIPTION
When globe is enabled, we use a mock DEM data source cache as a placeholder to leverage the draping architecture (in order to capture tiled texture to render as raster).

For most cases, globe is enabled without terrain exaggeration and makes use of this mocked mode by default. This PR reduces unnecessary workload related to DEM sampling under this code path, which improves placement time by up to ~20ms. This will have the effect of running placement more often as this is a task deferred across multiple frames using pauseable placement.

Another useful metric could to be count how many times placement has been run across a fixture in benchmap.

Full benchmark fixture run can be seen at: https://sites.mapbox.com/benchmap-js-results/runs/834

![Screenshot from 2022-07-21 13-08-35](https://user-images.githubusercontent.com/7061573/180306405-f71e2196-f3da-494a-bd8d-d4d01df76543.png)


<details><summary>Diagnostic metrics summary</summary>

![sites mapbox com_benchmap-js-results_runs_834 (1)](https://user-images.githubusercontent.com/7061573/180306161-9850c937-0e12-468f-8e27-7b1ce8fbef88.png)

</details>

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve symbol placement performance with globe projection</changelog>`
