### PR TITLE
Fix mismatching zoom on first interaction in `globe` view

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -258,14 +258,13 @@ class Transform {
 
     setMercatorFromTransition(): boolean {
         const oldProjection = this.projection.name;
-
         this.mercatorFromTransition = true;
         this.projectionOptions = {name: 'mercator'};
         this.projection = getProjection({name: 'mercator'});
-
         const projectionHasChanged = oldProjection !== 'mercator';
-        if (projectionHasChanged) this._calcMatrices();
-
+        if (projectionHasChanged) {
+            this._calcMatrices();
+        }
         return projectionHasChanged;
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -257,8 +257,16 @@ class Transform {
     }
 
     setMercatorFromTransition(): boolean {
+        const oldProjection = this.projection.name;
+
         this.mercatorFromTransition = true;
-        return this.setProjection({name: 'mercator'});
+        this.projectionOptions = {name: 'mercator'};
+        this.projection = getProjection({name: 'mercator'});
+
+        const projectionHasChanged = oldProjection !== 'mercator';
+        if (projectionHasChanged) this._calcMatrices();
+
+        return projectionHasChanged;
     }
 
     get minZoom(): number { return this._minZoom; }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -261,7 +261,7 @@ class Transform {
         this.mercatorFromTransition = true;
         this.projectionOptions = {name: 'mercator'};
         this.projection = getProjection({name: 'mercator'});
-        const projectionHasChanged = oldProjection !== 'mercator';
+        const projectionHasChanged = oldProjection !== this.projection.name;
         if (projectionHasChanged) {
             this._calcMatrices();
         }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -259,8 +259,7 @@ class Transform {
     setMercatorFromTransition(): boolean {
         const oldProjection = this.projection.name;
         this.mercatorFromTransition = true;
-        this.projectionOptions = {name: 'mercator'};
-        this.projection = getProjection(this.projectionOptions);
+        this.setProjection({name: 'mercator'});
         return (oldProjection !== 'mercator');
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -257,10 +257,8 @@ class Transform {
     }
 
     setMercatorFromTransition(): boolean {
-        const oldProjection = this.projection.name;
         this.mercatorFromTransition = true;
-        this.setProjection({name: 'mercator'});
-        return (oldProjection !== 'mercator');
+        return this.setProjection({name: 'mercator'});
     }
 
     get minZoom(): number { return this._minZoom; }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1196,11 +1196,10 @@ class Map extends Camera {
         const projection = tr.projection.name;
         let projectionHasChanged;
 
-        if (projection.name === 'globe' && tr.zoom >= GLOBE_ZOOM_THRESHOLD_MAX) {
+        if (projection === 'globe' && tr.zoom >= GLOBE_ZOOM_THRESHOLD_MAX) {
             tr.setMercatorFromTransition();
             projectionHasChanged = true;
-
-        } else if (projection.name === 'mercator' && tr.zoom < GLOBE_ZOOM_THRESHOLD_MAX) {
+        } else if (projection === 'mercator' && tr.zoom < GLOBE_ZOOM_THRESHOLD_MAX) {
             tr.setProjection({name: 'globe'});
             projectionHasChanged = true;
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1196,11 +1196,11 @@ class Map extends Camera {
         const projection = tr.projection.name;
         let projectionHasChanged;
 
-        if (projection === 'globe' && tr.zoom >= GLOBE_ZOOM_THRESHOLD_MAX) {
+        if (projection.name === 'globe' && tr.zoom >= GLOBE_ZOOM_THRESHOLD_MAX) {
             tr.setMercatorFromTransition();
             projectionHasChanged = true;
 
-        } else if (projection === 'mercator' && tr.zoom < GLOBE_ZOOM_THRESHOLD_MAX) {
+        } else if (projection.name === 'mercator' && tr.zoom < GLOBE_ZOOM_THRESHOLD_MAX) {
             tr.setProjection({name: 'globe'});
             projectionHasChanged = true;
         }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1819,15 +1819,24 @@ test('Map', (t) => {
 
         t.test('Crossing globe-to-mercator zoom threshold sets mercator transition and calculates matrices', (t) => {
             const map = createMap(t, {projection: 'globe'});
+
             map.on('load', () => {
+
                 t.spy(map.transform, 'setMercatorFromTransition');
                 t.spy(map.transform, '_calcMatrices');
+
+                t.equal(map.transform.setMercatorFromTransition.callCount, 0);
+                t.equal(map.transform.mercatorFromTransition, false);
+                t.equal(map.transform._calcMatrices.callCount, 0);
+
                 map.setZoom(7);
+
                 map.once('render', () => {
                     t.equal(map.transform.setMercatorFromTransition.callCount, 1);
                     t.equal(map.transform.mercatorFromTransition, true);
                     t.equal(map.transform._calcMatrices.callCount, 3);
                     t.end();
+
                 });
             });
         });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1828,9 +1828,9 @@ test('Map', (t) => {
                     t.equal(map.transform.mercatorFromTransition, true);
                     t.equal(map.transform._calcMatrices.callCount, 3);
                     t.end();
-                })
-            })
-        })
+                });
+            });
+        });
 
         t.test('Changing zoom on globe does not clear tiles', (t) => {
             const map = createMap(t, {projection: 'globe'});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1817,6 +1817,21 @@ test('Map', (t) => {
             });
         });
 
+        t.test('Crossing globe-to-mercator zoom threshold sets mercator transition and calculates matrices', (t) => {
+            const map = createMap(t, {projection: 'globe'});
+            map.on('load', () => {
+                t.spy(map.transform, 'setMercatorFromTransition');
+                t.spy(map.transform, '_calcMatrices');
+                map.setZoom(7);
+                map.once('render', () => {
+                    t.equal(map.transform.setMercatorFromTransition.callCount, 1);
+                    t.equal(map.transform.mercatorFromTransition, true);
+                    t.equal(map.transform._calcMatrices.callCount, 3);
+                    t.end();
+                })
+            })
+        })
+
         t.test('Changing zoom on globe does not clear tiles', (t) => {
             const map = createMap(t, {projection: 'globe'});
             t.spy(map.painter, 'clearBackgroundTiles');


### PR DESCRIPTION
A regression was introduced by https://github.com/mapbox/mapbox-gl-js/commit/d57036a4dbe0db1209f5a60930c49ce9188a1ab9 that shifts the camera on the first pan interaction when a map is set with `globe` and zoom is past 6. 

This was specifically introduced by a change that separated the logic of setting the projection to mercator when the passing the globe-to-mercator zoom threshold from `updateProjection`. Previously, the logic called [`setProjection`](https://github.com/mapbox/mapbox-gl-js/commit/d57036a4dbe0db1209f5a60930c49ce9188a1ab9#diff-f62d8d42ec7424781f2e987a61684959e1bc794c67f75cd33548bd4a62c73028L1201) which called `map.transform._calcMatrices`; however, the new logic did not include a call to `map.transform._calcMatrices` which caused a misalignment, giving the zoom shift effect.

This change adds calling `map.transform._calcMatrices` when the projection has changed during a call to setMercatorFromTransition.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
