### PR TITLE
check for event.cancelable in touch events

### DIFF
--- a/src/ui/handler/touch_pan.js
+++ b/src/ui/handler/touch_pan.js
@@ -54,7 +54,9 @@ export default class TouchPanHandler {
             }
         }
 
-        e.preventDefault();
+        if (e.cancelable) {
+          e.preventDefault();
+        }
 
         return this._calculateTransform(e, points, mapTouches);
     }


### PR DESCRIPTION
Chrome has started warning when canceling an event that cannot be cancelled, like scrolling.
This causes a fair bit of log spam. I know it fires for touchmove and touchend and there's 
reports that it also fires for touchstart.

    IgnoredEventCancel: intervention: Ignored attempt to cancel a touchmove event with
    cancelable=false, for example because scrolling is in progress and cannot be interrupted

References:

- https://github.com/react-grid-layout/react-draggable/issues/553
- https://www.uriports.com/blog/easy-fix-for-intervention-ignored-attempt-to-cancel-a-touchmove-event-with-cancelable-false/
- https://github.com/FL3NKEY/scroll-lock/issues/19
- https://stackoverflow.com/a/53315365/30900

Fixes #11961.
