### PR TITLE
Fix "improve map" link to include location when hash is disabled

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -3,6 +3,7 @@
 import * as DOM from '../../util/dom.js';
 import {bindAll} from '../../util/util.js';
 import config from '../../util/config.js';
+import {getHashString} from '../hash.js';
 
 import type Map, {ControlPosition} from '../map.js';
 
@@ -131,7 +132,7 @@ class AttributionControl {
                 }
                 return acc;
             }, `?`);
-            editLink.href = `${config.FEEDBACK_URL}/${paramString}${this._map._hash ? this._map._hash.getHashString(true) : ''}`;
+            editLink.href = `${config.FEEDBACK_URL}/${paramString}#${getHashString(this._map, true)}`;
             editLink.rel = 'noopener nofollow';
             this._setElementTitle(editLink, 'MapFeedback');
         }

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -12,7 +12,7 @@ import type Map from './map.js';
  *
  * @returns {Hash} `this`
  */
-class Hash {
+export default class Hash {
     _map: ?Map;
     _updateHash: () => ?TimeoutID;
     _hashName: ?string;
@@ -58,29 +58,11 @@ class Hash {
         return this;
     }
 
-    getHashString(mapFeedback?: boolean): string {
+    getHashString(): string {
         const map = this._map;
         if (!map) return '';
-        const center = map.getCenter(),
-            zoom = Math.round(map.getZoom() * 100) / 100,
-            // derived from equation: 512px * 2^z / 360 / 10^d < 0.5px
-            precision = Math.ceil((zoom * Math.LN2 + Math.log(512 / 360 / 0.5)) / Math.LN10),
-            m = Math.pow(10, precision),
-            lng = Math.round(center.lng * m) / m,
-            lat = Math.round(center.lat * m) / m,
-            bearing = map.getBearing(),
-            pitch = map.getPitch();
-        let hash = '';
-        if (mapFeedback) {
-            // new map feedback site has some constraints that don't allow
-            // us to use the same hash format as we do for the Map hash option.
-            hash += `/${lng}/${lat}/${zoom}`;
-        } else {
-            hash += `${zoom}/${lat}/${lng}`;
-        }
 
-        if (bearing || pitch) hash += (`/${Math.round(bearing * 10) / 10}`);
-        if (pitch) hash += (`/${Math.round(pitch)}`);
+        const hash = getHashString(map);
 
         if (this._hashName) {
             const hashName = this._hashName;
@@ -142,7 +124,25 @@ class Hash {
         const location = window.location.href.replace(/(#.+)?$/, this.getHashString());
         window.history.replaceState(window.history.state, null, location);
     }
-
 }
 
-export default Hash;
+export function getHashString(map: Map, mapFeedback?: boolean): string {
+    const center = map.getCenter(),
+        zoom = Math.round(map.getZoom() * 100) / 100,
+        // derived from equation: 512px * 2^z / 360 / 10^d < 0.5px
+        precision = Math.ceil((zoom * Math.LN2 + Math.log(512 / 360 / 0.5)) / Math.LN10),
+        m = Math.pow(10, precision),
+        lng = Math.round(center.lng * m) / m,
+        lat = Math.round(center.lat * m) / m,
+        bearing = map.getBearing(),
+        pitch = map.getPitch();
+
+    // new map feedback site has some constraints that don't allow
+    // us to use the same hash format as we do for the Map hash option.
+    let hash = mapFeedback ? `/${lng}/${lat}/${zoom}` : `${zoom}/${lat}/${lng}`;
+
+    if (bearing || pitch) hash += (`/${Math.round(bearing * 10) / 10}`);
+    if (pitch) hash += (`/${Math.round(pitch)}`);
+
+    return hash;
+}

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -14,8 +14,7 @@ function createMap(t) {
             layers: [],
             owner: 'mapbox',
             id: 'streets-v10',
-        },
-        hash: true
+        }
     });
 }
 


### PR DESCRIPTION
As suggested by @Andygol, this PR fixes the "Improve this map" link to include current map location even if the map `hash` option is disabled (which is the default). This seemed like an easy low hanging fruit to improve the number of map contributions through our [Contribute page](https://www.mapbox.com/contribute/).

<img width="857" alt="image" src="https://user-images.githubusercontent.com/25395/181559046-14e83cc1-fef4-40bf-894f-8ee2c6c9f1d7.png">

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix "improve map" link in the attribution to include location even if map hash is disabled</changelog>`
