### PR TITLE
Fix abrupt jump with globe view + maxBounds after transition to mercator

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1617,7 +1617,7 @@ class Transform {
         if (!this.center || !this.width || !this.height || this._constraining) return;
 
         this._constraining = true;
-        const isGlobe = this.projection.name === 'globe';
+        const isGlobe = this.projection.name === 'globe' || this.mercatorFromTransition;
 
         // alternate constraining for non-Mercator projections
         if (this.projection.isReprojectedInTileSpace || isGlobe) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -824,6 +824,9 @@ class Map extends Camera {
      * as close as possible to the operation's request while still
      * remaining within the bounds.
      *
+     * For `mercator` projection, the viewport will be constrained to the bounds.
+     * For other projections such as `globe`, only the map center will be constrained.
+     *
      * @param {LngLatBoundsLike | null | undefined} bounds The maximum bounds to set. If `null` or `undefined` is provided, the function removes the map's maximum bounds.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example


### PR DESCRIPTION
Quick follow-up to #12114. Make sure the constraining logic is the same throughout the zoom range for the globe view so that there are no abrupt jumps when zooming in. We don't have to be very precise here because it doesn't make sense to use `maxBounds` on higher zoom levels coupled with the globe view anyway (the advantage of the latter disappears).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
