### PR TITLE
Make ambient occlusion and edge radius private in the style-spec

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -880,6 +880,7 @@
     },
     "fill-extrusion-edge-radius": {
       "type": "number",
+      "private": true,
       "default": 0,
       "minimum": 0,
       "maximum": 1,
@@ -4674,6 +4675,7 @@
     "fill-extrusion-ambient-occlusion-intensity": {
       "property-type": "data-constant",
       "type": "number",
+      "private": true,
       "default": 0.0,
       "minimum": 0,
       "maximum": 1,
@@ -4696,6 +4698,7 @@
     "fill-extrusion-ambient-occlusion-radius": {
       "property-type": "data-constant",
       "type": "number",
+      "private": true,
       "default": 3.0,
       "minimum": 0,
       "expression": {

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -93,7 +93,8 @@ function validSchema(k, t, obj, ref, version, kind) {
         'period',
         'requires',
         'sdk-support',
-        'overridable'
+        'overridable',
+        'private'
     ];
 
     // Schema object.


### PR DESCRIPTION
This PR makes fill extrusion's ambient occlusion and edge radius private in the style-spec package, making #12134 and #12135 obsolete. PR will land into the `main`, so we can intentionally make these changes public later. I  will cherry-pick it in the [release-v2.10.0](https://github.com/mapbox/mapbox-gl-js/tree/release-v2.10.0) branch after the merge.