### PR TITLE
Fix blank globe on Android by reverting "Prevent unnecessary terrain define with globe"

### DIFF
--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -385,7 +385,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         const invMatrix = bucket.getProjection().createInversionMatrix(tr, coord.canonical);
 
         const baseDefines = ([]: any);
-        if (painter.terrainRenderModeElevated() && pitchWithMap) {
+        if (painter.terrain && pitchWithMap) {
             baseDefines.push('PITCH_WITH_MAP_TERRAIN');
         }
         if (bucketIsGlobeProjection) {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -846,11 +846,6 @@ class Painter {
         return !imagePosA || !imagePosB;
     }
 
-    terrainRenderModeElevated(): boolean {
-        // Whether elevation sampling should be enabled in the vertex shader.
-        return this.style && !!this.style.getTerrain() && !!this.terrain && !this.terrain.renderingToTexture;
-    }
-
     /**
      * Returns #defines that would need to be injected into every Program
      * based on the current state of Painter.
@@ -859,11 +854,12 @@ class Painter {
      * @private
      */
     currentGlobalDefines(): string[] {
+        const terrain = this.terrain && !this.terrain.renderingToTexture; // Enables elevation sampling in vertex shader.
         const rtt = this.terrain && this.terrain.renderingToTexture;
         const fog = this.style && this.style.fog;
         const defines = [];
 
-        if (this.terrainRenderModeElevated()) defines.push('TERRAIN');
+        if (terrain) defines.push('TERRAIN');
         // When terrain is active, fog is rendered as part of draping, not as part of tile
         // rendering. Removing the fog flag during tile rendering avoids additional defines.
         if (fog && !rtt && fog.getOpacity(this.transform.pitch) !== 0.0) {


### PR DESCRIPTION
This reverts commit 7aa71e9af52971ffab762c4bcdca4fdac146963d.

Fixes a regression introduced in https://github.com/mapbox/mapbox-gl-js/pull/12039 where the globe (without terrain and at low zoom) shows up blank on Android devices. Tested in Chrome and Firefox.

Before:
![Screenshot from 2022-08-10 11-06-57](https://user-images.githubusercontent.com/14878684/183974049-cdd6524b-1b40-4de7-9156-2bb039adb44d.png)

After:

![Screenshot from 2022-08-10 11-08-39](https://user-images.githubusercontent.com/14878684/183974301-920a9bed-d3b0-4ae5-8980-2f0579135c9c.png)

Benchmark [here](https://sites.mapbox.com/benchmap-js-results/runs/886)

Fixing on main tracked in https://github.com/mapbox/mapbox-gl-js/pull/12152

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] document any changes to public APIs
 - [x] post benchmark scores
 - [X] manually test the debug page
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
