### PR TITLE
Fix terrain "source" error being fired when using `map.getStyle()` with globe view

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1222,12 +1222,13 @@ class Style extends Evented {
                 sources[source.id] = source.serialize();
             }
         }
+
         return filterObject({
             version: this.stylesheet.version,
             name: this.stylesheet.name,
             metadata: this.stylesheet.metadata,
             light: this.stylesheet.light,
-            terrain: this.stylesheet.terrain,
+            terrain: this.getTerrain(),
             fog: this.stylesheet.fog,
             center: this.stylesheet.center,
             zoom: this.stylesheet.zoom,
@@ -1446,7 +1447,7 @@ class Style extends Evented {
     }
 
     getTerrain(): ?TerrainSpecification {
-        return this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.elevated ? this.terrain.get() : null;
+        return this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.elevated ? this.terrain.get() : undefined;
     }
 
     setTerrainForDraping() {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1228,7 +1228,7 @@ class Style extends Evented {
             name: this.stylesheet.name,
             metadata: this.stylesheet.metadata,
             light: this.stylesheet.light,
-            terrain: this.getTerrain(),
+            terrain: this.getTerrain() || undefined,
             fog: this.stylesheet.fog,
             center: this.stylesheet.center,
             zoom: this.stylesheet.zoom,
@@ -1447,7 +1447,7 @@ class Style extends Evented {
     }
 
     getTerrain(): ?TerrainSpecification {
-        return this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.elevated ? this.terrain.get() : undefined;
+        return this.terrain && this.terrain.drapeRenderMode === DrapeRenderMode.elevated ? this.terrain.get() : null;
     }
 
     setTerrainForDraping() {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -383,6 +383,7 @@ test('Map', (t) => {
                     t.equal(initStyleObj.setTerrain.callCount, 1);
                     t.ok(map.style.terrain);
                     t.equal(map.getTerrain(), undefined);
+                    t.equal(map.getStyle().terrain, undefined);
                     t.end();
                 });
             });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -340,7 +340,8 @@ test('Map', (t) => {
             map.on('style.load', () => {
                 t.equal(initStyleObj.setTerrain.callCount, 1);
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getStyle().terrain, undefined);
                 t.end();
             });
         });
@@ -355,7 +356,8 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(initStyleObj.setTerrain.callCount, 1);
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getStyle().terrain, undefined);
                 map.setZoom(12); // Above threshold for Mercator transition
                 map.once('render', () => {
                     t.notOk(map.style.terrain);
@@ -374,12 +376,13 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(initStyleObj.setTerrain.callCount, 0);
                 t.notOk(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getStyle().terrain, undefined);
                 map.setZoom(3); // Below threshold for Mercator transition
                 map.once('render', () => {
                     t.equal(initStyleObj.setTerrain.callCount, 1);
                     t.ok(map.style.terrain);
-                    t.equal(map.getTerrain(), null);
+                    t.equal(map.getTerrain(), undefined);
                     t.end();
                 });
             });
@@ -394,7 +397,7 @@ test('Map', (t) => {
                 map.setTerrain(null);
                 t.equal(initStyleObj.setTerrain.callCount, 2);
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
                 t.end();
             });
         });
@@ -454,14 +457,14 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
                 // Should not overwrite style: https://github.com/mapbox/mapbox-gl-js/issues/11939
                 t.equal(style.terrain, undefined);
                 map.remove();
 
                 map = new Map({style, container: div, testMode: true});
                 t.equal(map.getProjection().name, 'mercator');
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
                 t.equal(style.terrain, undefined);
                 t.end();
             });
@@ -475,13 +478,13 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
 
                 const style2 = createStyle();
                 map.setStyle(style2);
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), null);
+                t.equal(map.getTerrain(), undefined);
 
                 t.end();
             });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -340,7 +340,7 @@ test('Map', (t) => {
             map.on('style.load', () => {
                 t.equal(initStyleObj.setTerrain.callCount, 1);
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
                 t.equal(map.getStyle().terrain, undefined);
                 t.end();
             });
@@ -356,7 +356,7 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(initStyleObj.setTerrain.callCount, 1);
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
                 t.equal(map.getStyle().terrain, undefined);
                 map.setZoom(12); // Above threshold for Mercator transition
                 map.once('render', () => {
@@ -376,13 +376,13 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(initStyleObj.setTerrain.callCount, 0);
                 t.notOk(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
                 t.equal(map.getStyle().terrain, undefined);
                 map.setZoom(3); // Below threshold for Mercator transition
                 map.once('render', () => {
                     t.equal(initStyleObj.setTerrain.callCount, 1);
                     t.ok(map.style.terrain);
-                    t.equal(map.getTerrain(), undefined);
+                    t.equal(map.getTerrain(), null);
                     t.equal(map.getStyle().terrain, undefined);
                     t.end();
                 });
@@ -398,7 +398,7 @@ test('Map', (t) => {
                 map.setTerrain(null);
                 t.equal(initStyleObj.setTerrain.callCount, 2);
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
                 t.end();
             });
         });
@@ -458,14 +458,14 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
                 // Should not overwrite style: https://github.com/mapbox/mapbox-gl-js/issues/11939
                 t.equal(style.terrain, undefined);
                 map.remove();
 
                 map = new Map({style, container: div, testMode: true});
                 t.equal(map.getProjection().name, 'mercator');
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
                 t.equal(style.terrain, undefined);
                 t.end();
             });
@@ -479,13 +479,13 @@ test('Map', (t) => {
                 map.setProjection('globe');
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
 
                 const style2 = createStyle();
                 map.setStyle(style2);
                 t.equal(map.getProjection().name, 'globe');
                 t.ok(map.style.terrain);
-                t.equal(map.getTerrain(), undefined);
+                t.equal(map.getTerrain(), null);
 
                 t.end();
             });


### PR DESCRIPTION
Closes #11553.

In order to enable draping with globe view, we mock a terrain source like this: `const mockTerrainOptions = {source: '', exaggeration: 0};`. This mocked terrain is returned in the `map.getStyle()`. 

If a user decides to use set the map's style with `map.getStyle()` it will trigger a terrain error while validating the terrain source. It is not useful/meaningful to the user to see the mocked terrain source in the returned value from `map.getStyle()` and therefore should hide it from being returned in `map.getStyle()`. To do so, I use in the `style.getTerrain()` to return the value of terrain in the `serialize` function, which should mimic the behavior of other projections when terrain is not set (e.g. return 'undefined').

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix terrain error being fired when using map.getStyle() with globe view</changelog>`
