### PR TITLE
Allowing two-finger pitch with cooperative gestures in fullscreen

### DIFF
--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -4,6 +4,7 @@ import Point from '@mapbox/point-geometry';
 import * as DOM from '../../util/dom.js';
 import type Map from '../map.js';
 import type {HandlerResult} from '../handler_manager.js';
+import {isFullscreen} from '../../util/util.js';
 
 class TwoTouchHandler {
 
@@ -237,7 +238,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
         const vectorA = points[0].sub(lastPoints[0]);
         const vectorB = points[1].sub(lastPoints[1]);
 
-        if (this._map._cooperativeGestures && e.touches.length < 3) return;
+        if (this._map._cooperativeGestures && !isFullscreen() && e.touches.length < 3) return;
 
         this._valid = this.gestureBeginsVertically(vectorA, vectorB, e.timeStamp);
 


### PR DESCRIPTION
Follow up to #12058, which fixed cooperative gestures dragging behavior and warning message incorrectly appearing in fullscreen on mobile (#11635). A small oversight was that the cooperative gestures still applied to touch pitch, making them require 3 instead of 2 fingers, which causes two finger interactions to instead pan the map. This PR makes fullscreen behavior consistent with maps without cooperative gestures.

Also adds previously missing tests for touch pitch.

Here I test a two-finger drag on Android:

## Before fix:
[pitch-broken.webm](https://user-images.githubusercontent.com/14878684/184451537-11988215-22d8-4c0b-a019-671ba6f13308.webm)

## After fix:
[pitch-fixed.webm](https://user-images.githubusercontent.com/14878684/184451532-5289d154-6e16-4e20-bac7-c2b73bdd3584.webm)

## Launch Checklist

 - [X] briefly describe the changes in this PR
 - [X] include before/after visuals or gifs if this PR includes visual changes
 - [X] write tests for all new functionality
 - [X] manually test the debug page
 - [X] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [X] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix incorrectly requiring three finger drags to change pitch with cooperative gestures while in fullscreen.</changelog>`
