### PR TITLE
Move `preloadOnly` to AnimationOptions

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -99,6 +99,7 @@ export type FullCameraOptions = {
  * @property {boolean} animate If `false`, no animation will occur.
  * @property {boolean} essential If `true`, then the animation is considered essential and will not be affected by
  *   [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
+ * @property {boolean} preloadOnly If `true`, it will trigger tiles loading across the animation path, but no animation will occur.
  * @see [Example: Slowly fly to a location](https://docs.mapbox.com/mapbox-gl-js/example/flyto-options/)
  * @see [Example: Customize camera animations](https://docs.mapbox.com/mapbox-gl-js/example/camera-animation/)
  * @see [Example: Navigate the map with game-like controls](https://docs.mapbox.com/mapbox-gl-js/example/game-controls/)
@@ -108,7 +109,8 @@ export type AnimationOptions = {
     easing?: (_: number) => number,
     offset?: PointLike,
     animate?: boolean,
-    essential?: boolean
+    essential?: boolean,
+    preloadOnly?: boolean
 };
 
 export type EasingOptions = CameraOptions & AnimationOptions;
@@ -988,7 +990,7 @@ class Camera extends Evented {
      * @see [Example: Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
      * @see [Example: Update a feature in realtime](https://docs.mapbox.com/mapbox-gl-js/example/live-update-feature/)
      */
-    jumpTo(options: CameraOptions & {preloadOnly?: boolean}, eventData?: Object): this {
+    jumpTo(options: CameraOptions & {preloadOnly?: $PropertyType<AnimationOptions, 'preloadOnly'>}, eventData?: Object): this {
         this.stop();
 
         const tr = options.preloadOnly ? this.transform.clone() : this.transform;
@@ -1194,7 +1196,7 @@ class Camera extends Evented {
      * });
      * @see [Example: Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
      */
-    easeTo(options: EasingOptions & {easeId?: string, preloadOnly?: boolean}, eventData?: Object): this {
+    easeTo(options: EasingOptions & {easeId?: string}, eventData?: Object): this {
         this._stop(false, options.easeId);
 
         options = extend({
@@ -1445,7 +1447,7 @@ class Camera extends Evented {
      * @see [Example: Slowly fly to a location](https://www.mapbox.com/mapbox-gl-js/example/flyto-options/)
      * @see [Example: Fly to a location based on scroll position](https://www.mapbox.com/mapbox-gl-js/example/scroll-fly-to/)
      */
-    flyTo(options: EasingOptions & {preloadOnly?: boolean}, eventData?: Object): this {
+    flyTo(options: EasingOptions, eventData?: Object): this {
         // Fall through to jumpTo if user has set prefers-reduced-motion
         if (!options.essential && browser.prefersReducedMotion) {
             const coercedOptions = pick(options, ['center', 'zoom', 'bearing', 'pitch', 'around']);

--- a/src/ui/handler_inertia.js
+++ b/src/ui/handler_inertia.js
@@ -69,7 +69,7 @@ export default class HandlerInertia {
             inertia.shift();
     }
 
-    _onMoveEnd(panInertiaOptions?: DragPanOptions): ?(EasingOptions & {easeId?: string, preloadOnly?: boolean}) {
+    _onMoveEnd(panInertiaOptions?: DragPanOptions): ?(EasingOptions & {easeId?: string}) {
         this._drainInertiaBuffer();
         if (this._inertiaBuffer.length < 2) {
             return;


### PR DESCRIPTION
This PR moves the` preloadOnly` option to `AnimationOptions` and adds the JSDoc description

<img width="650" alt="Screen Shot 2022-08-19 at 16 26 13" src="https://user-images.githubusercontent.com/533564/185629373-1c61ce96-4054-4b18-b44b-6b696ad2ea3b.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
