### PR TITLE
Fix error in shadow edge tap smoothing calculation

### DIFF
--- a/src/shaders/_prelude_shadow.fragment.glsl
+++ b/src/shaders/_prelude_shadow.fragment.glsl
@@ -85,7 +85,7 @@ highp float shadow_occlusion_0(highp vec4 pos, highp float bias) {
         f.x * (o31 + o32) +
         (1.0 - f.x) * f.y * o03 +
         f.y * (o13 + o23) +
-        f.x * f.x * o33 +
+        f.x * f.y * o33 +
         o11 + o21 + o12 + o22;
 
     return clamp(value / 9.0, 0.0, 1.0);


### PR DESCRIPTION
There was a small error in the edge tap smoothing calculation. It caused the shadow to be slightly uneven in strength. This was almost unnoticeable in normal circumstances, because the error after clamping was at most -3.5 %. In the metal shader debugger the issue can be seen quite clearly.

![Screenshot 2022-08-22 at 13 34 13](https://user-images.githubusercontent.com/4976209/185902773-0805e349-c366-4def-b91a-a8d02aa2f4e4.png)

After the fix, the shadowing is flat as it should be.

![Screenshot 2022-08-22 at 13 37 57](https://user-images.githubusercontent.com/4976209/185902787-114345bb-995c-4c21-95a3-a1c28552c783.png)

PR contains shader changes @mapbox/gl-native 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
