### PR TITLE
Updating READMEs and version numbers for v2.10.0 final release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,21 @@
-## 2.10.0-beta.1
+## 2.10.0
 
 ## Features ✨ and improvements 🏁
+* Add new marker styling option rotationAlignment: 'horizon' allowing marker rotation to match the curvature of the horizon in globe view ([#11894](https://github.com/mapbox/mapbox-gl-js/pull/11894))
+* Improve panning precision on Globe View and relax constraints on lower zoom levels ([#12114](https://github.com/mapbox/mapbox-gl-js/pull/12114))
+* Add unit option to number-format expression ([#11839](https://github.com/mapbox/mapbox-gl-js/pull/11839)) (h/t [varna](https://github.com/varna))
+* Add screen reader alert for cooperative gestures warning message. ([#12058](https://github.com/mapbox/mapbox-gl-js/pull/12058))
 * Improve rendering performance on globe view ([#12050](https://github.com/mapbox/mapbox-gl-js/pull/12050))
 * Improve tile loading performance on low zoom levels ([#12061](https://github.com/mapbox/mapbox-gl-js/pull/12061))
 * Improve globe-mercator transition and map load performance with globe projection ([#12039](https://github.com/mapbox/mapbox-gl-js/pull/12039))
-* Improve panning precision on Globe View and relax constraints on lower zoom levels ([#12114](https://github.com/mapbox/mapbox-gl-js/pull/12114))
 
 
 ## Bug fixes 🐞
-* Fix a bug where id expression didn't work for 0 values ([#12000](https://github.com/mapbox/mapbox-gl-js/pull/12000))
+* Fix a bug where `id` expression didn't correctly handle a value of 0 ([#12000](https://github.com/mapbox/mapbox-gl-js/pull/12000))
 * Fix precision errors in depth pack/unpack ([#12005](https://github.com/mapbox/mapbox-gl-js/pull/12005))
 * Fix `cooperativeGestures` preventing panning on mobile while in fullscreen. ([#12058](https://github.com/mapbox/mapbox-gl-js/pull/12058))
-* Add screen reader alert for cooperative gestures warning message. ([#12058](https://github.com/mapbox/mapbox-gl-js/pull/12058))
-* Fix clearing raster tiles when toggling `setStyle` with a globe projection ([#12049](https://github.com/mapbox/mapbox-gl-js/pull/12049))
-* Fix creating map in an iframe with sandbox attribute. ([#12101](https://github.com/mapbox/mapbox-gl-js/pull/12101))
+* Fix misplaced raster tiles after toggling `setStyle` with a globe projection ([#12049](https://github.com/mapbox/mapbox-gl-js/pull/12049))
+* Fix exception on creating map in an iframe with sandbox attribute. ([#12101](https://github.com/mapbox/mapbox-gl-js/pull/12101))
 * Fix "improve map" link in the attribution to include location even if map hash is disabled ([#12122](https://github.com/mapbox/mapbox-gl-js/pull/12122))
 * Fix Chrome console warnings about ignored event cancel on touch interactions ([#12121](https://github.com/mapbox/mapbox-gl-js/pull/12121)) (h/t [jschaf](https://github.com/jschaf))
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "2.10.0-beta.1",
+  "version": "2.10.0",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 13.26.0
+
+### Features ✨
+
+* Add unit option to number-format expression ([#11839](https://github.com/mapbox/mapbox-gl-js/pull/11839)) (h/t [varna](https://github.com/varna))
+
+## Bug fixes 🐞
+* Fix a bug where `id` expression didn't correctly handle a value of 0 ([#12000](https://github.com/mapbox/mapbox-gl-js/pull/12000))
+
 ## 13.25.0
 
 ### Features ✨

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "13.26.0-dev",
+  "version": "13.26.0",
   "author": "Mapbox",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-gl-js/pull/12160