### PR TITLE
Edits to the spec with respect to new fill-extrusion properties

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -887,7 +887,9 @@
       "doc": "Radius of a fill extrusion edge in meters. If not zero, rounds extrusion edges for a smoother appearance.",
       "sdk-support": {
         "basic functionality": {
-          "js": "v2.10.0"
+          "js": "v2.10.0",
+          "android": "10.7.0",
+          "ios": "10.7.0"
         }
       },
       "property-type": "constant"
@@ -4686,7 +4688,7 @@
         ]
       },
       "transition": true,
-      "doc": "Controls the intensity of ambient occlusion (AO) shading. Current AO implementation is a low-cost best-effort approach that shades area near ground and concave angles between walls. Default value 0.0 disables ambient occlusion and values around 0.3 provide the most plausible results for buildings.",
+      "doc": "Controls the intensity of shading near ground and concave angles between walls. Default value 0.0 disables ambient occlusion and values around 0.3 provide the most plausible results for buildings.",
       "sdk-support": {
         "basic functionality": {
           "js": "2.10.0",
@@ -4708,7 +4710,10 @@
         ]
       },
       "transition": true,
-      "doc": "The radius of ambient occlusion (AO) shading, in meters. Current AO implementation is a low-cost best-effort approach that shades area near ground and concave angles between walls where the radius defines only vertical impact. Default value 3.0 corresponds to hight of one floor and brings the most plausible results for buildings.",
+      "doc": "Shades area near ground and concave angles between walls where the radius defines only vertical impact. Default value 3.0 corresponds to height of one floor and brings the most plausible results for buildings.",
+      "requires": [
+        "fill-extrusion-edge-radius"
+      ],
       "sdk-support": {
         "basic functionality": {
           "js": "2.10.0",


### PR DESCRIPTION
Makes the following changes:

- Fixes spelling `hight` to `height`
- Removes mentions in description around implementation as low-cost. These description fields should be pithy for Studio's use of them.
- Adds a required field to `fill-extrusion-ambient-occlusion-radius` for `fill-extrusion-edge-radius`
- Adds `android:10.7.0` and `ios:10.7.0` SDK compatibility to `fill-extrusion-edge-radius`