### PR TITLE
Add a debug page for globe getBounds

### DIFF
--- a/debug/globe-bounds.html
+++ b/debug/globe-bounds.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        #map, #map2 { position: absolute; top: 0; bottom: 0; }
+        #map { left: 0; right: 50%; }
+        #map2 { left: 50%; right: 0; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<div id='map2'></div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 2,
+    center: [0, 0],
+    style: 'mapbox://styles/mapbox/streets-v11',
+    hash: true,
+    projection: 'globe'
+});
+
+var map2 = new mapboxgl.Map({
+    container: 'map2',
+    zoom: 0.1,
+    center: [0, 0],
+    style: 'mapbox://styles/mapbox/streets-v11',
+    // projection: 'globe'
+});
+
+var lineData = {
+    type: 'LineString',
+    coordinates: []
+};
+var boundsData = {
+    'type': 'LineString',
+    coordinates: []
+};
+
+map2.on('load', () => {
+    map2.addSource('bounds', {
+        'type': 'geojson',
+        'data': lineData
+    });
+    map2.addLayer({
+        'id': 'bounds',
+        'type': 'line',
+        'source': 'bounds',
+        'paint': {
+            'line-color': 'blue',
+            'line-width': 5
+        }
+    });
+
+    map2.addSource('abounds', {
+        'type': 'geojson',
+        'data': boundsData
+    });
+    map2.addLayer({
+        'id': 'abounds',
+        'type': 'line',
+        'source': 'abounds',
+        'paint': {
+            'line-color': 'red',
+            'line-width': 5
+        }
+    });
+
+    updateBounds();
+});
+
+map.on('move', () => {
+    updateBounds();
+});
+
+function updateBounds() {
+    const points = [];
+    const w = map._containerWidth;
+    const h = map._containerHeight;
+    const res = 20;
+    for (let i = 0; i <= res; i++) points.push([w * i / res, 0]);
+    for (let i = 0; i <= res; i++) points.push([w, h * i / res]);
+    for (let i = 0; i <= res; i++) points.push([w * (1 - i / res), h]);
+    for (let i = 0; i <= res; i++) points.push([0, h * (1 - i / res)]);
+
+    lineData.coordinates = points.map(p => map.unproject(p).toArray());
+
+    const bounds = map.getBounds();
+
+    boundsData.coordinates = [
+        bounds.getSouthWest().toArray(),
+        bounds.getSouthEast().toArray(),
+        bounds.getNorthEast().toArray(),
+        bounds.getNorthWest().toArray(),
+        bounds.getSouthWest().toArray(),
+    ];
+
+    map2.getSource('bounds').setData(lineData);
+    map2.getSource('abounds').setData(boundsData);
+}
+
+const marker = new mapboxgl.Marker();
+
+map.on('mousemove', (e) => {
+    marker.setLngLat(e.lngLat).addTo(map2);
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds `debug/globe-bounds.html` page for debugging `getBounds` with the globe projection, splitting the view into two maps, where blue is the outline of the view of the left map, and red is what `getBounds` returns (while ideally red should encompass blue), and also a marker that shows the same location when you move the mouse on the left. 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/25395/187212888-33fb3894-229e-4d78-b74a-a4d50136488a.png">

Some points while investigating this for future reference:

- Currently we calculate bounds based on a bbox of 4 corners of the view. Doing the same for globe doesn't work even if we extend the number of points (e.g. add the middle points on either side) — the extremums can be at any point of the side, especially when you take rotation and pitch into account. E.g. on the above screenshot, the topmost bbox latitude is somewhere in the bottom third of the screen near Svalbard. 
- If we want precise bounds, we'd likely need to calculate frustum plane vs sphere intersections. The math might get pretty complicated there — I couldn't come up with the right calculations here. Aside from maximum of 4 plane-sphere intersections, there might be up to 4 "arcs" (where you see the horizon of the globe).
- Alternatively, we could do adaptive bounds calculation similar to the one happening in `tile_transform.js` for alternative projections — start with 4 corners, and delve recursively into midpoints while they stray too much from Euclidean midpoints. This might still produce a noticeable error, but will at least be a significant improvement to the current results. We should also be careful of the case where midpoint is in the middle but the line gets curvy on either side of the midpoint.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
