### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mapbox/gl-js


### PR DESCRIPTION
Adding a CODEOWNERS file to indicate repo ownership within Mapbox.