### PR TITLE
Fix `aabb.fromPoints` API

### DIFF
--- a/src/util/primitives.js
+++ b/src/util/primitives.js
@@ -174,18 +174,15 @@ class Aabb {
     center: Vec3;
 
     static fromPoints(points: Array<Vec3>): Aabb {
-        const aabbMin = [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE];
-        const aabbMax = [Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE];
-        for (const p of points) {
-            aabbMin[0] = Math.min(aabbMin[0], p[0]);
-            aabbMin[1] = Math.min(aabbMin[1], p[1]);
-            aabbMin[2] = Math.min(aabbMin[2], p[2]);
+        const min = [Infinity, Infinity, Infinity];
+        const max = [-Infinity, -Infinity, -Infinity];
 
-            aabbMax[0] = Math.max(aabbMax[0], p[0]);
-            aabbMax[1] = Math.max(aabbMax[1], p[1]);
-            aabbMax[2] = Math.max(aabbMax[2], p[2]);
+        for (const p of points) {
+            vec3.min(min, min, p);
+            vec3.max(max, max, p);
         }
-        return new Aabb(aabbMin, aabbMax);
+
+        return new Aabb(min, max);
     }
 
     constructor(min_: Vec3, max_: Vec3) {

--- a/test/integration/render-tests/globe/globe-transition/bearing/style.json
+++ b/test/integration/render-tests/globe/globe-transition/bearing/style.json
@@ -5,7 +5,7 @@
       "width": 512,
       "height": 512,
       "debug": true,
-      "allowed": 0.002
+      "allowed": 0.004
     }
   },
   "center": [3, 49],

--- a/test/integration/render-tests/globe/globe-transition/tile-edges/style.json
+++ b/test/integration/render-tests/globe/globe-transition/tile-edges/style.json
@@ -5,7 +5,7 @@
       "width": 640,
       "height": 512,
       "debug": true,
-      "allowed": 0.002
+      "allowed": 0.004
     }
   },
   "center": [5.44, 46.42],

--- a/test/integration/render-tests/globe/globe-transition/transition-fill/style.json
+++ b/test/integration/render-tests/globe/globe-transition/transition-fill/style.json
@@ -5,7 +5,7 @@
       "width": 512,
       "height": 512,
       "debug": true,
-      "allowed": 0.002
+      "allowed": 0.004
     }
   },
   "center": [0.236, 42.762],

--- a/test/unit/util/primitives.test.js
+++ b/test/unit/util/primitives.test.js
@@ -16,6 +16,19 @@ test('primitives', (t) => {
             t.end();
         });
 
+        t.test('Create an aabb from points', (t) => {
+            const p0 = vec3.fromValues(-10, 20, 30);
+            const p1 = vec3.fromValues(10, -30, 50);
+            const p2 = vec3.fromValues(50, 10, -100);
+            const p3 = vec3.fromValues(-15, 5, 120);
+            const aabb = Aabb.fromPoints([p0, p1, p2, p3]);
+
+            t.equal(aabb.min, vec3.fromValues(-15, -30, -100));
+            t.equal(aabb.max, vec3.fromValues(50, 20, 120));
+            t.deepEqual(aabb.center, vec3.fromValues(17.5, -5, 10));
+            t.end();
+        });
+
         t.test('Create 4 quadrants', (t) => {
             const min = vec3.fromValues(0, 0, 0);
             const max = vec3.fromValues(2, 4, 1);

--- a/test/unit/util/primitives.test.js
+++ b/test/unit/util/primitives.test.js
@@ -23,8 +23,8 @@ test('primitives', (t) => {
             const p3 = vec3.fromValues(-15, 5, 120);
             const aabb = Aabb.fromPoints([p0, p1, p2, p3]);
 
-            t.equal(aabb.min, vec3.fromValues(-15, -30, -100));
-            t.equal(aabb.max, vec3.fromValues(50, 20, 120));
+            t.deepEqual(aabb.min, vec3.fromValues(-15, -30, -100));
+            t.deepEqual(aabb.max, vec3.fromValues(50, 20, 120));
             t.deepEqual(aabb.center, vec3.fromValues(17.5, -5, 10));
             t.end();
         });


### PR DESCRIPTION
Issue discovered while working on https://github.com/mapbox/mapbox-gl-js/pull/12138. Fixes a regression introduced by https://github.com/mapbox/mapbox-gl-js/commit/7398fb3460a71cc247e7c96a9719d0c09a41c4a7 for a function used as part of the tile cover process with globe.

```
const aabbMin = [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE];
const aabbMax = [Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE];
```
uses `MIN_VALUE` (0) instead of `INFINITY`, this gives the wrong values when the AABB bounds are negative. e.g., with an AABB with points like that:
```
[-10, -5, 10, 5]
```
the bounds gets clamped like this:
```
[0, 10]
```
instead of:
```
[-10, 10]
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix invalid AABB calculation as part of the globe tile cover</changelog>`
