### PR TITLE
Prevent unnecessary texture upload on image source updates

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -113,6 +113,7 @@ class ImageSource extends Evented implements Source {
     boundsBuffer: ?VertexBuffer;
     boundsSegments: ?SegmentVector;
     _loaded: boolean;
+    _dirty: boolean;
     perspectiveTransform: [number, number];
 
     /**
@@ -134,6 +135,7 @@ class ImageSource extends Evented implements Source {
         this.setEventedParent(eventedParent);
 
         this.options = options;
+        this._dirty = false;
     }
 
     load(newCoordinates?: Coordinates, loaded?: boolean) {
@@ -153,6 +155,7 @@ class ImageSource extends Evented implements Source {
                 } else {
                     this.image = image;
                 }
+                this._dirty = true;
                 this.width = this.image.width;
                 this.height = this.image.height;
                 if (newCoordinates) {
@@ -323,11 +326,14 @@ class ImageSource extends Evented implements Source {
         const context = this.map.painter.context;
         const gl = context.gl;
 
-        if (!this.texture) {
-            this.texture = new Texture(context, this.image, gl.RGBA);
-            this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
-        } else {
-            this.texture.update(this.image);
+        if (this._dirty) {
+            if (!this.texture) {
+                this.texture = new Texture(context, this.image, gl.RGBA);
+                this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
+            } else {
+                this.texture.update(this.image);
+            }
+            this._dirty = false;
         }
 
         this._prepareData(context);

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -169,7 +169,7 @@ test('ImageSource', (t) => {
         t.end();
     });
 
-    t.test('', (t) => {
+    t.test('https://github.com/mapbox/mapbox-gl-js/issues/12209', (t) => {
         const source = createSource({url : '/image.png'});
         source.tiles[0] = new OverscaledTileID(0, 0, 0, 0, 0);
         const map = new StubMap();

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -5,7 +5,10 @@ import {Evented} from '../../../src/util/evented.js';
 import Transform from '../../../src/geo/transform.js';
 import {extend} from '../../../src/util/util.js';
 import browser from '../../../src/util/browser.js';
+import {OverscaledTileID} from '../../../src/source/tile_id.js';
 import window from '../../../src/util/window.js';
+import Context from '../../../src/gl/context.js';
+import gl from 'gl';
 
 function createSource(options) {
     options = extend({
@@ -19,6 +22,8 @@ function createSource(options) {
 class StubMap extends Evented {
     constructor() {
         super();
+        this.painter = {};
+        this.painter.context = new Context(gl(10, 10));
         this.transform = new Transform();
         this._requestManager = {
             transformRequest: (url) => {
@@ -48,6 +53,7 @@ test('ImageSource', (t) => {
         req.response = new ArrayBuffer(1);
         req.onload();
         img.onload();
+        img.data = new Uint8Array(req.response);
     };
     t.stub(browser, 'getImageData').callsFake(() => new ArrayBuffer(1));
 
@@ -159,6 +165,36 @@ test('ImageSource', (t) => {
         t.equal(serialized.type, 'image');
         t.equal(serialized.url, '/image.png');
         t.deepEqual(serialized.coordinates, [[0, 0], [1, 0], [1, 1], [0, 1]]);
+
+        t.end();
+    });
+
+    t.test('', (t) => {
+        const source = createSource({url : '/image.png'});
+        source.tiles[0] = new OverscaledTileID(0, 0, 0, 0, 0);
+        const map = new StubMap();
+        const coordinates = [[0, 0], [-1, 0], [-1, -1], [0, -1]];
+
+        source.onAdd(map);
+        t.ok(!source.loaded());
+        t.ok(!source._dirty);
+        respond();
+        t.ok(source.loaded());
+        t.ok(source._dirty);
+        t.ok(source.image);
+
+        source.prepare();
+        t.ok(source.texture);
+        const spy = t.spy(source.texture, 'update');
+
+        source.prepare();
+        t.equal(spy.callCount, 0);
+        source.updateImage({url: '/image2.png', coordinates});
+        respond();
+        source.prepare();
+        t.equal(spy.callCount, 1);
+        source.prepare();
+        t.equal(spy.callCount, 1);
 
         t.end();
     });

--- a/test/unit/terrain/terrain.test.js
+++ b/test/unit/terrain/terrain.test.js
@@ -370,23 +370,27 @@ test('Elevation', (t) => {
                 t.true(map._averageElevation.isEasing(timestamp));
                 t.equal(map.transform.averageElevation, 0);
 
-                timestamp += AVERAGE_ELEVATION_EASE_TIME * 0.5;
-                changed = map._updateAverageElevation(timestamp);
-                t.true(changed);
-                t.true(map._averageElevation.isEasing(timestamp));
-                t.equal(map.transform.averageElevation, 154.15083854452925);
+                const assertAlmostEqual = (t, actual, expected, epsilon = 1e-6) => {
+                    t.ok(Math.abs(actual - expected) < epsilon);
+                };
 
                 timestamp += AVERAGE_ELEVATION_EASE_TIME * 0.5;
                 changed = map._updateAverageElevation(timestamp);
                 t.true(changed);
                 t.true(map._averageElevation.isEasing(timestamp));
-                t.equal(map.transform.averageElevation, 308.3016770890585);
+                assertAlmostEqual(t, map.transform.averageElevation, 154.15083854452925);
+
+                timestamp += AVERAGE_ELEVATION_EASE_TIME * 0.5;
+                changed = map._updateAverageElevation(timestamp);
+                t.true(changed);
+                t.true(map._averageElevation.isEasing(timestamp));
+                assertAlmostEqual(t, map.transform.averageElevation, 308.3016770890585);
 
                 timestamp += AVERAGE_ELEVATION_SAMPLING_INTERVAL;
                 changed = map._updateAverageElevation(timestamp);
                 t.false(changed);
                 t.false(map._averageElevation.isEasing(timestamp));
-                t.equal(map.transform.averageElevation, 308.3016770890585);
+                assertAlmostEqual(t, map.transform.averageElevation, 308.3016770890585);
 
                 t.end();
             });


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/mapbox/mapbox-gl-js/pull/11564. 

The reason `texture.update` was added was mentioned as the following in the original PR:

>also uses texture.update rather than always creating a new texture when the source's image is updated

But this introduced another regression since the check did not account whether the image changed at all making it run most frames, where it was running previously only when the texture had to be created.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix potential performance regression on image source updates</changelog>`
