### PR TITLE
Add missing height calculation for fill extrusion rounded edges in depth shader

### DIFF
--- a/src/shaders/fill_extrusion_depth.vertex.glsl
+++ b/src/shaders/fill_extrusion_depth.vertex.glsl
@@ -1,4 +1,5 @@
 uniform mat4 u_matrix;
+uniform float u_edge_radius;
 
 attribute vec4 a_pos_normal_ed;
 attribute vec2 a_centroid_pos;
@@ -23,7 +24,7 @@ void main() {
     vec3 normal = top_up_ny.y == 1.0 ? vec3(0.0, 0.0, 1.0) : normalize(vec3(x_normal, (2.0 * top_up_ny.z - 1.0) * (1.0 - abs(x_normal)), 0.0));
 
     base = max(0.0, base);
-    height = max(0.0, height);
+    height = max(0.0, top_up_ny.y == 0.0 && top_up_ny.x == 1.0 ? height - u_edge_radius : height);
 
     float t = top_up_ny.x;
 


### PR DESCRIPTION
This PR adds the missing height calculations for the fill extrusion rounded edges in the depth vertex shader used by the shadow code. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
