### PR TITLE
Update style support table for Android and iOS

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1907,8 +1907,8 @@
         },
         "data-driven styling": {
           "js": "2.3.0",
-          "android": "10.7.0",
-          "ios": "10.7.0"
+          "android": "10.0.0",
+          "ios": "10.0.0"
         }
       },
       "expression": {
@@ -5002,9 +5002,7 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "2.3.0",
-          "android": "10.0.0",
-          "ios": "10.0.0"
+          "js": "2.3.0"
         }
       },
       "expression": {
@@ -5065,10 +5063,7 @@
           "ios": "4.4.0",
           "macos": "0.11.0"
         },
-        "data-driven styling": {
-          "android": "10.0.0",
-          "ios": "10.0.0"
-        }
+        "data-driven styling": {}
       },
       "expression": {
         "interpolated": true,

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3255,7 +3255,9 @@
         "group": "Camera",
         "sdk-support": {
           "basic functionality": {
-            "js": "2.6.0"
+            "js": "2.6.0",
+            "android": "10.9.0",
+            "ios": "10.9.0"
           }
         }
       },
@@ -3264,7 +3266,9 @@
         "group": "Camera",
         "sdk-support": {
           "basic functionality": {
-            "js": "2.6.0"
+            "js": "2.6.0",
+            "android": "10.9.0",
+            "ios": "10.9.0"
           }
         }
       },

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1906,7 +1906,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "2.3.0"
+          "js": "2.3.0",
+          "android": "10.7.0",
+          "ios": "10.7.0"
         }
       },
       "expression": {
@@ -2814,7 +2816,9 @@
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
-            "js": "1.10.0"
+            "js": "1.10.0",
+            "android": "10.0.0",
+            "ios": "10.0.0"
           }
         }
       },
@@ -2823,7 +2827,9 @@
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
-            "js": "1.10.0"
+            "js": "1.10.0",
+            "android": "10.0.0",
+            "ios": "10.0.0"
           }
         }
       },
@@ -3210,7 +3216,9 @@
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.46.0"
+            "js": "0.46.0",
+            "android": "10.0.0",
+            "ios": "10.0.0"
           }
         }
       },
@@ -4994,7 +5002,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "2.3.0"
+          "js": "2.3.0",
+          "android": "10.0.0",
+          "ios": "10.0.0"
         }
       },
       "expression": {
@@ -5055,7 +5065,10 @@
           "ios": "4.4.0",
           "macos": "0.11.0"
         },
-        "data-driven styling": {}
+        "data-driven styling": {
+          "android": "10.0.0",
+          "ios": "10.0.0"
+        }
       },
       "expression": {
         "interpolated": true,


### PR DESCRIPTION
This PR updates the style spec reference with pitch and distance-from-center expressions which aim to land with v10.9.0.

edit: did an audit of the full spec and updated the SDK version table for things that landed on mobile. 

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
