### PR TITLE
Fix resource leak on Safari on `map.remove()`

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3437,10 +3437,21 @@ class Map extends Camera {
 
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
+
+        this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
+        this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
+
         removeNode(this._canvasContainer);
         removeNode(this._controlContainer);
         removeNode(this._missingCSSCanary);
+
+        this._canvas = undefined;
+        this._canvasContainer = undefined;
+        this._controlContainer = undefined;
+        this._missingCSSCanary = undefined;
+
         this._container.classList.remove('mapboxgl-map');
+        this._container.removeEventListener('scroll', this._onMapScroll, false);
 
         PerformanceUtils.clearMetrics();
         removeAuthState(this.painter.context.gl);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3445,10 +3445,10 @@ class Map extends Camera {
         removeNode(this._controlContainer);
         removeNode(this._missingCSSCanary);
 
-        this._canvas = undefined;
-        this._canvasContainer = undefined;
-        this._controlContainer = undefined;
-        this._missingCSSCanary = undefined;
+        this._canvas = (undefined: any);
+        this._canvasContainer = (undefined: any);
+        this._controlContainer = (undefined: any);
+        this._missingCSSCanary = (undefined: any);
 
         this._container.classList.remove('mapboxgl-map');
         this._container.removeEventListener('scroll', this._onMapScroll, false);

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -2211,6 +2211,26 @@ test('Map', (t) => {
         });
     });
 
+    t.test('#remove does not leak event listeners on container', (t) => {
+        const container = window.document.createElement('div');
+        container.addEventListener = t.spy();
+        container.removeEventListener = t.spy();
+
+        t.stub(Map.prototype, '_detectMissingCSS');
+        t.stub(Map.prototype, '_authenticate');
+
+        const map = new Map({
+            container,
+            testMode: true
+        });
+        map.remove();
+
+        t.equal(container.addEventListener.callCount, container.removeEventListener.callCount);
+        t.equal(container.addEventListener.callCount, 1);
+        t.equal(container.removeEventListener.callCount, 1);
+        t.end();
+    });
+
     t.test('#addControl', (t) => {
         const map = createMap(t);
         const control = {


### PR DESCRIPTION
…ners and dereference canvas and other containers to prevent resource leak on Safari

### Brief Description
I have been investigating an issue where our mobile application - which uses mapbox-gl-js - was crashing after repeatedly opening and closing a page containing a map.

In examining heap snapshots I noticed that event listeners and Map instances were being leaked.

The final line of the changes I believe is a resource leak on every platform - the container element is an existing element in the DOM passed to us by the library user (either by ID or as a direct HTMLElement) which the existing code then attaches an eventListener to for 'scroll' but never removes it. This results in the browser not being able to reclaim the resources for the mapboxgl.Map instance even after the map has been removed by calling map.remove().

The changes above that relate more specifically to iOS Safari where I was again seeing instances of mapboxgl.Map being leaked, and on inspection of the heapmap the retaining element was these contextLost/contextRestored event listeners. In theory this should not be required I think, but I know that iOS Safari has a lot of well-known issues around performance and memory particular in relation to canvas.

### Testing/Reproduction

I have created a simple test site to show the problem.

To Recreate the issue use: https://joyful-granita-e529dc.netlify.app/existing.html. This recreates the problem using the latest version of mapbox-gl-js (2.10.0). The test page simply loads and then unloads a map in a continual loop until you hit Stop.

* Run in Safari
* Input a valid mapbox token into the token input at the top
* Hit Start
* Let it load and unload a map for 20+ iterations
* Hit Stop
* Open Web Inspector > Timelines > Javascript Allocations
* Take a heap snapshot (camera icon)
* Inspect the snapshot

On inspecting the snapshot you will see a large retained size, and inspecting the heap you will see all the leaked Map instances are still present. Safari devtool helpfully shows that _onMapScroll is the retaining reference here.

![Screenshot 2022-09-07 at 17 02 16](https://user-images.githubusercontent.com/3168135/188925904-dbc26567-3db8-4b30-a83b-6a09b5120d90.png)

To view the fixed version, repeat the above steps using this link: https://joyful-granita-e529dc.netlify.app/fixed.html

This is the same reproduction but pointing out a custom build of mapbox-gl-js that contains the fixes attached to this PR. If you repeat the steps above, on inspection of the heap snapshot you will see there are no leaked Map instances.
 
![Screenshot 2022-09-07 at 17 06 06](https://user-images.githubusercontent.com/3168135/188926544-f63c3290-bbf1-4a01-8914-97465ce12081.png)

The above can also be repeated in Chrome using the Performance Monitor to view JS Heap size. On the "existing" version the heap will increase indefinitely and manually triggering a GC will not bring memory down. On the "fixed" version heap size will remain stable.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix memory leak when removing maps</changelog>`
