### PR TITLE
Fix cursor state on popup.remove() (#12223)

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -225,7 +225,9 @@ export default class Popup extends Evented {
             map.off('mousemove', this._onMouseEvent);
             map.off('mouseup', this._onMouseEvent);
             map.off('drag', this._onMouseEvent);
-            map._canvasContainer?.classList.remove('mapboxgl-track-pointer');
+            if (map._canvasContainer) {
+                map._canvasContainer.classList.remove('mapboxgl-track-pointer');
+            }
             this._map = undefined;
         }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -225,6 +225,7 @@ export default class Popup extends Evented {
             map.off('mousemove', this._onMouseEvent);
             map.off('mouseup', this._onMouseEvent);
             map.off('drag', this._onMouseEvent);
+            map._canvasContainer.classList.remove('mapboxgl-track-pointer');
             this._map = undefined;
         }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -225,7 +225,7 @@ export default class Popup extends Evented {
             map.off('mousemove', this._onMouseEvent);
             map.off('mouseup', this._onMouseEvent);
             map.off('drag', this._onMouseEvent);
-            map._canvasContainer.classList.remove('mapboxgl-track-pointer');
+            map._canvasContainer?.classList.remove('mapboxgl-track-pointer');
             this._map = undefined;
         }
 


### PR DESCRIPTION
- add in function to remove 'mapboxgl-track-pointer' from map element class on popup.remove() to return cursor to original state

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>returns cursor to original state after a popup is removed</changelog>`
