### PR TITLE
fix antimeridian mouse scroll wrapping

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -271,6 +271,9 @@ class ScrollZoomHandler {
 
         const tr = this._map.transform;
 
+        // If projection wraps and center crosses the antimeridian, reset this._easing to resolve https://github.com/mapbox/mapbox-gl-js/issues/11910
+        if (tr.projection.wrap && (tr.center.lng > 180 || tr.center.lng < -180)) this._easing = null;
+
         const startingZoom = () => {
             return (tr._terrainEnabled() && this._aroundCoord) ? tr.computeZoomRelativeTo(this._aroundCoord) : tr.zoom;
         };


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix mouse scroll jumping when crossing the antimeridian on projections that wrap.</changelog>`
