### PR TITLE
Fix displaced markers when toggling projections

### DIFF
--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -46,7 +46,7 @@ export default class Albers extends Projection {
         const dt = degToRad(this.center[0]) * n;
         l = wrap(l, -Math.PI - dt, Math.PI - dt);
 
-        const lng = radToDeg(l / n) + this.center[0];
+        const lng = clamp(radToDeg(l / n) + this.center[0], -180, 180);
         const phi = Math.asin(clamp((c - (x * x + r0y * r0y) * n * n) / (2 * n), -1, 1));
         const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1052,6 +1052,9 @@ class Map extends Camera {
      */
     setRenderWorldCopies(renderWorldCopies?: ?boolean): this {
         this.transform.renderWorldCopies = renderWorldCopies;
+        if (!this.transform.renderWorldCopies) {
+            this._forceMarkerAndPopupUpdate({'setToWrap': true});
+        }
         return this._update();
     }
 
@@ -1248,7 +1251,7 @@ class Map extends Camera {
                 this.style._sourceCaches[id].clearTiles();
             }
             this._update(true);
-            this._forceMarkerAndPopupUpdate({'projectionHasChanged': true});
+            this._forceMarkerAndPopupUpdate({'setToWrap': true});
         }
 
         return this;
@@ -3264,14 +3267,14 @@ class Map extends Camera {
     _forceMarkerAndPopupUpdate(options?: Object) {
         for (const marker of this._markers) {
             // Wrap marker location when toggling to a projection without world copies
-            if (options && options.projectionHasChanged && !this.transform.renderWorldCopies) {
+            if (options && options.setToWrap && !this.getRenderWorldCopies()) {
                 marker._lngLat = marker._lngLat.wrap();
             }
             marker._update();
         }
         for (const popup of this._popups) {
             // Wrap popup location when toggling to a projection without world copies and track pointer set to false
-            if (options && options.projectionHasChanged && !this.transform.renderWorldCopies && !popup._trackPointer) {
+            if (options && options.setToWrap && !this.getRenderWorldCopies() && !popup._trackPointer) {
                 popup._lngLat = popup._lngLat.wrap();
             }
             popup._update();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3129,7 +3129,7 @@ class Map extends Camera {
             this._updateTerrain(); // Terrain DEM source updates here and skips update in style._updateSources.
             averageElevationChanged = this._updateAverageElevation(frameStartTime);
             this.style._updateSources(this.transform);
-            // Update positions of markers and popups
+            // Update positions of markers and popups on enabling/disabling terrain
             this._forceMarkerAndPopupUpdate();
         } else {
             averageElevationChanged = this._updateAverageElevation(frameStartTime);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1053,7 +1053,7 @@ class Map extends Camera {
     setRenderWorldCopies(renderWorldCopies?: ?boolean): this {
         this.transform.renderWorldCopies = renderWorldCopies;
         if (!this.transform.renderWorldCopies) {
-            this._forceMarkerAndPopupUpdate({'setToWrap': true});
+            this._forceMarkerAndPopupUpdate(true);
         }
         return this._update();
     }
@@ -1251,7 +1251,7 @@ class Map extends Camera {
                 this.style._sourceCaches[id].clearTiles();
             }
             this._update(true);
-            this._forceMarkerAndPopupUpdate({'setToWrap': true});
+            this._forceMarkerAndPopupUpdate(true);
         }
 
         return this;
@@ -3264,17 +3264,17 @@ class Map extends Camera {
         }
     }
 
-    _forceMarkerAndPopupUpdate(options?: Object) {
+    _forceMarkerAndPopupUpdate(shouldWrap?: Boolean) {
         for (const marker of this._markers) {
             // Wrap marker location when toggling to a projection without world copies
-            if (options && options.setToWrap && !this.getRenderWorldCopies()) {
+            if (shouldWrap && !this.getRenderWorldCopies()) {
                 marker._lngLat = marker._lngLat.wrap();
             }
             marker._update();
         }
         for (const popup of this._popups) {
             // Wrap popup location when toggling to a projection without world copies and track pointer set to false
-            if (options && options.setToWrap && !this.getRenderWorldCopies() && !popup._trackPointer) {
+            if (shouldWrap && !this.getRenderWorldCopies() && !popup._trackPointer) {
                 popup._lngLat = popup._lngLat.wrap();
             }
             popup._update();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3264,7 +3264,7 @@ class Map extends Camera {
         }
     }
 
-    _forceMarkerAndPopupUpdate(shouldWrap?: Boolean) {
+    _forceMarkerAndPopupUpdate(shouldWrap?: boolean) {
         for (const marker of this._markers) {
             // Wrap marker location when toggling to a projection without world copies
             if (shouldWrap && !this.getRenderWorldCopies()) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1243,12 +1243,12 @@ class Map extends Camera {
         this.style.applyProjectionUpdate();
 
         if (projectionHasChanged) {
-            this._forceMarkerAndPopupUpdate({'projectionHasChanged': true});
             this.painter.clearBackgroundTiles();
             for (const id in this.style._sourceCaches) {
                 this.style._sourceCaches[id].clearTiles();
             }
             this._update(true);
+            this._forceMarkerAndPopupUpdate({'projectionHasChanged': true});
         }
 
         return this;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1243,6 +1243,7 @@ class Map extends Camera {
         this.style.applyProjectionUpdate();
 
         if (projectionHasChanged) {
+            this._forceMarkerAndPopupUpdate({'projectionChanged': true});
             this.painter.clearBackgroundTiles();
             for (const id in this.style._sourceCaches) {
                 this.style._sourceCaches[id].clearTiles();
@@ -3129,8 +3130,7 @@ class Map extends Camera {
             averageElevationChanged = this._updateAverageElevation(frameStartTime);
             this.style._updateSources(this.transform);
             // Update positions of markers and popups
-            this._forceMarkerUpdate();
-            this._forcePopupUpdate();
+            this._forceMarkerAndPopupUpdate();
         } else {
             averageElevationChanged = this._updateAverageElevation(frameStartTime);
         }
@@ -3261,14 +3261,21 @@ class Map extends Camera {
         }
     }
 
-    _forceMarkerUpdate() {
+    _forceMarkerAndPopupUpdate(options?: Object) {
         for (const marker of this._markers) {
+            // Wrap marker location when toggling to a projection without world copies
+            if (options && options.projectionChanged && !this.transform.renderWorldCopies) {
+                marker._lngLat = marker._lngLat.wrap();
+            }
             marker._update();
-        }
-    }
+        
 
-    _forcePopupUpdate() {
+        }
         for (const popup of this._popups) {
+            // Wrap popup location when toggling to a projection without world copies and track pointer set to false
+            if (options && options.projectionChanged && !this.transform.renderWorldCopies && !popup._trackPointer) {
+                popup._lngLat = popup._lngLat.wrap();
+            }
             popup._update();
         }
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1243,7 +1243,7 @@ class Map extends Camera {
         this.style.applyProjectionUpdate();
 
         if (projectionHasChanged) {
-            this._forceMarkerAndPopupUpdate({'projectionChanged': true});
+            this._forceMarkerAndPopupUpdate({'projectionHasChanged': true});
             this.painter.clearBackgroundTiles();
             for (const id in this.style._sourceCaches) {
                 this.style._sourceCaches[id].clearTiles();
@@ -3264,16 +3264,14 @@ class Map extends Camera {
     _forceMarkerAndPopupUpdate(options?: Object) {
         for (const marker of this._markers) {
             // Wrap marker location when toggling to a projection without world copies
-            if (options && options.projectionChanged && !this.transform.renderWorldCopies) {
+            if (options && options.projectionHasChanged && !this.transform.renderWorldCopies) {
                 marker._lngLat = marker._lngLat.wrap();
             }
             marker._update();
-        
-
         }
         for (const popup of this._popups) {
             // Wrap popup location when toggling to a projection without world copies and track pointer set to false
-            if (options && options.projectionChanged && !this.transform.renderWorldCopies && !popup._trackPointer) {
+            if (options && options.projectionHasChanged && !this.transform.renderWorldCopies && !popup._trackPointer) {
                 popup._lngLat = popup._lngLat.wrap();
             }
             popup._update();

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -548,8 +548,6 @@ export default class Marker extends Evented {
 
         if (map.transform.renderWorldCopies) {
             this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
-        } else {
-            this._lngLat = this._lngLat.wrap();
         }
 
         this._pos = map.project(this._lngLat);

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -548,6 +548,8 @@ export default class Marker extends Evented {
 
         if (map.transform.renderWorldCopies) {
             this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
+        } else {
+            this._lngLat = this._lngLat.wrap();
         }
 
         this._pos = map.project(this._lngLat);

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -153,7 +153,6 @@ export default class Popup extends Evented {
         map.on('remove', this.remove);
         this._update();
         map._addPopup(this);
-
         this._focusFirstElement();
 
         if (this._trackPointer) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -617,8 +617,6 @@ export default class Popup extends Evented {
 
         if (map.transform.renderWorldCopies && !this._trackPointer) {
             this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
-        } else if (!this._trackPointer && this._lngLat) {
-            this._lngLat = this._lngLat.wrap();
         }
 
         if (!this._trackPointer || cursor) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -152,6 +152,8 @@ export default class Popup extends Evented {
 
         map.on('remove', this.remove);
         this._update();
+        map._addPopup(this);
+
         this._focusFirstElement();
 
         if (this._trackPointer) {
@@ -228,6 +230,7 @@ export default class Popup extends Evented {
             if (map._canvasContainer) {
                 map._canvasContainer.classList.remove('mapboxgl-track-pointer');
             }
+            map._removePopup(this);
             this._map = undefined;
         }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -614,6 +614,8 @@ export default class Popup extends Evented {
 
         if (map.transform.renderWorldCopies && !this._trackPointer) {
             this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
+        } else if (!this._trackPoint && this._lngLat) {
+            this._lngLat = this._lngLat.wrap();
         }
 
         if (!this._trackPointer || cursor) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -614,7 +614,7 @@ export default class Popup extends Evented {
 
         if (map.transform.renderWorldCopies && !this._trackPointer) {
             this._lngLat = smartWrap(this._lngLat, this._pos, map.transform);
-        } else if (!this._trackPoint && this._lngLat) {
+        } else if (!this._trackPointer && this._lngLat) {
             this._lngLat = this._lngLat.wrap();
         }
 

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -914,7 +914,7 @@ test('When toggling projections, markers update with correct position', (t) => {
     const marker = new Marker()
         .setLngLat([12, 55])
         .addTo(map);
-    
+
     map.setCenter([-179, 0]);
     t.equal(marker.getLngLat().lng, -348);
 
@@ -923,7 +923,7 @@ test('When toggling projections, markers update with correct position', (t) => {
     map._domRenderTaskQueue.run();
 
     map.once('render', () => {
-        t.equal(marker.getLngLat().lng, 12)
+        t.equal(marker.getLngLat().lng, 12);
         map.remove();
         t.end();
     });

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -929,6 +929,26 @@ test('When toggling projections, markers update with correct position', (t) => {
     });
 });
 
+test('When disabling render world copies, markers update with correct position', (t) => {
+    const map = createMap(t);
+    const marker = new Marker()
+        .setLngLat([12, 55])
+        .addTo(map);
+
+    map.setCenter([-179, 0]);
+    t.equal(marker.getLngLat().lng, -348);
+
+    map.setRenderWorldCopies(false);
+
+    map._domRenderTaskQueue.run();
+
+    map.once('render', () => {
+        t.equal(marker.getLngLat().lng, 12);
+        map.remove();
+        t.end();
+    });
+});
+
 test('Marker and fog', (t) => {
     const map = createMap(t);
     const marker = new Marker({draggable: true})

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -909,6 +909,26 @@ test('Drag below / behind camera', (t) => {
     t.end();
 });
 
+test('When toggling projections, markers update with correct position', (t) => {
+    const map = createMap(t);
+    const marker = new Marker()
+        .setLngLat([12, 55])
+        .addTo(map);
+    
+    map.setCenter([-179, 0]);
+    t.equal(marker.getLngLat().lng, -348);
+
+    map.setProjection('albers');
+
+    map._domRenderTaskQueue.run();
+
+    map.once('render', () => {
+        t.equal(marker.getLngLat().lng, 12)
+        map.remove();
+        t.end();
+    });
+});
+
 test('Marker and fog', (t) => {
     const map = createMap(t);
     const marker = new Marker({draggable: true})

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -405,6 +405,26 @@ test('Popup is repositioned at the specified LngLat', (t) => {
     t.end();
 });
 
+test('When toggling projections, popups update with correct position', (t) => {
+    const map = createMap(t);
+    const popup = new Popup()
+        .setText('Test')
+        .setLngLat([12, 55])
+        .addTo(map);
+
+    map.setCenter([-179, 0]);
+    t.equal(popup.getLngLat().lng, -348);
+
+    map.setProjection('albers');
+
+    map._domRenderTaskQueue.run();
+    map.once('render', () => {
+        t.equal(popup.getLngLat().lng, 12);
+        map.remove();
+        t.end();
+    });
+});
+
 test('Popup anchors as specified by the anchor option', (t) => {
     const map = createMap(t);
     const popup = new Popup({anchor: 'top-left'})

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -446,7 +446,6 @@ test('When disabling render world copies, popups update with correct position', 
     });
 });
 
-
 test('Popup anchors as specified by the anchor option', (t) => {
     const map = createMap(t);
     const popup = new Popup({anchor: 'top-left'})

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -425,6 +425,28 @@ test('When toggling projections, popups update with correct position', (t) => {
     });
 });
 
+test('When disabling render world copies, popups update with correct position', (t) => {
+    const map = createMap(t);
+    const popup = new Popup()
+        .setText('Test')
+        .setLngLat([12, 55])
+        .addTo(map);
+
+    map.setCenter([-179, 0]);
+    t.equal(popup.getLngLat().lng, -348);
+
+    map.setRenderWorldCopies(false);
+
+    map._domRenderTaskQueue.run();
+
+    map.once('render', () => {
+        t.equal(popup.getLngLat().lng, 12);
+        map.remove();
+        t.end();
+    });
+});
+
+
 test('Popup anchors as specified by the anchor option', (t) => {
     const map = createMap(t);
     const popup = new Popup({anchor: 'top-left'})


### PR DESCRIPTION
This PR fixes #12129, updating marker position correctly when toggling between a map that renders world copies and a map that doesn't by wrapping the lng of the marker when updating for projections that wrap.

BEFORE:

https://user-images.githubusercontent.com/42715836/190811871-e34fea2c-7515-45c2-9832-61c2893313dc.mov

AFTER:

https://user-images.githubusercontent.com/42715836/190811958-8bee6795-b70a-4ec3-ad29-1ccf0b38c1e2.mov


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix updating marker position when toggling between world copied projections and projections without</changelog>`
