### PR TITLE
Upgrade Flow to v0.145

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -31,7 +31,7 @@
 .*/test/build/downstream-flow-fixture/.*
 
 [version]
-0.142.0
+0.143.0
 
 [options]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -31,7 +31,7 @@
 .*/test/build/downstream-flow-fixture/.*
 
 [version]
-0.143.0
+0.145.0
 
 [options]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,40 +2,26 @@
 .*\.svg
 .*\.png
 .*/\.nyc_output/.*
-.*/docs/.*
 .*/node_modules/.cache/.*
 .*/node_modules/.*/tests?/.*
 .*/node_modules/@mapbox/jsonlint-lines-primitives/.*
 .*/node_modules/@mapbox/mvt-fixtures/.*
 .*/node_modules/@mapbox/geojson-types/fixtures/.*
-.*/node_modules/@mapbox/mr-ui/.*
-.*/node_modules/@mapbox/dr-ui/.*
-.*/node_modules/@mapbox/batfish/.*
 .*/node_modules/browserify/.*
-.*/node_modules/browser-sync.*/.*
 .*/node_modules/nyc/.*
-.*/node_modules/fbjs/.*
-.*/node_modules/es5-ext/.*
 .*/node_modules/jsdom/.*
 .*/node_modules/eslint.*/.*
 .*/node_modules/highlight.*/.*
-.*/node_modules/rxjs/.*
 .*/node_modules/@?babel.*/.*
 .*/node_modules/svgo/.*
-.*/node_modules/moment/.*
-.*/node_modules/regenerate-unicode-properties/.*
 .*/node_modules/remark.*/.*
-.*/node_modules/webpack/.*
 .*/node_modules/caniuse-lite/.*
 .*/node_modules/d3.*/.*
 .*/node_modules/css-tree/.*
 .*/node_modules/lodash/.*
 .*/node_modules/fsevents/.*
-.*/node_modules/browser-sync-client/.*
-.*/node_modules/core-js.*/.*
 .*/node_modules/stylelint/.*
 .*/node_modules/postcss.*/.*
-.*/node_modules/prismjs.*/.*
 .*/node_modules/documentation/.*
 .*/node_modules/module-deps/.*
 .*/test/unit/style-spec/fixture/invalidjson.input.json
@@ -43,15 +29,11 @@
 .*/query-tests/.*
 .*/expression-tests/.*
 .*/test/build/downstream-flow-fixture/.*
-.*/_batfish_tmp/.*
-.*/_site/.*
 
 [version]
 0.142.0
 
 [options]
-server.max_workers=4
-merge_timeout=180
 
 [strict]
 nonstrict-import

--- a/bench/benchmarks/query_box.js
+++ b/bench/benchmarks/query_box.js
@@ -37,8 +37,9 @@ export default class QueryBox extends Benchmark {
     }
 
     bench() {
+        const p = [0, 0];
         for (const map of this.maps) {
-            map.queryRenderedFeatures({});
+            map.queryRenderedFeatures(p);
         }
     }
 

--- a/bench/lib/tile_parser.js
+++ b/bench/lib/tile_parser.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Protobuf from 'pbf';
-import VT from '@mapbox/vector-tile';
+import {VectorTile} from '@mapbox/vector-tile';
 import assert from 'assert';
 
 import deref from '../../src/style-spec/deref.js';
@@ -137,7 +137,7 @@ export default class TileParser {
             projection: getProjection({name: 'mercator'})
         });
 
-        const vectorTile = new VT.VectorTile(new Protobuf(tile.buffer));
+        const vectorTile = new VectorTile(new Protobuf(tile.buffer));
 
         return new Promise((resolve, reject) => {
             workerTile.parse(vectorTile, this.layerIndex, [], (this.actor: any), (err, result) => {

--- a/flow-typed/geojson.js
+++ b/flow-typed/geojson.js
@@ -1,0 +1,43 @@
+// @flow strict
+
+type GeoJSONPosition = [number, number] | [number, number, number];
+type Geometry<T, C> = { type: T, coordinates: C }
+
+declare module "@mapbox/geojson-types" {
+    declare export type GeoJSONPoint = Geometry<'Point', GeoJSONPosition>;
+    declare export type GeoJSONMultiPoint = Geometry<'MultiPoint', Array<GeoJSONPosition>>;
+
+    declare export type GeoJSONLineString = Geometry<'LineString', Array<GeoJSONPosition>>;
+    declare export type GeoJSONMultiLineString = Geometry<'MultiLineString', Array<Array<GeoJSONPosition>>>;
+
+    declare export type GeoJSONPolygon = Geometry<'Polygon', Array<Array<GeoJSONPosition>>>;
+    declare export type GeoJSONMultiPolygon = Geometry<'MultiPolygon', Array<Array<Array<GeoJSONPosition>>>>;
+
+    declare export type GeoJSONGeometry =
+        | GeoJSONPoint
+        | GeoJSONMultiPoint
+        | GeoJSONLineString
+        | GeoJSONMultiLineString
+        | GeoJSONPolygon
+        | GeoJSONMultiPolygon
+        | GeoJSONGeometryCollection;
+
+    declare export type GeoJSONGeometryCollection = {
+        type: 'GeometryCollection',
+        geometries: Array<GeoJSONGeometry>
+    };
+
+    declare export type GeoJSONFeature = {
+        type: 'Feature',
+        geometry: ?GeoJSONGeometry,
+        properties: ?{},
+        id?: number | string
+    };
+
+    declare export type GeoJSONFeatureCollection = {
+        type: 'FeatureCollection',
+        features: Array<GeoJSONFeature>
+    };
+
+    declare export type GeoJSON = GeoJSONGeometry | GeoJSONFeature | GeoJSONFeatureCollection;
+}

--- a/flow-typed/jsdom.js
+++ b/flow-typed/jsdom.js
@@ -1,11 +1,9 @@
 // @flow strict
 
-import type Window from '../src/types/window';
-
 declare module "jsdom" {
     declare class JSDOM {
         constructor(content: string, options: Object): JSDOM;
-        window: Window;
+        window: WindowProxy;
     }
     declare class VirtualConsole {
         constructor(): VirtualConsole;

--- a/flow-typed/vector-tile.js
+++ b/flow-typed/vector-tile.js
@@ -1,42 +1,49 @@
 // @flow
-import type Pbf from 'pbf';
-import type Point from '@mapbox/point-geometry';
-import type { GeoJSONFeature } from '@mapbox/geojson-types';
-
-declare interface VectorTile {
-    layers: {[_: string]: VectorTileLayer};
-}
-
-declare interface VectorTileLayer {
-    version?: number;
-    name: string;
-    extent: number;
-    length: number;
-    feature(i: number): VectorTileFeature;
-}
-
-declare interface VectorTileFeature {
-    extent: number;
-    type: 1 | 2 | 3;
-    id: number;
-    properties: {[_: string]: string | number | boolean};
-
-    loadGeometry(): Array<Array<Point>>;
-    toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
-}
-
 declare module "@mapbox/vector-tile" {
-    declare class VectorTileImpl {
-        constructor(pbf: Pbf): VectorTile;
-    }
+    import type Pbf from 'pbf';
+    import type Point from '@mapbox/point-geometry';
+    import type { GeoJSONFeature } from '@mapbox/geojson-types';
 
-    declare class VectorTileFeatureImpl {
-        static types: ['Unknown', 'Point', 'LineString', 'Polygon'];
+    declare export interface IVectorTile {
+        layers: {[_: string]: IVectorTileLayer};
+    }
+    declare export interface IVectorTileLayer {
+        version?: ?number;
+        name: string;
+        extent: number;
+        length: number;
+        feature(i: number): IVectorTileFeature;
+    }
+    declare export interface IVectorTileFeature {
+        extent: number;
+        type: 1 | 2 | 3;
+        id: number;
+        properties: {[_: string]: string | number | boolean};
+
+        loadGeometry(): Array<Array<Point>>;
         toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
     }
 
-    declare module.exports: {
-        VectorTile: typeof VectorTileImpl;
-        VectorTileFeature: typeof VectorTileFeatureImpl;
+    declare export class VectorTile implements IVectorTile {
+        constructor(pbf: Pbf): VectorTile;
+        layers: {[_: string]: IVectorTileLayer};
+    }
+    declare export class VectorTileLayer implements IVectorTileLayer {
+        version?: ?number;
+        name: string;
+        extent: number;
+        length: number;
+        feature(i: number): IVectorTileFeature;
+    }
+    declare export class VectorTileFeature implements IVectorTileFeature {
+        extent: number;
+        type: 1 | 2 | 3;
+        id: number;
+        properties: {[_: string]: string | number | boolean};
+
+        loadGeometry(): Array<Array<Point>>;
+        toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+
+        static types: ['Unknown', 'Point', 'LineString', 'Polygon'];
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^39.3.6",
-    "flow-bin": "0.143.0",
+    "flow-bin": "0.145.0",
     "gl": "5.0.3",
     "glob": "^8.0.3",
     "is-builtin-module": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.2",
-    "@mapbox/geojson-types": "^1.0.2",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.1",
     "@mapbox/point-geometry": "^0.1.0",
@@ -63,7 +62,7 @@
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^39.3.6",
-    "flow-bin": "0.142.0",
+    "flow-bin": "0.143.0",
     "gl": "5.0.3",
     "glob": "^8.0.3",
     "is-builtin-module": "^3.2.0",

--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -12,6 +12,7 @@ import type {CanonicalTileID} from '../source/tile_id.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
 import type Point from '@mapbox/point-geometry';
 import type {ProjectionSpecification} from '../style-spec/types.js';
+import type {IVectorTileFeature, IVectorTileLayer} from '@mapbox/vector-tile';
 
 export type BucketParameters<Layer: TypedStyleLayer> = {
     index: number,
@@ -37,7 +38,7 @@ export type PopulateParameters = {
 }
 
 export type IndexedFeature = {
-    feature: VectorTileFeature,
+    feature: IVectorTileFeature,
     id: number | string | void,
     index: number,
     sourceLayerIndex: number,
@@ -84,7 +85,7 @@ export interface Bucket {
     +stateDependentLayers: Array<any>;
     +stateDependentLayerIds: Array<string>;
     populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform): void;
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions): void;
+    update(states: FeatureStates, vtLayer: IVectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions): void;
     isEmpty(): boolean;
 
     upload(context: Context): void;

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -32,6 +32,7 @@ import type {TileTransform} from '../../geo/projection/tile_transform.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import type Projection from '../../geo/projection/projection.js';
 import type {Vec3} from 'gl-matrix';
+import {IVectorTileLayer} from '@mapbox/vector-tile';
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
     layoutVertexArray.emplaceBack(
@@ -151,7 +152,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
         }
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
+    update(states: FeatureStates, vtLayer: IVectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -32,7 +32,7 @@ import type {TileTransform} from '../../geo/projection/tile_transform.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import type Projection from '../../geo/projection/projection.js';
 import type {Vec3} from 'gl-matrix';
-import {IVectorTileLayer} from '@mapbox/vector-tile';
+import type {IVectorTileLayer} from '@mapbox/vector-tile';
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
     layoutVertexArray.emplaceBack(

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -33,7 +33,7 @@ import type {FeatureStates} from '../../source/source_state.js';
 import type {SpritePositions} from '../../util/image.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
-import {IVectorTileLayer} from '@mapbox/vector-tile';
+import type {IVectorTileLayer} from '@mapbox/vector-tile';
 
 class FillBucket implements Bucket {
     index: number;

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -33,6 +33,7 @@ import type {FeatureStates} from '../../source/source_state.js';
 import type {SpritePositions} from '../../util/image.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
+import {IVectorTileLayer} from '@mapbox/vector-tile';
 
 class FillBucket implements Bucket {
     index: number;
@@ -132,7 +133,7 @@ class FillBucket implements Bucket {
         }
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
+    update(states: FeatureStates, vtLayer: IVectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -8,8 +8,8 @@ import {ProgramConfigurationSet} from '../program_configuration.js';
 import {TriangleIndexArray} from '../index_array_type.js';
 import EXTENT from '../extent.js';
 import earcut from 'earcut';
-import mvt from '@mapbox/vector-tile';
-const vectorTileFeatureTypes = mvt.VectorTileFeature.types;
+import {VectorTileFeature} from '@mapbox/vector-tile';
+const vectorTileFeatureTypes = VectorTileFeature.types;
 import classifyRings from '../../util/classify_rings.js';
 import assert from 'assert';
 const EARCUT_MAX_RINGS = 500;
@@ -42,6 +42,7 @@ import type {SpritePositions} from '../../util/image.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
 import {earthRadius} from '../../geo/lng_lat.js';
+import {IVectorTileLayer} from '@mapbox/vector-tile';
 
 const FACTOR = Math.pow(2, 13);
 
@@ -274,7 +275,7 @@ class FillExtrusionBucket implements Bucket {
         this.sortBorders();
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
+    update(states: FeatureStates, vtLayer: IVectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }
@@ -615,7 +616,7 @@ class FillExtrusionBucket implements Bucket {
         }
     }
 
-    encodeCentroid(c: Point, metadata: PartMetadata, append: boolean = true) {
+    encodeCentroid(c: ?Point, metadata: PartMetadata, append: boolean = true) {
         let x, y;
         // Encoded centroid x and y:
         //     x     y

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -32,6 +32,7 @@ import type {
     IndexedFeature,
     PopulateParameters
 } from '../bucket.js';
+import {earthRadius} from '../../geo/lng_lat.js';
 
 import type FillExtrusionStyleLayer from '../../style/style_layer/fill_extrusion_style_layer.js';
 import type Context from '../../gl/context.js';
@@ -41,8 +42,7 @@ import type {FeatureStates} from '../../source/source_state.js';
 import type {SpritePositions} from '../../util/image.js';
 import type {ProjectionSpecification} from '../../style-spec/types.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
-import {earthRadius} from '../../geo/lng_lat.js';
-import {IVectorTileLayer} from '@mapbox/vector-tile';
+import type {IVectorTileLayer} from '@mapbox/vector-tile';
 
 const FACTOR = Math.pow(2, 13);
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -35,7 +35,7 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {FeatureStates} from '../../source/source_state.js';
 import type LineAtlas from '../../render/line_atlas.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
-import {IVectorTileLayer} from '@mapbox/vector-tile';
+import type {IVectorTileLayer} from '@mapbox/vector-tile';
 
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -8,8 +8,8 @@ import SegmentVector from '../segment.js';
 import {ProgramConfigurationSet} from '../program_configuration.js';
 import {TriangleIndexArray} from '../index_array_type.js';
 import EXTENT from '../extent.js';
-import mvt from '@mapbox/vector-tile';
-const vectorTileFeatureTypes = mvt.VectorTileFeature.types;
+import {VectorTileFeature} from '@mapbox/vector-tile';
+const vectorTileFeatureTypes = VectorTileFeature.types;
 import {register} from '../../util/web_worker_transfer.js';
 import {hasPattern, addPatternDependencies} from './pattern_bucket_features.js';
 import loadGeometry from '../load_geometry.js';
@@ -35,6 +35,7 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {FeatureStates} from '../../source/source_state.js';
 import type LineAtlas from '../../render/line_atlas.js';
 import type {TileTransform} from '../../geo/projection/tile_transform.js';
+import {IVectorTileLayer} from '@mapbox/vector-tile';
 
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.
@@ -268,7 +269,7 @@ class LineBucket implements Bucket {
 
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
+    update(states: FeatureStates, vtLayer: IVectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, availableImages, imagePositions);
     }

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -520,16 +520,14 @@ class SymbolBucket implements Bucket {
 
                 // cos(11.25 degrees) = 0.98078528056
                 const cosAngleThreshold = 0.98078528056;
+                const predicate = (a, b) => {
+                    const v0 = tileCoordToECEF(a.x, a.y, canonical, 1);
+                    const v1 = tileCoordToECEF(b.x, b.y, canonical, 1);
+                    return vec3.dot(v0, v1) < cosAngleThreshold;
+                };
 
                 for (let i = 0; i < geom.length; i++) {
-                    geom[i] = resamplePred(
-                        geom[i],
-                        p => p,
-                        (a, b) => {
-                            const v0 = tileCoordToECEF(a.x, a.y, canonical, 1);
-                            const v1 = tileCoordToECEF(b.x, b.y, canonical, 1);
-                            return vec3.dot(v0, v1) < cosAngleThreshold;
-                        });
+                    geom[i] = resamplePred(geom[i], predicate);
                 }
             }
 

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -33,8 +33,8 @@ import {allowsVerticalWritingMode, stringContainsRTLText} from '../../util/scrip
 import {WritingMode} from '../../symbol/shaping.js';
 import loadGeometry from '../load_geometry.js';
 import toEvaluationFeature from '../evaluation_feature.js';
-import mvt from '@mapbox/vector-tile';
-const vectorTileFeatureTypes = mvt.VectorTileFeature.types;
+import {VectorTileFeature} from '@mapbox/vector-tile';
+const vectorTileFeatureTypes = VectorTileFeature.types;
 import {verticalizedCharacterMap} from '../../util/verticalize_punctuation.js';
 import Anchor from '../../symbol/anchor.js';
 import {getSizeData} from '../../symbol/symbol_size.js';
@@ -84,6 +84,7 @@ export type SingleCollisionBox = {
 };
 import type {Mat4, Vec3} from 'gl-matrix';
 import type {SpritePositions} from '../../util/image.js';
+import type {IVectorTileLayer} from '@mapbox/vector-tile';
 
 export type CollisionArrays = {
     textBox?: SingleCollisionBox;
@@ -620,7 +621,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    update(states: FeatureStates, vtLayer: VectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
+    update(states: FeatureStates, vtLayer: IVectorTileLayer, availableImages: Array<string>, imagePositions: SpritePositions) {
         if (!this.stateDependentLayers.length) return;
         this.text.programConfigurations.updatePaintArrays(states, vtLayer, this.layers, availableImages, imagePositions);
         this.icon.programConfigurations.updatePaintArrays(states, vtLayer, this.layers, availableImages, imagePositions);

--- a/src/data/evaluation_feature.js
+++ b/src/data/evaluation_feature.js
@@ -3,6 +3,7 @@
 import loadGeometry from './load_geometry.js';
 
 import type Point from '@mapbox/point-geometry';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 type EvaluationFeature = {
     +type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon',
@@ -19,7 +20,7 @@ type EvaluationFeature = {
  * @param {boolean} needGeometry
  * @private
  */
-export default function toEvaluationFeature(feature: VectorTileFeature, needGeometry: boolean): EvaluationFeature {
+export default function toEvaluationFeature(feature: IVectorTileFeature, needGeometry: boolean): EvaluationFeature {
     return {type: feature.type,
         id: feature.id,
         properties:feature.properties,

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -8,7 +8,7 @@ import EXTENT from './extent.js';
 import featureFilter from '../style-spec/feature_filter/index.js';
 import Grid from 'grid-index';
 import DictionaryCoder from '../util/dictionary_coder.js';
-import vt from '@mapbox/vector-tile';
+import {VectorTile} from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 import GeoJSONFeature from '../util/vectortile_to_geojson.js';
 import {arraysIntersect, mapObject, extend} from '../util/util.js';
@@ -29,6 +29,7 @@ import type {FilterSpecification, PromoteIdSpecification} from '../style-spec/ty
 import type {TilespaceQueryGeometry} from '../style/query_geometry.js';
 import type {FeatureIndex as FeatureIndexStruct} from './array_types.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
+import type {IVectorTileLayer, IVectorTileFeature} from '@mapbox/vector-tile';
 
 type QueryParameters = {
     pixelPosMatrix: Float32Array,
@@ -63,8 +64,8 @@ class FeatureIndex {
     rawTileData: ArrayBuffer;
     bucketLayerIDs: Array<Array<string>>;
 
-    vtLayers: {[_: string]: VectorTileLayer};
-    vtFeatures: {[_: string]: VectorTileFeature[]};
+    vtLayers: {[_: string]: IVectorTileLayer};
+    vtFeatures: {[_: string]: IVectorTileFeature[]};
     sourceLayerCoder: DictionaryCoder;
 
     constructor(tileID: OverscaledTileID, promoteId?: ?PromoteIdSpecification) {
@@ -77,7 +78,7 @@ class FeatureIndex {
         this.promoteId = promoteId;
     }
 
-    insert(feature: VectorTileFeature, geometry: Array<Array<Point>>, featureIndex: number, sourceLayerIndex: number, bucketIndex: number, layoutVertexArrayOffset: number = 0) {
+    insert(feature: IVectorTileFeature, geometry: Array<Array<Point>>, featureIndex: number, sourceLayerIndex: number, bucketIndex: number, layoutVertexArrayOffset: number = 0) {
         const key = this.featureIndexArray.length;
         this.featureIndexArray.emplaceBack(featureIndex, sourceLayerIndex, bucketIndex, layoutVertexArrayOffset);
 
@@ -104,9 +105,9 @@ class FeatureIndex {
         }
     }
 
-    loadVTLayers(): {[_: string]: VectorTileLayer} {
+    loadVTLayers(): {[_: string]: IVectorTileLayer} {
         if (!this.vtLayers) {
-            this.vtLayers = new vt.VectorTile(new Protobuf(this.rawTileData)).layers;
+            this.vtLayers = new VectorTile(new Protobuf(this.rawTileData)).layers;
             this.sourceLayerCoder = new DictionaryCoder(this.vtLayers ? Object.keys(this.vtLayers).sort() : ['_geojsonTileLayer']);
             this.vtFeatures = {};
             for (const layer in this.vtLayers) {
@@ -156,7 +157,7 @@ class FeatureIndex {
                 styleLayers,
                 serializedLayers,
                 sourceFeatureState,
-                (feature: VectorTileFeature, styleLayer: StyleLayer, featureState: Object, layoutVertexArrayOffset: number = 0) => {
+                (feature: IVectorTileFeature, styleLayer: StyleLayer, featureState: Object, layoutVertexArrayOffset: number = 0) => {
                     if (!featureGeometry) {
                         featureGeometry = loadGeometry(feature, this.tileID.canonical, args.tileTransform);
                     }
@@ -178,7 +179,7 @@ class FeatureIndex {
         styleLayers: {[_: string]: StyleLayer},
         serializedLayers: {[_: string]: Object},
         sourceFeatureState?: SourceFeatureState,
-        intersectionTest?: (feature: VectorTileFeature, styleLayer: StyleLayer, featureState: Object, layoutVertexArrayOffset: number) => boolean | number) {
+        intersectionTest?: (feature: IVectorTileFeature, styleLayer: StyleLayer, featureState: Object, layoutVertexArrayOffset: number) => boolean | number) {
 
         const {featureIndex, bucketIndex, sourceLayerIndex, layoutVertexArrayOffset} = featureIndexData;
         const layerIDs = this.bucketLayerIDs[bucketIndex];
@@ -273,7 +274,7 @@ class FeatureIndex {
         return result;
     }
 
-    loadFeature(featureIndexData: FeatureIndices): VectorTileFeature {
+    loadFeature(featureIndexData: FeatureIndices): IVectorTileFeature {
         const {featureIndex, sourceLayerIndex} = featureIndexData;
 
         this.loadVTLayers();
@@ -300,7 +301,7 @@ class FeatureIndex {
         return false;
     }
 
-    getId(feature: VectorTileFeature, sourceLayerId: string): string | number | void {
+    getId(feature: IVectorTileFeature, sourceLayerId: string): string | number | void {
         let id = feature.id;
         if (this.promoteId) {
             const propName = typeof this.promoteId === 'string' ? this.promoteId : this.promoteId[sourceLayerId];

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -17,6 +17,7 @@ import {
     UniformColor,
     Uniform4f
 } from '../render/uniform_binding.js';
+import assert from 'assert';
 
 import type {CanonicalTileID} from '../source/tile_id.js';
 import type Context from '../gl/context.js';
@@ -35,7 +36,7 @@ import type {
 import type {PossiblyEvaluated} from '../style/properties.js';
 import type {FeatureStates} from '../source/source_state.js';
 import type {FormattedSection} from '../style-spec/expression/types/formatted.js';
-import assert from 'assert';
+import type {IVectorTileLayer} from '@mapbox/vector-tile';
 
 export type BinderUniform = {
     name: string,
@@ -470,7 +471,7 @@ export default class ProgramConfiguration {
         }
     }
 
-    updatePaintArrays(featureStates: FeatureStates, featureMap: FeaturePositionMap, vtLayer: VectorTileLayer, layer: TypedStyleLayer, availableImages: Array<string>, imagePositions: SpritePositions): boolean {
+    updatePaintArrays(featureStates: FeatureStates, featureMap: FeaturePositionMap, vtLayer: IVectorTileLayer, layer: TypedStyleLayer, availableImages: Array<string>, imagePositions: SpritePositions): boolean {
         let dirty: boolean = false;
         for (const id in featureStates) {
             const positions = featureMap.getPositions(id);
@@ -618,7 +619,7 @@ export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
         this.needsUpload = true;
     }
 
-    updatePaintArrays(featureStates: FeatureStates, vtLayer: VectorTileLayer, layers: $ReadOnlyArray<TypedStyleLayer>, availableImages: Array<string>, imagePositions: SpritePositions) {
+    updatePaintArrays(featureStates: FeatureStates, vtLayer: IVectorTileLayer, layers: $ReadOnlyArray<TypedStyleLayer>, availableImages: Array<string>, imagePositions: SpritePositions) {
         for (const layer of layers) {
             this.needsUpload = this.programConfigurations[layer.id].updatePaintArrays(featureStates, this._featureMap, vtLayer, layer, availableImages, imagePositions) || this.needsUpload;
         }

--- a/src/geo/projection/resample.js
+++ b/src/geo/projection/resample.js
@@ -29,7 +29,7 @@ function addResampled(resampled, mx0, my0, mx2, my2, start, end, reproject, tole
 
 // reproject and resample a line, adding point where necessary for lines that become curves;
 // note that this operation is mutable (modifying original points) for performance
-export default function resample(line: Array<Point>, reproject: (Point) => Point, tolerance: number): Array<Point> {
+export default function resample(line: Array<Point>, reproject: (Point) => void, tolerance: number): Array<Point> {
     let prev = line[0];
     let mx0 = prev.x;
     let my0 = prev.y;
@@ -49,31 +49,27 @@ export default function resample(line: Array<Point>, reproject: (Point) => Point
     return resampled;
 }
 
-function addResampledPred(resampled: Point[], a: Point, b: Point, reproject, pred) {
+function addResampledPred(resampled: Point[], a: Point, b: Point, pred) {
     const split = pred(a, b);
 
     // if the predicate condition is met, recurse into two halves
     if (split) {
-        const mid = a.add(b).mult(0.5);
-        reproject(mid);
-
-        addResampledPred(resampled, a, mid, reproject, pred);
-        addResampledPred(resampled, mid, b, reproject, pred);
+        const mid = a.add(b)._mult(0.5);
+        addResampledPred(resampled, a, mid, pred);
+        addResampledPred(resampled, mid, b, pred);
 
     } else {
         resampled.push(b);
     }
 }
 
-export function resamplePred(line: Point[], reproject: (Point) => Point, predicate: (Point, Point) => boolean): Point[] {
+export function resamplePred(line: Point[], predicate: (Point, Point) => boolean): Point[] {
     let prev = line[0];
-    reproject(prev);
     const resampled = [prev];
 
     for (let i = 1; i < line.length; i++) {
         const point = line[i];
-        reproject(point);
-        addResampledPred(resampled, prev, point, reproject, predicate);
+        addResampledPred(resampled, prev, point, predicate);
         prev = point;
     }
 

--- a/src/source/geojson_wrapper.js
+++ b/src/source/geojson_wrapper.js
@@ -2,9 +2,11 @@
 
 import Point from '@mapbox/point-geometry';
 
-import mvt from '@mapbox/vector-tile';
-const toGeoJSON = mvt.VectorTileFeature.prototype.toGeoJSON;
+import {VectorTileFeature} from '@mapbox/vector-tile';
+const toGeoJSON = VectorTileFeature.prototype.toGeoJSON;
 import EXTENT from '../data/extent.js';
+
+import type {IVectorTile, IVectorTileLayer, IVectorTileFeature} from '@mapbox/vector-tile';
 
 // The feature type used by geojson-vt and supercluster. Should be extracted to
 // global type and used in module definitions for those two modules.
@@ -20,7 +22,7 @@ type Feature = {
     geometry: Array<Array<[number, number]>>,
 }
 
-class FeatureWrapper implements VectorTileFeature {
+class FeatureWrapper implements IVectorTileFeature {
     _feature: Feature;
 
     extent: number;
@@ -71,8 +73,8 @@ class FeatureWrapper implements VectorTileFeature {
     }
 }
 
-class GeoJSONWrapper implements VectorTile, VectorTileLayer {
-    layers: {[_: string]: VectorTileLayer};
+class GeoJSONWrapper implements IVectorTile, IVectorTileLayer {
+    layers: {[_: string]: IVectorTileLayer};
     name: string;
     extent: number;
     length: number;
@@ -86,7 +88,7 @@ class GeoJSONWrapper implements VectorTile, VectorTileLayer {
         this._features = features;
     }
 
-    feature(i: number): VectorTileFeature {
+    feature(i: number): IVectorTileFeature {
         return new FeatureWrapper(this._features[i]);
     }
 }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -57,6 +57,7 @@ import type Painter from '../render/painter.js';
 import type {QueryFeature} from '../util/vectortile_to_geojson.js';
 import type {Vec3} from 'gl-matrix';
 import type {TextureImage} from '../render/texture.js';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 export type TileState =

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -2,7 +2,7 @@
 
 import {getArrayBuffer} from '../util/ajax.js';
 
-import vt from '@mapbox/vector-tile';
+import {VectorTile} from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 import WorkerTile from './worker_tile.js';
 import {extend} from '../util/util.js';
@@ -22,10 +22,11 @@ import type Actor from '../util/actor.js';
 import type StyleLayerIndex from '../style/style_layer_index.js';
 import type {Callback} from '../types/callback.js';
 import type Scheduler from '../util/scheduler.js';
+import type {IVectorTile} from '@mapbox/vector-tile';
 
 export type LoadVectorTileResult = {
     rawData: ArrayBuffer;
-    vectorTile?: VectorTile;
+    vectorTile?: IVectorTile;
     expires?: any;
     cacheControl?: any;
     resourceTiming?: Array<PerformanceResourceTiming>;
@@ -106,7 +107,7 @@ export function loadVectorTile(params: RequestedTileParameters, callback: LoadVe
                 callback(err);
             } else if (data) {
                 callback(null, {
-                    vectorTile: skipParse ? undefined : new vt.VectorTile(new Protobuf(data)),
+                    vectorTile: skipParse ? undefined : new VectorTile(new Protobuf(data)),
                     rawData: data,
                     cacheControl,
                     expires
@@ -200,7 +201,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
 
             // response.vectorTile will be present in the GeoJSON worker case (which inherits from this class)
             // because we stub the vector tile interface around JSON data instead of parsing it directly
-            workerTile.vectorTile = response.vectorTile || new vt.VectorTile(new Protobuf(rawTileData));
+            workerTile.vectorTile = response.vectorTile || new VectorTile(new Protobuf(rawTileData));
             const parseTile = () => {
                 workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
                     if (err || !result) return callback(err);

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -32,6 +32,7 @@ import type {
 } from '../source/worker_source.js';
 import type {PromoteIdSpecification} from '../style-spec/types.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
+import type {VectorTile, IVectorTile} from '@mapbox/vector-tile';
 
 class WorkerTile {
     tileID: OverscaledTileID;
@@ -53,12 +54,12 @@ class WorkerTile {
     tileTransform: TileTransform;
 
     status: 'parsing' | 'done';
-    data: VectorTile;
+    data: IVectorTile;
     collisionBoxArray: CollisionBoxArray;
 
     abort: ?() => void;
     reloadCallback: ?WorkerTileCallback;
-    vectorTile: VectorTile;
+    vectorTile: IVectorTile;
 
     constructor(params: WorkerTileParameters) {
         this.tileID = new OverscaledTileID(params.tileID.overscaledZ, params.tileID.wrap, params.tileID.canonical.z, params.tileID.canonical.x, params.tileID.canonical.y);
@@ -80,7 +81,7 @@ class WorkerTile {
         this.projection = params.projection;
     }
 
-    parse(data: VectorTile, layerIndex: StyleLayerIndex, availableImages: Array<string>, actor: Actor, callback: WorkerTileCallback) {
+    parse(data: IVectorTile, layerIndex: StyleLayerIndex, availableImages: Array<string>, actor: Actor, callback: WorkerTileCallback) {
         const m = PerformanceUtils.beginMeasure('parseTile1');
         this.status = 'parsing';
         this.data = data;

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -32,7 +32,7 @@ import type {
 } from '../source/worker_source.js';
 import type {PromoteIdSpecification} from '../style-spec/types.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
-import type {VectorTile, IVectorTile} from '@mapbox/vector-tile';
+import type {IVectorTile} from '@mapbox/vector-tile';
 
 class WorkerTile {
     tileID: OverscaledTileID;

--- a/src/style-spec/expression/definitions/within.js
+++ b/src/style-spec/expression/definitions/within.js
@@ -7,7 +7,6 @@ import type {Expression, SerializedExpression} from '../expression.js';
 import type ParsingContext from '../parsing_context.js';
 import type EvaluationContext from '../evaluation_context.js';
 import type {GeoJSON, GeoJSONPolygon, GeoJSONMultiPolygon} from '@mapbox/geojson-types';
-import Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../../../source/tile_id.js';
 
 type GeoJSONPolygons =| GeoJSONPolygon | GeoJSONMultiPolygon;
@@ -16,7 +15,7 @@ type GeoJSONPolygons =| GeoJSONPolygon | GeoJSONMultiPolygon;
 type BBox = [number, number, number, number];
 const EXTENT = 8192;
 
-function updateBBox(bbox: BBox, coord: Point) {
+function updateBBox(bbox: BBox, coord: [number, number]) {
     bbox[0] = Math.min(bbox[0], coord[0]);
     bbox[1] = Math.min(bbox[1], coord[1]);
     bbox[2] = Math.max(bbox[2], coord[0]);

--- a/src/style/query_geometry.js
+++ b/src/style/query_geometry.js
@@ -65,12 +65,17 @@ export class QueryGeometry {
     static createFromScreenPoints(geometry: PointLike | [PointLike, PointLike], transform: Transform): QueryGeometry {
         let screenGeometry;
         let aboveHorizon;
+
+        // $FlowFixMe: Flow can't refine that this will be PointLike but we can
         if (geometry instanceof Point || typeof geometry[0] === 'number') {
+            // $FlowFixMe
             const pt = Point.convert(geometry);
-            screenGeometry = [Point.convert(geometry)];
+            screenGeometry = [pt];
             aboveHorizon = transform.isPointAboveHorizon(pt);
         } else {
+            // $FlowFixMe
             const tl = Point.convert(geometry[0]);
+            // $FlowFixMe
             const br = Point.convert(geometry[1]);
             screenGeometry = [tl, br];
             aboveHorizon = polygonizeBounds(tl, br).every((p) => transform.isPointAboveHorizon(p));

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -33,6 +33,7 @@ import type Map from '../ui/map.js';
 import type {StyleSetterOptions} from './style.js';
 import type {TilespaceQueryGeometry} from './query_geometry.js';
 import type {DEMSampler} from '../terrain/elevation.js';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 const TRANSITION_SUFFIX = '-transition';
 
@@ -60,7 +61,7 @@ class StyleLayer extends Evented {
 
     +queryRadius: (bucket: Bucket) => number;
     +queryIntersectsFeature: (queryGeometry: TilespaceQueryGeometry,
-                              feature: VectorTileFeature,
+                              feature: IVectorTileFeature,
                               featureState: FeatureState,
                               geometry: Array<Array<Point>>,
                               zoom: number,

--- a/src/style/style_layer/circle_style_layer.js
+++ b/src/style/style_layer/circle_style_layer.js
@@ -22,6 +22,7 @@ import type {LayoutProps, PaintProps} from './circle_style_layer_properties.js';
 import type {LayerSpecification} from '../../style-spec/types.js';
 import type {TilespaceQueryGeometry} from '../query_geometry.js';
 import type {DEMSampler} from '../../terrain/elevation.js';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 class CircleStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<LayoutProps>;
@@ -47,7 +48,7 @@ class CircleStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(queryGeometry: TilespaceQueryGeometry,
-                           feature: VectorTileFeature,
+                           feature: IVectorTileFeature,
                            featureState: FeatureState,
                            geometry: Array<Array<Point>>,
                            zoom: number,

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -22,6 +22,15 @@ import type {DEMSampler} from '../../terrain/elevation.js';
 import type {Vec2, Vec4} from 'gl-matrix';
 import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
+class Point3D extends Point {
+    z: number;
+
+    constructor(x: number, y: number, z: number) {
+        super(x, y);
+        this.z = z;
+    }
+}
+
 class FillExtrusionStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<PaintProps>;
     _transitioningPaint: Transitioning<PaintProps>;
@@ -112,7 +121,7 @@ function dot(a, b) {
     return a.x * b.x + a.y * b.y;
 }
 
-export function getIntersectionDistance(projectedQueryGeometry: Array<Point>, projectedFace: Array<Point>): number {
+export function getIntersectionDistance(projectedQueryGeometry: Array<Point>, projectedFace: Array<Point3D>): number {
 
     if (projectedQueryGeometry.length === 1) {
         // For point queries calculate the z at which the point intersects the face
@@ -175,7 +184,7 @@ export function getIntersectionDistance(projectedQueryGeometry: Array<Point>, pr
     }
 }
 
-function checkIntersection(projectedBase: Array<Array<Point>>, projectedTop: Array<Array<Point>>, projectedQueryGeometry: Array<Point>) {
+function checkIntersection(projectedBase: Array<Array<Point3D>>, projectedTop: Array<Array<Point3D>>, projectedQueryGeometry: Array<Point>) {
     let closestDistance = Infinity;
 
     if (polygonIntersectsMultiPolygon(projectedQueryGeometry, projectedTop)) {
@@ -274,8 +283,8 @@ function projectExtrusionGlobe(tr: Transform, geometry: Array<Array<Point>>, zBa
             vec3.transformMat4(basePoint, basePoint, m);
             vec3.transformMat4(topPoint, topPoint, m);
 
-            ringBase.push(toPoint(basePoint));
-            ringTop.push(toPoint(topPoint));
+            ringBase.push(new Point3D(basePoint[0], basePoint[1], basePoint[2]));
+            ringTop.push(new Point3D(topPoint[0], topPoint[1], topPoint[2]));
         }
         projectedBase.push(ringBase);
         projectedTop.push(ringTop);
@@ -326,13 +335,8 @@ function projectExtrusion2D(geometry: Array<Array<Point>>, zBase: number, zTop: 
             const topZ = sZ + topZZ;
             const topW = Math.max(sW + topWZ, 0.00001);
 
-            const b = new Point(baseX / baseW, baseY / baseW);
-            b.z = baseZ / baseW;
-            ringBase.push(b);
-
-            const t = new Point(topX / topW, topY / topW);
-            t.z = topZ / topW;
-            ringTop.push(t);
+            ringBase.push(new Point3D(baseX / baseW, baseY / baseW, baseZ / baseW));
+            ringTop.push(new Point3D(topX / topW, topY / topW, topZ / topW));
         }
         projectedBase.push(ringBase);
         projectedTop.push(ringTop);
@@ -368,7 +372,7 @@ function projectExtrusion3D(geometry: Array<Array<Point>>, zBase: number, zTop: 
             v[3] = 1;
             vec4.transformMat4(v, v, m);
             v[3] = Math.max(v[3], 0.00001);
-            const base = toPoint([v[0] / v[3], v[1] / v[3], v[2] / v[3]]);
+            const base = new Point3D(v[0] / v[3], v[1] / v[3], v[2] / v[3]);
 
             v[0] = x;
             v[1] = y;
@@ -376,7 +380,7 @@ function projectExtrusion3D(geometry: Array<Array<Point>>, zBase: number, zTop: 
             v[3] = 1;
             vec4.transformMat4(v, v, m);
             v[3] = Math.max(v[3], 0.00001);
-            const top = toPoint([v[0] / v[3], v[1] / v[3], v[2] / v[3]]);
+            const top = new Point3D(v[0] / v[3], v[1] / v[3], v[2] / v[3]);
 
             ringBase.push(base);
             ringTop.push(top);
@@ -385,12 +389,6 @@ function projectExtrusion3D(geometry: Array<Array<Point>>, zBase: number, zTop: 
         projectedTop.push(ringTop);
     }
     return [projectedBase, projectedTop];
-}
-
-function toPoint(v: Vec4): Point {
-    const p = new Point(v[0], v[1]);
-    p.z = v[2];
-    return p;
 }
 
 function getTerrainHeightOffset(x: number, y: number, zBase: number, zTop: number, demSampler: DEMSampler, centroid: Vec2, exaggeration: number, lat: number): { base: number, top: number} {

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -20,6 +20,7 @@ import type {LayerSpecification} from '../../style-spec/types.js';
 import type {TilespaceQueryGeometry} from '../query_geometry.js';
 import type {DEMSampler} from '../../terrain/elevation.js';
 import type {Vec2, Vec4} from 'gl-matrix';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 class FillExtrusionStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<PaintProps>;
@@ -54,7 +55,7 @@ class FillExtrusionStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(queryGeometry: TilespaceQueryGeometry,
-                           feature: VectorTileFeature,
+                           feature: IVectorTileFeature,
                            featureState: FeatureState,
                            geometry: Array<Array<Point>>,
                            zoom: number,

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -100,9 +100,7 @@ class FillExtrusionStyleLayer extends StyleLayer {
         }
 
         const demSampler = terrainVisible ? elevationHelper : null;
-        const projected = projectExtrusion(transform, geometry, base, height, translation, pixelPosMatrix, demSampler, centroid, exaggeration, transform.center.lat, queryGeometry.tileID.canonical);
-        const projectedBase = projected[0];
-        const projectedTop = projected[1];
+        const [projectedBase, projectedTop] = projectExtrusion(transform, geometry, base, height, translation, pixelPosMatrix, demSampler, centroid, exaggeration, transform.center.lat, queryGeometry.tileID.canonical);
 
         const screenQuery = queryGeometry.queryGeometry;
         const projectedQueryGeometry = screenQuery.isPointQuery() ? screenQuery.screenBounds : screenQuery.screenGeometry;
@@ -177,7 +175,7 @@ export function getIntersectionDistance(projectedQueryGeometry: Array<Point>, pr
     }
 }
 
-function checkIntersection(projectedBase: Array<Point>, projectedTop: Array<Point>, projectedQueryGeometry: Array<Point>) {
+function checkIntersection(projectedBase: Array<Array<Point>>, projectedTop: Array<Array<Point>>, projectedQueryGeometry: Array<Point>) {
     let closestDistance = Infinity;
 
     if (polygonIntersectsMultiPolygon(projectedQueryGeometry, projectedTop)) {

--- a/src/style/style_layer/fill_style_layer.js
+++ b/src/style/style_layer/fill_style_layer.js
@@ -17,6 +17,7 @@ import type EvaluationParameters from '../evaluation_parameters.js';
 import type Transform from '../../geo/transform.js';
 import type {LayerSpecification} from '../../style-spec/types.js';
 import type {TilespaceQueryGeometry} from '../query_geometry.js';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 class FillStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<LayoutProps>;
@@ -65,7 +66,7 @@ class FillStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(queryGeometry: TilespaceQueryGeometry,
-                           feature: VectorTileFeature,
+                           feature: IVectorTileFeature,
                            featureState: FeatureState,
                            geometry: Array<Array<Point>>,
                            zoom: number,

--- a/src/style/style_layer/heatmap_style_layer.js
+++ b/src/style/style_layer/heatmap_style_layer.js
@@ -22,6 +22,7 @@ import type {DEMSampler} from '../../terrain/elevation.js';
 import type {FeatureState} from '../../style-spec/expression/index.js';
 import type Transform from '../../geo/transform.js';
 import type CircleBucket from '../../data/bucket/circle_bucket.js';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 class HeatmapStyleLayer extends StyleLayer {
 
@@ -72,7 +73,7 @@ class HeatmapStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(queryGeometry: TilespaceQueryGeometry,
-                           feature: VectorTileFeature,
+                           feature: IVectorTileFeature,
                            featureState: FeatureState,
                            geometry: Array<Array<Point>>,
                            zoom: number,

--- a/src/style/style_layer/line_style_layer.js
+++ b/src/style/style_layer/line_style_layer.js
@@ -19,6 +19,7 @@ import type {LayoutProps, PaintProps} from './line_style_layer_properties.js';
 import type Transform from '../../geo/transform.js';
 import type {LayerSpecification} from '../../style-spec/types.js';
 import type {TilespaceQueryGeometry} from '../query_geometry.js';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 class LineFloorwidthProperty extends DataDrivenProperty<number> {
     useIntegerZoom: true;
@@ -102,7 +103,7 @@ class LineStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(queryGeometry: TilespaceQueryGeometry,
-                           feature: VectorTileFeature,
+                           feature: IVectorTileFeature,
                            featureState: FeatureState,
                            geometry: Array<Array<Point>>,
                            zoom: number,

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -183,7 +183,7 @@ function getGlCoordMatrix(posMatrix: Float32Array,
     }
 }
 
-function project(point: Point, matrix: Mat4, elevation: number = 0): ProjectedSymbol {
+function project(point: {x: number, y: number}, matrix: Mat4, elevation: number = 0): ProjectedSymbol {
     const pos = [point.x, point.y, elevation, 1];
     if (elevation) {
         vec4.transformMat4(pos, pos, matrix);
@@ -597,7 +597,8 @@ function placeGlyphAlongLine(
     };
 
     const getTruncatedLineSegment = () => {
-        return projectTruncatedLineSegment(previousTilePoint(), currentVertex, prev, absOffsetX - distanceToPrev + 1, labelPlaneMatrix, getElevation, reprojection, tileID.canonical);
+        const prevTilePoint = previousTilePoint();
+        return projectTruncatedLineSegment(prevTilePoint, currentVertex || prevTilePoint, prev, absOffsetX - distanceToPrev + 1, labelPlaneMatrix, getElevation, reprojection, tileID.canonical);
     };
 
     while (distanceToPrev + currentSegmentDistance <= absOffsetX) {

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -172,8 +172,8 @@ class MouseRotateWrapper {
     element: HTMLElement;
     mouseRotate: MouseRotateHandler;
     mousePitch: MousePitchHandler;
-    _startPos: Point;
-    _lastPos: Point;
+    _startPos: ?Point;
+    _lastPos: ?Point;
 
     constructor(map: Map, element: HTMLElement, pitch?: boolean = false) {
         this._clickTolerance = 10;

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -21,8 +21,8 @@ class BoxZoomHandler {
     _container: HTMLElement;
     _enabled: boolean;
     _active: boolean;
-    _startPos: Point;
-    _lastPos: Point;
+    _startPos: ?Point;
+    _lastPos: ?Point;
     _box: HTMLElement;
     _clickTolerance: number;
 
@@ -95,12 +95,13 @@ class BoxZoomHandler {
         if (!this._active) return;
 
         const pos = point;
+        const p0 = this._startPos;
+        const p1 = this._lastPos;
 
-        if (this._lastPos.equals(pos) || (!this._box && pos.dist(this._startPos) < this._clickTolerance)) {
+        if (!p0 || !p1 || p1.equals(pos) || (!this._box && pos.dist(p0) < this._clickTolerance)) {
             return;
         }
 
-        const p0 = this._startPos;
         this._lastPos = pos;
 
         if (!this._box) {
@@ -126,10 +127,10 @@ class BoxZoomHandler {
     mouseupWindow(e: MouseEvent, point: Point): ?HandlerResult {
         if (!this._active) return;
 
-        if (e.button !== 0) return;
-
         const p0 = this._startPos,
             p1 = point;
+
+        if (!p0 || e.button !== 0) return;
 
         this.reset();
 

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -162,7 +162,7 @@ export class TouchRotateHandler extends TwoTouchHandler {
         const lastVector = this._vector;
         this._vector = points[0].sub(points[1]);
 
-        if (!lastVector || !this._active && this._isBelowThreshold(this._vector)) return;
+        if (!lastVector || (!this._active && this._isBelowThreshold(this._vector))) return;
         this._active = true;
 
         return {

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -25,7 +25,7 @@ class TwoTouchHandler {
     }
 
     _start(points: [Point, Point]) {} //eslint-disable-line
-    _move(points: [Point, Point], pinchAround: Point, e: TouchEvent): ?HandlerResult { return {}; } //eslint-disable-line
+    _move(points: [Point, Point], pinchAround: ?Point, e: TouchEvent): ?HandlerResult { return {}; } //eslint-disable-line
 
     touchstart(e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) {
         //console.log(e.target, e.targetTouches.length ? e.targetTouches[0].target : null);
@@ -123,7 +123,7 @@ export class TouchZoomHandler extends TwoTouchHandler {
         this._startDistance = this._distance = points[0].dist(points[1]);
     }
 
-    _move(points: [Point, Point], pinchAround: Point): ?HandlerResult {
+    _move(points: [Point, Point], pinchAround: ?Point): ?HandlerResult {
         const lastDistance = this._distance;
         this._distance = points[0].dist(points[1]);
         if (!this._active && Math.abs(getZoomDelta(this._distance, this._startDistance)) < ZOOM_THRESHOLD) return;
@@ -158,11 +158,11 @@ export class TouchRotateHandler extends TwoTouchHandler {
         this._minDiameter = points[0].dist(points[1]);
     }
 
-    _move(points: [Point, Point], pinchAround: Point): ?HandlerResult {
+    _move(points: [Point, Point], pinchAround: ?Point): ?HandlerResult {
         const lastVector = this._vector;
         this._vector = points[0].sub(points[1]);
 
-        if (!this._active && this._isBelowThreshold(this._vector)) return;
+        if (!lastVector || !this._active && this._isBelowThreshold(this._vector)) return;
         this._active = true;
 
         return {
@@ -186,7 +186,10 @@ export class TouchRotateHandler extends TwoTouchHandler {
         const circumference = Math.PI * this._minDiameter;
         const threshold = ROTATION_THRESHOLD / circumference * 360;
 
-        const bearingDeltaSinceStart = getBearingDelta(vector, this._startVector);
+        const startVector = this._startVector;
+        if (!startVector) return false;
+
+        const bearingDeltaSinceStart = getBearingDelta(vector, startVector);
         return Math.abs(bearingDeltaSinceStart) < threshold;
     }
 }
@@ -232,7 +235,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
 
     }
 
-    _move(points: [Point, Point], center: Point, e: TouchEvent): ?HandlerResult {
+    _move(points: [Point, Point], center: ?Point, e: TouchEvent): ?HandlerResult {
         const lastPoints = this._lastPoints;
         if (!lastPoints) return;
         const vectorA = points[0].sub(lastPoints[0]);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1733,7 +1733,7 @@ class Map extends Camera {
         }
 
         options = options || {};
-        geometry = geometry || [[0, 0], [this.transform.width, this.transform.height]];
+        geometry = geometry || [([0, 0]: PointLike), ([this.transform.width, this.transform.height]: PointLike)];
 
         return this.style.queryRenderedFeatures(geometry, options, this.transform);
     }

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -685,5 +685,6 @@ function normalizeOffset(offset: Offset = new Point(0, 0), anchor: Anchor = 'bot
     }
 
     // input specifies an offset per position
+    // $FlowFixMe we know offset is an object at this point but Flow can't refine it for some reason
     return Point.convert(offset[anchor] || [0, 0]);
 }

--- a/src/util/intersection_tests.js
+++ b/src/util/intersection_tests.js
@@ -6,11 +6,11 @@ import Point from '@mapbox/point-geometry';
 
 export {polygonIntersectsBufferedPoint, polygonIntersectsMultiPolygon, polygonIntersectsBufferedMultiLine, polygonIntersectsPolygon, distToSegmentSquared, polygonIntersectsBox, polygonContainsPoint};
 
-type Line = Array<Point>;
-type MultiLine = Array<Line>;
-type Ring = Array<Point>;
-type Polygon = Array<Point>;
-type MultiPolygon = Array<Polygon>;
+type Line = $ReadOnlyArray<Point>;
+type MultiLine = $ReadOnlyArray<Line>;
+type Ring = $ReadOnlyArray<Point>;
+type Polygon = $ReadOnlyArray<Point>;
+type MultiPolygon = $ReadOnlyArray<Polygon>;
 
 function polygonIntersectsPolygon(polygonA: Polygon, polygonB: Polygon): boolean {
     for (let i = 0; i < polygonA.length; i++) {
@@ -133,7 +133,7 @@ function distToSegmentSquared(p: Point, v: Point, w: Point): number {
 }
 
 // point in polygon ray casting algorithm
-function multiPolygonContainsPoint(rings: Array<Ring>, p: Point) {
+function multiPolygonContainsPoint(rings: MultiPolygon, p: Point) {
     let c = false,
         ring, p1, p2;
 

--- a/src/util/polygon_clipping.js
+++ b/src/util/polygon_clipping.js
@@ -8,7 +8,9 @@ export type ClippedPolygon = {
     bounds: [Point, Point]
 };
 
-function clipPolygon(polygons: Array<Array<Point>>, clipAxis1: number, clipAxis2: number, axis: number): Array<Array<Point>> {
+type PolygonArray = Array<Array<Array<Point>>>;
+
+function clipPolygon(polygons: PolygonArray, clipAxis1: number, clipAxis2: number, axis: number): PolygonArray {
     const intersectX = (ring, ax, ay, bx, by, x) => {
         ring.push(new Point(x, ay + (by - ay) * ((x - ax) / (bx - ax))));
     };
@@ -73,7 +75,7 @@ function clipPolygon(polygons: Array<Array<Point>>, clipAxis1: number, clipAxis2
     return polygonsClipped;
 }
 
-export function subdividePolygons(polygons: Array<Array<Point>>, bounds: [Point, Point], gridSizeX: number, gridSizeY: number, padding: number = 0.0, splitFn: Function): Array<ClippedPolygon> {
+export function subdividePolygons(polygons: PolygonArray, bounds: [Point, Point], gridSizeX: number, gridSizeY: number, padding: number = 0.0, splitFn: Function): Array<ClippedPolygon> {
     const outPolygons = [];
 
     if (!polygons.length || !gridSizeX || !gridSizeY) {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -105,12 +105,12 @@ export function getBounds(points: Point[]): { min: Point, max: Point} {
  * Returns the square of the 2D distance between an AABB defined by min and max and a point.
  * If point is null or undefined, the AABB distance from the origin (0,0) is returned.
  *
- * @param {Point} min The minimum extent of the AABB.
- * @param {Point} max The maximum extent of the AABB.
- * @param {Point} [point] The point to compute the distance from, may be undefined.
+ * @param {Array<number>} min The minimum extent of the AABB.
+ * @param {Array<number>} max The maximum extent of the AABB.
+ * @param {Array<number>} [point] The point to compute the distance from, may be undefined.
  * @returns {number} The square distance from the AABB, 0.0 if the AABB contains the point.
  */
-export function getAABBPointSquareDist(min: Point, max: Point, point: ?Point): number {
+export function getAABBPointSquareDist(min: Array<number>, max: Array<number>, point: ?Array<number>): number {
     let sqDist = 0.0;
 
     for (let i = 0; i < 2; ++i) {

--- a/src/util/vectortile_to_geojson.js
+++ b/src/util/vectortile_to_geojson.js
@@ -1,6 +1,7 @@
 // @flow
 import type {LayerSpecification} from '../style-spec/types.js';
 import type {GeoJSONGeometry, GeoJSONFeature} from '@mapbox/geojson-types';
+import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 // we augment GeoJSON with custom properties in query*Features results
 export type QueryFeature = $ReadOnly<GeoJSONFeature> & {
@@ -15,7 +16,7 @@ class Feature {
     _geometry: ?GeoJSONGeometry;
     properties: {};
     id: number | string | void;
-    _vectorTileFeature: VectorTileFeature;
+    _vectorTileFeature: IVectorTileFeature;
     _x: number;
     _y: number;
     _z: number;
@@ -26,7 +27,7 @@ class Feature {
     sourceLayer: ?mixed;
     state: ?mixed;
 
-    constructor(vectorTileFeature: VectorTileFeature, z: number, x: number, y: number, id: string | number | void) {
+    constructor(vectorTileFeature: IVectorTileFeature, z: number, x: number, y: number, id: string | number | void) {
         this.type = 'Feature';
 
         this._vectorTileFeature = vectorTileFeature;

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import vt from '@mapbox/vector-tile';
+import {VectorTile} from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 import {test} from '../../util/test.js';
 import VectorTileWorkerSource from '../../../src/source/vector_tile_worker_source.js';
@@ -206,7 +206,7 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
 
     function loadVectorData(params, callback) {
         return callback(null, {
-            vectorTile: new vt.VectorTile(new Protobuf(rawTileData)),
+            vectorTile: new VectorTile(new Protobuf(rawTileData)),
             rawData: rawTileData,
             cacheControl: null,
             expires: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -3678,10 +3678,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@0.143.0:
-  version "0.143.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.143.0.tgz#f802a18ae86ba87e11dbbbba5922039b551e3f1c"
-  integrity sha512-wduASzl276BkxWBQ83wFMf43ZRNSCQdb4de7JA6GAGsJ7pAbETc1tGWRP/lnk9wnjxmH/tPeqIyLoRK1gvHkiA==
+flow-bin@0.145.0:
+  version "0.145.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.145.0.tgz#922f7c3568caaa5eb64621ec536deb56b24d1795"
+  integrity sha512-+9fi9BMxRBtSWC1x0hWggWTb8Vih+AC7wyvLAX5wR1m6u2lF2HLtixXqy2GX8bWgaynSEJR5lmPxYYC4wMI8cA==
 
 follow-redirects@^1.0.0:
   version "1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,11 +441,6 @@
     get-stream "^6.0.1"
     minimist "^1.2.6"
 
-"@mapbox/geojson-types@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz#9aecf642cb00eab1080a57c4f949a65b4a5846d6"
-  integrity sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==
-
 "@mapbox/jsonlint-lines-primitives@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
@@ -3683,10 +3678,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@0.142.0:
-  version "0.142.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.142.0.tgz#b46b69de1123cf7c5a50917402968e07291df054"
-  integrity sha512-YgiapK/wrJjcgSgOWfoncbZ4vZrZWdHs+p7V9duI9zo4ehW2nM/VRrpSaWoZ+CWu3t+duGyAvupJvC6MM2l07w==
+flow-bin@0.143.0:
+  version "0.143.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.143.0.tgz#f802a18ae86ba87e11dbbbba5922039b551e3f1c"
+  integrity sha512-wduASzl276BkxWBQ83wFMf43ZRNSCQdb4de7JA6GAGsJ7pAbETc1tGWRP/lnk9wnjxmH/tPeqIyLoRK1gvHkiA==
 
 follow-redirects@^1.0.0:
   version "1.15.1"


### PR DESCRIPTION
Upgrade Flow from v0.142 to v0.145 as a part of #12194. This was a difficult push because v0.143.0 fixed a bug which made Flow basically ignore many of the library definitions, leading to ~140 errors that were not caught before. A few notes:

- I had to inline `@mapbox/geojson-types` instead of using that package because the latter no longer works for reasons I don't really understand. On a positive note, we could now deprecate that package because it's no longer used anywhere else.
- `@mapbox/vector-tile`-related changes are due to the need to differentiate between `VectorTile`/etc. _class instances_ vs objects that fit corresponding `interfaces` (which is needed for our `GeoJSONWrapper` logic which wraps GeoJSON to imitate VT classes).
- There are many fixes related to objects that are expected to be of a certain type but could be `undefined`, something Flow didn't handle in all cases before.
- The config ignores were cleaned up of packages we no longer use.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
