### PR TITLE
Format shaders to support function constant blocks

### DIFF
--- a/src/shaders/atmosphere.fragment.glsl
+++ b/src/shaders/atmosphere.fragment.glsl
@@ -36,8 +36,9 @@ float stars(vec3 p, float scale, vec2 offset) {
 void main() {
     highp vec3 dir = normalize(v_ray_dir);
 
+    float globe_pos_dot_dir;
 #ifdef PROJECTION_GLOBE_VIEW
-    float globe_pos_dot_dir = dot(u_globe_pos, dir);
+    globe_pos_dot_dir = dot(u_globe_pos, dir);
     highp vec3 closest_point_forward = abs(globe_pos_dot_dir) * dir;
     float norm_dist_from_center = length(closest_point_forward - u_globe_pos) / u_globe_radius;
 
@@ -53,6 +54,7 @@ void main() {
     float horizon_angle_mercator = dir.y < horizon_dir.y ?
         0.0 : max(acos(dot(dir, horizon_dir)), 0.0);
 
+    float horizon_angle;
 #ifdef PROJECTION_GLOBE_VIEW
     // Angle between dir and globe center
     highp vec3 closest_point = globe_pos_dot_dir * dir;
@@ -60,7 +62,7 @@ void main() {
     float theta = asin(clamp(closest_point_to_center / length(u_globe_pos), -1.0, 1.0));
 
     // Backward facing closest point rays should be treated separately
-    float horizon_angle = globe_pos_dot_dir < 0.0 ?
+    horizon_angle = globe_pos_dot_dir < 0.0 ?
         PI - theta - u_horizon_angle : theta - u_horizon_angle;
 
     // Increase speed of change of the angle interpolation for
@@ -69,7 +71,7 @@ void main() {
 
     horizon_angle = mix(horizon_angle, horizon_angle_mercator, angle_t);
 #else
-    float horizon_angle = horizon_angle_mercator;
+    horizon_angle = horizon_angle_mercator;
 #endif
 
     // Normalize in [0, 1]

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -25,11 +25,13 @@ void main() {
     vec3 normal = v_normal;
 #endif
 
+float z;
+vec4 color;
 #ifdef ZERO_ROOF_RADIUS
-    float z = float(normal.z > 0.00001);
-    vec4 color = mix(v_color, v_roof_color, z);
+    z = float(normal.z > 0.00001);
+    color = mix(v_color, v_roof_color, z);
 #else
-    vec4 color = v_color;
+    color = v_color;
 #endif
 #ifdef FAUX_AO
     float intensity = u_ao[0];

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -84,16 +84,18 @@ void main() {
 
     float ele = 0.0;
     float h = 0.0;
+    float c_ele;
+    vec3 pos;
 #ifdef TERRAIN
     bool flat_roof = centroid_pos.x != 0.0 && t > 0.0;
     ele = elevation(pos_nx.xy);
-    float c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
+    c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
     // If centroid elevation lower than vertex elevation, roof at least 2 meters height above base.
     h = flat_roof ? max(c_ele + height, ele + base + 2.0) : ele + (t > 0.0 ? height : base == 0.0 ? -5.0 : base);
-    vec3 pos = vec3(pos_nx.xy, h);
+    pos = vec3(pos_nx.xy, h);
 #else
     h = t > 0.0 ? height : base;
-    vec3 pos = vec3(pos_nx.xy, h);
+    pos = vec3(pos_nx.xy, h);
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW

--- a/src/shaders/fill_extrusion_depth.vertex.glsl
+++ b/src/shaders/fill_extrusion_depth.vertex.glsl
@@ -30,15 +30,16 @@ void main() {
     centroid_pos = a_centroid_pos;
 #endif
 
+vec3 pos;
 #ifdef TERRAIN
     bool flat_roof = centroid_pos.x != 0.0 && t > 0.0;
     float ele = elevation(pos_nx.xy);
     float c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
     // If centroid elevation lower than vertex elevation, roof at least 2 meters height above base.
     float h = flat_roof ? max(c_ele + height, ele + base + 2.0) : ele + (t > 0.0 ? height : base);
-    vec3 pos = vec3(pos_nx.xy, h);
+    pos = vec3(pos_nx.xy, h);
 #else
-    vec3 pos = vec3(pos_nx.xy, t > 0.0 ? height : base);
+    pos = vec3(pos_nx.xy, t > 0.0 ? height : base);
 #endif
 
     float hidden = float(centroid_pos.x == 0.0 && centroid_pos.y == 1.0);

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -87,15 +87,17 @@ void main() {
 
     float ele = 0.0;
     float h = z;
+    vec3 p;
+    float c_ele;
 #ifdef TERRAIN
     bool flat_roof = centroid_pos.x != 0.0 && t > 0.0;
     ele = elevation(pos_nx.xy);
-    float c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
+    c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
     // If centroid elevation lower than vertex elevation, roof at least 2 meters height above base.
     h = flat_roof ? max(c_ele + height, ele + base + 2.0) : ele + (t > 0.0 ? height : base == 0.0 ? -5.0 : base);
-    vec3 p = vec3(pos_nx.xy, h);
+    p = vec3(pos_nx.xy, h);
 #else
-    vec3 p = vec3(pos_nx.xy, z);
+    p = vec3(pos_nx.xy, z);
 #endif
 
 #ifdef PROJECTION_GLOBE_VIEW

--- a/src/shaders/globe_raster.fragment.glsl
+++ b/src/shaders/globe_raster.fragment.glsl
@@ -12,6 +12,7 @@ uniform vec2 u_viewport;
 #endif
 
 void main() {
+    vec4 color;
 #ifdef CUSTOM_ANTIALIASING
     vec2 uv = gl_FragCoord.xy / u_viewport;
 
@@ -30,9 +31,9 @@ void main() {
     float antialias = smoothstep(0.0, antialias_factor, norm_dist_from_center);
 
     vec4 raster = texture2D(u_image0, v_pos0);
-    vec4 color = vec4(raster.rgb * antialias, raster.a * antialias);
+    color = vec4(raster.rgb * antialias, raster.a * antialias);
 #else
-    vec4 color = texture2D(u_image0, v_pos0);
+    color = texture2D(u_image0, v_pos0);
 #endif
 #ifdef FOG
     color = fog_dither(fog_apply_premultiplied(color, v_fog_pos));

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -62,6 +62,7 @@ void main(void) {
     // in extrusion data
     vec2 tilePos = floor(a_pos * 0.5);
 
+    vec3 pos;
 #ifdef PROJECTION_GLOBE_VIEW
     // Compute positions on both globe and mercator plane to support transition between the two modes
     // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
@@ -72,9 +73,9 @@ void main(void) {
     vec3 globe_pos = a_pos_3 + surface_extrusion + globe_elevation;
     vec3 mercator_elevation = u_up_dir * u_tile_up_scale * elevation(tilePos);
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + surface_extrusion + mercator_elevation;
-    vec3 pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
+    pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #else
-    vec3 pos = vec3(tilePos + extrude, elevation(tilePos));
+    pos = vec3(tilePos + extrude, elevation(tilePos));
 #endif
 
     gl_Position = u_matrix * vec4(pos, 1);

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -69,18 +69,21 @@ void main() {
     vec2 tile_anchor = a_pos;
     vec3 h = elevationVector(tile_anchor) * elevation(tile_anchor);
 
+    float globe_occlusion_fade;
+    vec3 world_pos;
+    vec3 mercator_pos;
 #ifdef PROJECTION_GLOBE_VIEW
-    vec3 mercator_pos = mercator_tile_position(u_inv_rot_matrix, tile_anchor, u_tile_id, u_merc_center);
-    vec3 world_pos = mix_globe_mercator(a_globe_anchor + h, mercator_pos, u_zoom_transition);
+    mercator_pos = mercator_tile_position(u_inv_rot_matrix, tile_anchor, u_tile_id, u_merc_center);
+    world_pos = mix_globe_mercator(a_globe_anchor + h, mercator_pos, u_zoom_transition);
 
     vec4 ecef_point = u_tile_matrix * vec4(world_pos, 1.0);
     vec3 origin_to_point = ecef_point.xyz - u_ecef_origin;
 
     // Occlude symbols that are on the non-visible side of the globe sphere
-    float globe_occlusion_fade = dot(origin_to_point, u_camera_forward) >= 0.0 ? 0.0 : 1.0;
+    globe_occlusion_fade = dot(origin_to_point, u_camera_forward) >= 0.0 ? 0.0 : 1.0;
 #else
-    vec3 world_pos = vec3(tile_anchor, 0) + h;
-    float globe_occlusion_fade = 1.0;
+    world_pos = vec3(tile_anchor, 0) + h;
+    globe_occlusion_fade = 1.0;
 #endif
 
     vec4 projected_point = u_matrix * vec4(world_pos, 1);
@@ -102,11 +105,12 @@ void main() {
     highp float symbol_rotation = 0.0;
     if (u_rotate_symbol) {
         // See comments in symbol_sdf.vertex
+        vec4 offsetProjected_point;
 #ifdef PROJECTION_GLOBE_VIEW
         vec3 displacement = vec3(a_globe_normal.z, 0, -a_globe_normal.x);
-        vec4 offsetProjected_point = u_matrix * vec4(a_globe_anchor + displacement, 1);
+        offsetProjected_point = u_matrix * vec4(a_globe_anchor + displacement, 1);
 #else
-        vec4 offsetProjected_point = u_matrix * vec4(tile_anchor + vec2(1, 0), 0, 1);
+        offsetProjected_point = u_matrix * vec4(tile_anchor + vec2(1, 0), 0, 1);
 #endif
         vec2 a = projected_point.xy / projected_point.w;
         vec2 b = offsetProjected_point.xy / offsetProjected_point.w;
@@ -114,11 +118,12 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec4 projected_pos;
 #ifdef PROJECTION_GLOBE_VIEW
     vec3 proj_pos = mix_globe_mercator(a_projected_pos.xyz + h, mercator_pos, u_zoom_transition);
-    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos, 1.0);
+    projected_pos = u_label_plane_matrix * vec4(proj_pos, 1.0);
 #else
-    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, h.z, 1.0);
+    projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, h.z, 1.0);
 #endif
 
     highp float angle_sin = sin(segment_angle + symbol_rotation);

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -80,18 +80,21 @@ void main() {
     vec2 tile_anchor = a_pos;
     vec3 h = elevationVector(tile_anchor) * elevation(tile_anchor);
 
+    float globe_occlusion_fade;
+    vec3 world_pos;
+    vec3 mercator_pos;
 #ifdef PROJECTION_GLOBE_VIEW
-    vec3 mercator_pos = mercator_tile_position(u_inv_rot_matrix, tile_anchor, u_tile_id, u_merc_center);
-    vec3 world_pos = mix_globe_mercator(a_globe_anchor + h, mercator_pos, u_zoom_transition);
+    mercator_pos = mercator_tile_position(u_inv_rot_matrix, tile_anchor, u_tile_id, u_merc_center);
+    world_pos = mix_globe_mercator(a_globe_anchor + h, mercator_pos, u_zoom_transition);
 
     vec4 ecef_point = u_tile_matrix * vec4(world_pos, 1.0);
     vec3 origin_to_point = ecef_point.xyz - u_ecef_origin;
 
     // Occlude symbols that are on the non-visible side of the globe sphere
-    float globe_occlusion_fade = dot(origin_to_point, u_camera_forward) >= 0.0 ? 0.0 : 1.0;
+    globe_occlusion_fade = dot(origin_to_point, u_camera_forward) >= 0.0 ? 0.0 : 1.0;
 #else
-    vec3 world_pos = vec3(tile_anchor, 0) + h;
-    float globe_occlusion_fade = 1.0;
+    world_pos = vec3(tile_anchor, 0) + h;
+    globe_occlusion_fade = 1.0;
 #endif
 
     vec4 projected_point = u_matrix * vec4(world_pos, 1);
@@ -128,11 +131,12 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec4 projected_pos;
 #ifdef PROJECTION_GLOBE_VIEW
     vec3 proj_pos = mix_globe_mercator(a_projected_pos.xyz + h, mercator_pos, u_zoom_transition);
-    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos, 1.0);
+    projected_pos = u_label_plane_matrix * vec4(proj_pos, 1.0);
 #else
-    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, h.z, 1.0);
+    projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, h.z, 1.0);
 #endif
 
     highp float angle_sin = sin(segment_angle + symbol_rotation);


### PR DESCRIPTION
We're converting the output of the cross-compiler Metal shaders to use regular if blocks instead of ifdefs. To support this, we need to update the declaration of some variables to be available outside of the conditional blocks.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
