### PR TITLE
Add i18n language fallbacks support

### DIFF
--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -104,13 +104,13 @@ class VectorTileSource extends Evented implements Source {
     load(callback?: Callback<void>) {
         this._loaded = false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
-        const language = this.map._language;
+        const language = Array.isArray(this.map._language) ? this.map._language.join() : this.map._language;
         const worldview = this.map._worldview;
         this._tileJSONRequest = loadTileJSON(this._options, this.map._requestManager, language, worldview, (err, tileJSON) => {
             this._tileJSONRequest = null;
             this._loaded = true;
             if (err) {
-                if (language) console.warn(`Ensure that your requested language string is a valid BCP-47 code. Found: ${language}`);
+                if (language) console.warn(`Ensure that your requested language string is a valid BCP-47 code or list of codes. Found: ${language}`);
                 if (worldview && worldview.length !== 2) console.warn(`Requested worldview strings must be a valid ISO alpha-2 code. Found: ${worldview}`);
 
                 this.fire(new ErrorEvent(err));

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -37,7 +37,7 @@ const defaultOptions: Options = {
 class ScaleControl {
     _map: Map;
     _container: HTMLElement;
-    _language: ?string;
+    _language: ?string | ?string[];
     options: Options;
 
     constructor(options: Options) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1066,7 +1066,10 @@ class Map extends Camera {
 
     _parseLanguage(language?: 'auto' | ?string | ?string[]): ?string | ?string[] {
         if (language === 'auto') return window.navigator.language;
-        if (Array.isArray(language)) return language.length > 0 ? language : undefined;
+        if (Array.isArray(language)) return language.length === 0 ?
+            undefined :
+            language.map(l => l === 'auto' ? window.navigator.language : l);
+
         return language;
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -77,7 +77,7 @@ type IControl = {
     onRemove(map: Map): void;
 
     +getDefaultPosition?: () => ControlPosition;
-    +_setLanguage?: (language: ?string) => void;
+    +_setLanguage?: (language: ?string | ?string[]) => void;
 }
 /* eslint-enable no-use-before-define */
 
@@ -254,7 +254,7 @@ const defaultOptions = {
  * @param {number} [options.pitch=0] The initial [pitch](https://docs.mapbox.com/help/glossary/camera#pitch) (tilt) of the map, measured in degrees away from the plane of the screen (0-85). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {LngLatBoundsLike} [options.bounds=null] The initial bounds of the map. If `bounds` is specified, it overrides `center` and `zoom` constructor options.
  * @param {Object} [options.fitBoundsOptions] A {@link Map#fitBounds} options object to use _only_ when fitting the initial `bounds` provided above.
- * @param {'auto' | string} [options.language=null] A string representing the desired language used for the map's labels and UI components. Languages can only be set on Mapbox vector tile sources.
+ * @param {'auto' | string | string[]} [options.language=null] A string with a BCP 47 language tag, or an array of such strings representing the desired languages used for the map's labels and UI components. Languages can only be set on Mapbox vector tile sources.
  *   By default, GL JS will not set a language so that the language of Mapbox tiles will be determined by the vector tile source's TileJSON.
  *   Valid language strings must be a [BCP-47 language code](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_subtags). Unsupported BCP-47 codes will not include any translations. Invalid codes will result in an recoverable error.
  *   If a label has no translation for the selected language, it will display in the label's local language.
@@ -385,7 +385,7 @@ class Map extends Camera {
     _averageElevation: EasedVariable;
     _containerWidth: number;
     _containerHeight: number;
-    _language: ?string;
+    _language: ?string | ?string[];
     _worldview: ?string;
 
     // `_useExplicitProjection` indicates that a projection is set by a call to map.setProjection()
@@ -487,7 +487,7 @@ class Map extends Camera {
         this._crossFadingFactor = 1;
         this._collectResourceTiming = options.collectResourceTiming;
         this._optimizeForTerrain = options.optimizeForTerrain;
-        this._language = options.language === 'auto' ? window.navigator.language : options.language;
+        this._language = this._parseLanguage(options.language);
         this._worldview = options.worldview;
         this._renderTaskQueue = new TaskQueue();
         this._domRenderTaskQueue = new TaskQueue();
@@ -1056,19 +1056,25 @@ class Map extends Camera {
      * Returns the map's language, which is used for translating map labels and UI components.
      *
      * @private
-     * @returns {string} Returns the map's language code.
+     * @returns {undefined | string | string[]} Returns the map's language code.
      * @example
      * const language = map.getLanguage();
      */
-    getLanguage(): ?string {
+    getLanguage(): ?string | ?string[] {
         return this._language;
+    }
+
+    _parseLanguage(language?: 'auto' | ?string | ?string[]): ?string | ?string[] {
+        if (language === 'auto') return window.navigator.language;
+        if (Array.isArray(language)) return language.length > 0 ? language : undefined;
+        return language;
     }
 
     /**
      * Sets the map's language, which is used for translating map labels and UI components.
      *
      * @private
-     * @param {'auto' | string} [language] A string representing the desired language used for the map's labels and UI components. Languages can only be set on Mapbox vector tile sources.
+     * @param {'auto' | string | string[]} [language] A string representing the desired language used for the map's labels and UI components. Languages can only be set on Mapbox vector tile sources.
      *  Valid language strings must be a [BCP-47 language code](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_subtags). Unsupported BCP-47 codes will not include any translations. Invalid codes will result in an recoverable error.
      *  If a label has no translation for the selected language, it will display in the label's local language.
      *  If param is set to `auto`, GL JS will select a user's preferred language as determined by the browser's [`window.navigator.language`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) property.
@@ -1079,13 +1085,16 @@ class Map extends Camera {
      * map.setLanguage('es');
      *
      * @example
+     * map.setLanguage(['en-GB', 'en-US']);
+     *
+     * @example
      * map.setLanguage('auto');
      *
      * @example
      * map.setLanguage();
      */
-    setLanguage(language?: 'auto' | ?string): this {
-        const newLanguage = language === 'auto' ? window.navigator.language : language;
+    setLanguage(language?: 'auto' | ?string | ?string[]): this {
+        const newLanguage = this._parseLanguage(language);
         if (!this.style || newLanguage === this._language) return this;
         this._language = newLanguage;
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -2614,8 +2614,8 @@ test('Map', (t) => {
                 map.setLanguage('es');
                 t.equal(map.getLanguage(), 'es');
 
-                map.setLanguage(['en-GB', 'en-US']);
-                t.deepEqual(map.getLanguage(), ['en-GB', 'en-US']);
+                map.setLanguage(['auto', 'en-GB', 'en-US']);
+                t.deepEqual(map.getLanguage(), [window.navigator.language, 'en-GB', 'en-US']);
 
                 map.setLanguage([]);
                 t.equal(map.getLanguage(), undefined);

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -2583,6 +2583,14 @@ test('Map', (t) => {
             });
         });
 
+        t.test('can instantiate map with fallback language', (t) => {
+            const map = createMap(t, {language: ['en-GB', 'en-US']});
+            map.on('style.load', () => {
+                t.deepEqual(map.getLanguage(), ['en-GB', 'en-US']);
+                t.end();
+            });
+        });
+
         t.test('can instantiate map with the preferred language of the user', (t) => {
             const map = createMap(t, {language: 'auto'});
             map.on('style.load', () => {
@@ -2605,13 +2613,23 @@ test('Map', (t) => {
             map.on('style.load', () => {
                 map.setLanguage('es');
                 t.equal(map.getLanguage(), 'es');
+
+                map.setLanguage(['en-GB', 'en-US']);
+                t.deepEqual(map.getLanguage(), ['en-GB', 'en-US']);
+
+                map.setLanguage([]);
+                t.equal(map.getLanguage(), undefined);
+
                 map.setLanguage('auto');
                 t.equal(map.getLanguage(), window.navigator.language);
+
                 map.setLanguage();
                 t.equal(map.getLanguage(), undefined);
+
                 t.end();
             });
         });
+
         t.end();
     });
 


### PR DESCRIPTION
In addition to specifying a single i18n language tag, the design and maps API team would like to have an option to provide fallback options https://github.com/mapbox/tilesets-api-team/issues/1081

In addition to a single string value, this PR allows i18n settings to be a vector of strings. The resulting query parameter would be a comma-separated list of language tags.

/cc @alexshalamov 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
