### PR TITLE
Fix inaccurate documentation for geometry-type expression with geojson sources

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3215,7 +3215,7 @@
         }
       },
       "geometry-type": {
-        "doc": "Returns the feature's geometry type: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`. `Multi*` feature types are only returned in GeoJSON sources. When working with vector tile sources, use the singular forms.",
+        "doc": "Returns the feature's geometry type: `Point`, `LineString`, `Polygon`. `Multi*` feature types use the singular forms.",
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/12256

Tested this out [here](https://codepen.io/snailbones/pen/jOxGQaM) and it seems that "MultiPoint", "MultiLineString", and "MultiPolygon" in geojson sources are treated as "Point", "LineString" and "Polygon" respectively.