### PR TITLE
cherry-pick #12201: Marker terrain occluded opacity

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -27,7 +27,7 @@ type Options = {
     rotation?: number,
     rotationAlignment?: string,
     pitchAlignment?: string,
-    terrainOccludedMarkerOpacity?: number
+    occludedOpacity?: number
 };
 
 /**
@@ -45,7 +45,7 @@ type Options = {
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `'map'` aligns the `Marker` to the plane of the map. `'viewport'` aligns the `Marker` to the plane of the viewport. `'auto'` automatically matches the value of `rotationAlignment`.
  * @param {string} [options.rotationAlignment='auto'] The alignment of the marker's rotation.`'map'` is aligned with the map plane, consistent with the cardinal directions as the map rotates. `'viewport'` is screenspace-aligned. `'horizon'` is aligned according to the nearest horizon, on non-globe projections it is equivalent to `'viewport'`. `'auto'` is equivalent to `'viewport'`.
- * @param {number} [options.terrainOccludedMarkerOpacity=0.2] The opacity of a marker that's occluded by 3D terrain.
+ * @param {number} [options.occludedOpacity=0.2] The opacity of a marker that's occluded by 3D terrain.
  * @example
  * // Create a new marker.
  * const marker = new mapboxgl.Marker()
@@ -85,7 +85,7 @@ export default class Marker extends Evented {
     _fadeTimer: ?TimeoutID;
     _updateFrameId: number;
     _updateMoving: () => void;
-    _terrainOccludedMarkerOpacity: number;
+    _occludedOpacity: number;
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -116,7 +116,7 @@ export default class Marker extends Evented {
         this._rotationAlignment = (options && options.rotationAlignment) || 'auto';
         this._pitchAlignment = (options && options.pitchAlignment && options.pitchAlignment) || 'auto';
         this._updateMoving = () => this._update(true);
-        this._terrainOccludedMarkerOpacity = (options && options.terrainOccludedMarkerOpacity) || 0.2;
+        this._occludedOpacity = (options && options.occludedOpacity) || 0.2;
 
         if (!options || !options.element) {
             this._defaultMarker = true;
@@ -445,7 +445,7 @@ export default class Marker extends Evented {
         } else {
             opacity = 1 - map._queryFogOpacity(mapLocation);
             if (map.transform._terrainEnabled() && map.getTerrain() && this._behindTerrain()) {
-                opacity *= this._terrainOccludedMarkerOpacity;
+                opacity *= this._occludedOpacity;
             }
         }
 
@@ -829,27 +829,28 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Sets the `terrainOccludedMarkerOpacity` property of the marker.
+     * Sets the `occludedOpacity` property of the marker.
+     * This opacity is used on the marker when the marker is occluded by terrain.
      *
-     * @param {number} [opacity=0.2] Sets the `terrainOccludedMarkerOpacity` property of the marker.
+     * @param {number} [opacity=0.2] Sets the `occludedOpacity` property of the marker.
      * @returns {Marker} Returns itself to allow for method chaining.
      * @example
-     * marker.setTerrainOccludedMarkerOpacity(0.3);
+     * marker.setOccludedOpacity(0.3);
      */
-    setTerrainOccludedMarkerOpacity(opacity: number): this {
-        this._terrainOccludedMarkerOpacity = opacity || 0.2;
+    setOccludedOpacity(opacity: number): this {
+        this._occludedOpacity = opacity || 0.2;
         this._update();
         return this;
     }
 
     /**
-     * Returns the current `terrainOccludedMarkerOpacity` of the marker.
+     * Returns the current `occludedOpacity` of the marker.
      *
      * @returns {number} The opacity of a terrain occluded marker.
      * @example
-     * const opacity = marker.getTerrainOccludedMarkerOpacity();
+     * const opacity = marker.getOccludedOpacity();
      */
-    getTerrainOccludedMarkerOpacity(): number {
-        return this._terrainOccludedMarkerOpacity;
+    getOccludedOpacity(): number {
+        return this._occludedOpacity;
     }
 }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -26,7 +26,8 @@ type Options = {
     clickTolerance?: number,
     rotation?: number,
     rotationAlignment?: string,
-    pitchAlignment?: string
+    pitchAlignment?: string,
+    terrainOccludedMarkerOpacity?: number
 };
 
 /**
@@ -44,6 +45,7 @@ type Options = {
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `'map'` aligns the `Marker` to the plane of the map. `'viewport'` aligns the `Marker` to the plane of the viewport. `'auto'` automatically matches the value of `rotationAlignment`.
  * @param {string} [options.rotationAlignment='auto'] The alignment of the marker's rotation.`'map'` is aligned with the map plane, consistent with the cardinal directions as the map rotates. `'viewport'` is screenspace-aligned. `'horizon'` is aligned according to the nearest horizon, on non-globe projections it is equivalent to `'viewport'`. `'auto'` is equivalent to `'viewport'`.
+ * @param {number} [options.terrainOccludedMarkerOpacity=0.2] The opacity of a marker that's occluded by 3D terrain.
  * @example
  * // Create a new marker.
  * const marker = new mapboxgl.Marker()
@@ -83,6 +85,7 @@ export default class Marker extends Evented {
     _fadeTimer: ?TimeoutID;
     _updateFrameId: number;
     _updateMoving: () => void;
+    _terrainOccludedMarkerOpacity: number;
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -113,6 +116,7 @@ export default class Marker extends Evented {
         this._rotationAlignment = (options && options.rotationAlignment) || 'auto';
         this._pitchAlignment = (options && options.pitchAlignment && options.pitchAlignment) || 'auto';
         this._updateMoving = () => this._update(true);
+        this._terrainOccludedMarkerOpacity = (options && options.terrainOccludedMarkerOpacity) || 0.2;
 
         if (!options || !options.element) {
             this._defaultMarker = true;
@@ -441,8 +445,7 @@ export default class Marker extends Evented {
         } else {
             opacity = 1 - map._queryFogOpacity(mapLocation);
             if (map.transform._terrainEnabled() && map.getTerrain() && this._behindTerrain()) {
-                const TERRAIN_OCCLUDED_OPACITY = 0.2;
-                opacity *= TERRAIN_OCCLUDED_OPACITY;
+                opacity *= this._terrainOccludedMarkerOpacity;
             }
         }
 
@@ -823,5 +826,30 @@ export default class Marker extends Evented {
             return this.getRotationAlignment();
         }
         return this._pitchAlignment;
+    }
+
+    /**
+     * Sets the `terrainOccludedMarkerOpacity` property of the marker.
+     *
+     * @param {number} [opacity=0.2] Sets the `terrainOccludedMarkerOpacity` property of the marker.
+     * @returns {Marker} Returns itself to allow for method chaining.
+     * @example
+     * marker.setTerrainOccludedMarkerOpacity(0.3);
+     */
+    setTerrainOccludedMarkerOpacity(opacity: number): this {
+        this._terrainOccludedMarkerOpacity = opacity || 0.2;
+        this._update();
+        return this;
+    }
+
+    /**
+     * Returns the current `terrainOccludedMarkerOpacity` of the marker.
+     *
+     * @returns {number} The opacity of a terrain occluded marker.
+     * @example
+     * const opacity = marker.getTerrainOccludedMarkerOpacity();
+     */
+    getTerrainOccludedMarkerOpacity(): number {
+        return this._terrainOccludedMarkerOpacity;
     }
 }

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -425,6 +425,20 @@ test('Marker#setDraggable turns off drag functionality', (t) => {
     t.end();
 });
 
+test('Marker#setOccludedOpacity functionality', (t) => {
+    const map = createMap(t);
+    const marker = new Marker({draggable: true, occludedOpacity: 0.8})
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    t.equal(marker.getOccludedOpacity(), 0.8);
+    marker.setOccludedOpacity(0.5);
+    t.equal(marker.getOccludedOpacity(), 0.5);
+
+    map.remove();
+    t.end();
+});
+
 test('Marker with draggable:true fires dragstart, drag, and dragend events at appropriate times in response to mouse-triggered drag with map-inherited clickTolerance', (t) => {
     const map = createMap(t);
     const marker = new Marker({draggable: true})


### PR DESCRIPTION
Cherry-pick PR https://github.com/mapbox/mapbox-gl-js/pull/12201 from @jacadzaca for minor review fixes and CI: including renaming of public API + unit tests.

Fixes https://github.com/mapbox/mapbox-gl-js/issues/12123

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Allow to override marker opacity when occluded by terrain (h/t [jacadzaca](https://github.com/jacadzaca))</changelog>`
