### PR TITLE
Cancel image_source image request when underlying resource is no longer used

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -20,6 +20,7 @@ import type Map from '../ui/map.js';
 import type Dispatcher from '../util/dispatcher.js';
 import type Tile from './tile.js';
 import type {Callback} from '../types/callback.js';
+import type {Cancelable} from '../types/cancelable.js';
 import type VertexBuffer from '../gl/vertex_buffer.js';
 import type {
     ImageSourceSpecification,
@@ -210,7 +211,7 @@ class ImageSource extends Evented implements Source {
         if (!this.image || !options.url) {
             return this;
         }
-        if (this._imageRequest) {
+        if (this._imageRequest && options.url !== this.options.url) {
             this._imageRequest.cancel();
             this._imageRequest = null;
         }

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -214,6 +214,45 @@ test('ImageSource', (t) => {
         respond();
         t.ok(source.loaded());
         source.updateImage({url: '/image2.png', coordinates});
+        respond();
+        t.end();
+    });
+
+    t.test('cancels image request when onRemove is called', (t) => {
+        const source = createSource({url: '/image.png'});
+        source.onAdd(new StubMap());
+        const req = requests.shift();
+        const spy = t.spy(req, 'abort');
+
+        source.onRemove();
+
+        t.equal(spy.callCount, 1);
+        t.end();
+    });
+
+    t.test('cancels image request when updateImage is called', (t) => {
+        const source = createSource({url: '/image.png'});
+        source.image = img;
+        source.onAdd(new StubMap());
+        const req = requests.shift();
+        const spy = t.spy(req, 'abort');
+
+        source.updateImage({url: '/image2.png'});
+
+        t.equal(spy.callCount, 1);
+        t.end();
+    });
+
+    t.test('does not cancel image request when updateImage is called with the same url', (t) => {
+        const source = createSource({url: '/image.png'});
+        source.image = img;
+        source.onAdd(new StubMap());
+        const req = requests.shift();
+        const spy = t.spy(req, 'abort');
+
+        source.updateImage({url: '/image.png'});
+
+        t.equal(spy.callCount, 0);
         t.end();
     });
 


### PR DESCRIPTION
This PR introduces cancellation for image_source requests after the layer has been removed or updated to have a different url. It behaves similarly to the logic from `raster_tile_source`. It's very useful when the image_source is changing quite often due to user actions.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

changelog: <changelog>Cancel image_source image request when underlying resource is no longer used</changelog>