### PR TITLE
Fix bug in LngLatBounds.extend by allowing object literal LngLat as a parameter. 

### DIFF
--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -96,18 +96,17 @@ class LngLatBounds {
 
             if (!sw2 || !ne2) return this;
 
-        } else {
-            if (Array.isArray(obj)) {
-                if (obj.length === 4 || obj.every(Array.isArray)) {
-                    const lngLatBoundsObj = ((obj: any): LngLatBoundsLike);
-                    return this.extend(LngLatBounds.convert(lngLatBoundsObj));
-                } else {
-                    const lngLatObj = ((obj: any): LngLatLike);
-                    return this.extend(LngLat.convert(lngLatObj));
-                }
-            } else if (obj.hasOwnProperty("lat") && obj.hasOwnProperty("lon")) {
-                return this.extend(LngLat.convert(obj));
+        } else if (Array.isArray(obj)) {
+            if (obj.length === 4 || obj.every(Array.isArray)) {
+                const lngLatBoundsObj = ((obj: any): LngLatBoundsLike);
+                return this.extend(LngLatBounds.convert(lngLatBoundsObj));
+            } else {
+                const lngLatObj = ((obj: any): LngLatLike);
+                return this.extend(LngLat.convert(lngLatObj));
             }
+        } else if (obj.hasOwnProperty("lat") && obj.hasOwnProperty("lon")) {
+            return this.extend(LngLat.convert(obj));
+        } else {
             return this;
         }
 

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -104,7 +104,7 @@ class LngLatBounds {
                 const lngLatObj = ((obj: any): LngLatLike);
                 return this.extend(LngLat.convert(lngLatObj));
             }
-        } else if (obj.hasOwnProperty("lat") && obj.hasOwnProperty("lon")) {
+        } else if (typeof obj === 'object' && obj !== null && obj.hasOwnProperty("lat") && obj.hasOwnProperty("lon")) {
             return this.extend(LngLat.convert(obj));
         } else {
             return this;

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -2,7 +2,7 @@
 
 import LngLat from './lng_lat.js';
 
-import type { LngLatLike } from './lng_lat.js';
+import type {LngLatLike} from './lng_lat.js';
 
 /**
  * A `LngLatBounds` object represents a geographical bounding box,
@@ -273,7 +273,7 @@ class LngLatBounds {
     * console.log(llb.contains(ll)); // = true
     */
     contains(lnglat: LngLatLike): boolean {
-        const { lng, lat } = LngLat.convert(lnglat);
+        const {lng, lat} = LngLat.convert(lnglat);
 
         const containsLatitude = this._sw.lat <= lat && lat <= this._ne.lat;
         let containsLongitude = this._sw.lng <= lng && lng <= this._ne.lng;

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -2,7 +2,7 @@
 
 import LngLat from './lng_lat.js';
 
-import type {LngLatLike} from './lng_lat.js';
+import type { LngLatLike } from './lng_lat.js';
 
 /**
  * A `LngLatBounds` object represents a geographical bounding box,
@@ -105,6 +105,8 @@ class LngLatBounds {
                     const lngLatObj = ((obj: any): LngLatLike);
                     return this.extend(LngLat.convert(lngLatObj));
                 }
+            } else if (obj.hasOwnProperty("lat") && obj.hasOwnProperty("lon")) {
+                return this.extend(LngLat.convert(obj));
             }
             return this;
         }
@@ -272,7 +274,7 @@ class LngLatBounds {
     * console.log(llb.contains(ll)); // = true
     */
     contains(lnglat: LngLatLike): boolean {
-        const {lng, lat} = LngLat.convert(lnglat);
+        const { lng, lat } = LngLat.convert(lnglat);
 
         const containsLatitude = this._sw.lat <= lat && lat <= this._ne.lat;
         let containsLongitude = this._sw.lng <= lng && lng <= this._ne.lng;

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -100,6 +100,18 @@ test('LngLatBounds', (t) => {
         t.end();
     });
 
+    t.test('#extend with literal object LngLat', (t) => {
+        const bounds1 = new LngLatBounds([0, 0], [10, 10]);
+        const bounds2 = {lon: -10, lat: -10};
+
+        bounds1.extend(bounds2);
+
+        t.equal(bounds1.getSouth(), -10);
+        t.equal(bounds1.getWest(), -10);
+        t.equal(bounds1.getNorth(), 10);
+        t.equal(bounds1.getEast(), 10);
+    });
+
     t.test('#extend with null', (t) => {
         const bounds = new LngLatBounds([0, 0], [10, 10]);
 

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -110,6 +110,8 @@ test('LngLatBounds', (t) => {
         t.equal(bounds1.getWest(), -10);
         t.equal(bounds1.getNorth(), 10);
         t.equal(bounds1.getEast(), 10);
+
+        t.end();
     });
 
     t.test('#extend with null', (t) => {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fixes #12095 
### Changes
Checks if LngLatBounds.extend was passed an object literal LngLat (v3). This fixes a bug where it was treated like null and made no changes to the LngLatBounds object.
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs. No changes to public APIs
 - [ ] post benchmark scores - I can't seem to set up the benchmark software locally. "'BENCHMARK_VERSION' is not recognized as an internal or external command". I can't imagine it has substantially worse performance based on the nature of the change. 
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 I don't think it needs a native port.
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
Can someone apply the bug label please I don't believe I have permission as a community member.
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add object literal support in LngLatBounds.extend</changelog>`

Sorry about all the commits: yarn gave me errors when trying to perform the unit tests locally so I did unit tests tests on GitHub in this PR. They'll be squashed when merged though.
