### PR TITLE
Adaptive bounds calculation

### DIFF
--- a/debug/globe-bounds.html
+++ b/debug/globe-bounds.html
@@ -46,10 +46,6 @@ var boundsData = {
     'type': 'LineString',
     coordinates: []
 };
-var globeBoundsData = {
-    'type': 'LineString',
-    coordinates: []
-};
 
 map2.on('load', () => {
     map2.addSource('bounds', {
@@ -66,30 +62,16 @@ map2.on('load', () => {
         }
     });
 
-    map2.addSource('red-bounds', {
+    map2.addSource('abounds', {
         'type': 'geojson',
         'data': boundsData
     });
     map2.addLayer({
-        'id': 'red-bounds',
+        'id': 'abounds',
         'type': 'line',
-        'source': 'red-bounds',
+        'source': 'abounds',
         'paint': {
             'line-color': 'red',
-            'line-width': 5
-        }
-    });
-
-    map2.addSource('green-bounds', {
-        'type': 'geojson',
-        'data': globeBoundsData
-    });
-    map2.addLayer({
-        'id': 'green-bounds',
-        'type': 'line',
-        'source': 'green-bounds',
-        'paint': {
-            'line-color': 'green',
             'line-width': 5
         }
     });
@@ -114,7 +96,6 @@ function updateBounds() {
     lineData.coordinates = points.map(p => map.unproject(p).toArray());
 
     const bounds = map.getBounds();
-    const globeBounds = map.transform._getGlobeBounds();
 
     boundsData.coordinates = [
         bounds.getSouthWest().toArray(),
@@ -124,17 +105,8 @@ function updateBounds() {
         bounds.getSouthWest().toArray(),
     ];
 
-    globeBoundsData.coordinates = [
-        globeBounds.getSouthWest().toArray(),
-        globeBounds.getSouthEast().toArray(),
-        globeBounds.getNorthEast().toArray(),
-        globeBounds.getNorthWest().toArray(),
-        globeBounds.getSouthWest().toArray(),
-    ];
-
     map2.getSource('bounds').setData(lineData);
-    map2.getSource('red-bounds').setData(boundsData);
-    map2.getSource('green-bounds').setData(globeBoundsData);
+    map2.getSource('abounds').setData(boundsData);
 }
 
 const marker = new mapboxgl.Marker();

--- a/debug/globe-bounds.html
+++ b/debug/globe-bounds.html
@@ -46,6 +46,10 @@ var boundsData = {
     'type': 'LineString',
     coordinates: []
 };
+var globeBoundsData = {
+    'type': 'LineString',
+    coordinates: []
+};
 
 map2.on('load', () => {
     map2.addSource('bounds', {
@@ -62,16 +66,30 @@ map2.on('load', () => {
         }
     });
 
-    map2.addSource('abounds', {
+    map2.addSource('red-bounds', {
         'type': 'geojson',
         'data': boundsData
     });
     map2.addLayer({
-        'id': 'abounds',
+        'id': 'red-bounds',
         'type': 'line',
-        'source': 'abounds',
+        'source': 'red-bounds',
         'paint': {
             'line-color': 'red',
+            'line-width': 5
+        }
+    });
+
+    map2.addSource('green-bounds', {
+        'type': 'geojson',
+        'data': globeBoundsData
+    });
+    map2.addLayer({
+        'id': 'green-bounds',
+        'type': 'line',
+        'source': 'green-bounds',
+        'paint': {
+            'line-color': 'green',
             'line-width': 5
         }
     });
@@ -96,6 +114,7 @@ function updateBounds() {
     lineData.coordinates = points.map(p => map.unproject(p).toArray());
 
     const bounds = map.getBounds();
+    const globeBounds = map.transform._getGlobeBounds();
 
     boundsData.coordinates = [
         bounds.getSouthWest().toArray(),
@@ -105,8 +124,17 @@ function updateBounds() {
         bounds.getSouthWest().toArray(),
     ];
 
+    globeBoundsData.coordinates = [
+        globeBounds.getSouthWest().toArray(),
+        globeBounds.getSouthEast().toArray(),
+        globeBounds.getNorthEast().toArray(),
+        globeBounds.getNorthWest().toArray(),
+        globeBounds.getSouthWest().toArray(),
+    ];
+
     map2.getSource('bounds').setData(lineData);
-    map2.getSource('abounds').setData(boundsData);
+    map2.getSource('red-bounds').setData(boundsData);
+    map2.getSource('green-bounds').setData(globeBoundsData);
 }
 
 const marker = new mapboxgl.Marker();

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -20,7 +20,7 @@ import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile
 import {calculateGlobeMatrix, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
 import {projectClamped} from '../symbol/projection.js';
 
-import type Projection, {ProjectedPoint} from '../geo/projection/projection.js';
+import type Projection from '../geo/projection/projection.js';
 import type {Elevation} from '../terrain/elevation.js';
 import type {PaddingOptions} from './edge_insets.js';
 import type Tile from '../source/tile.js';
@@ -1394,6 +1394,10 @@ class Transform {
     }
 
     _getBounds(min: number, max: number): LngLatBounds {
+        if (this.projection.name === 'globe') {
+            return this._getGlobeBounds();
+        }
+
         const topLeft = new Point(this._edgeInsets.left, this._edgeInsets.top);
         const topRight = new Point(this.width - this._edgeInsets.right, this._edgeInsets.top);
         const bottomRight = new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -17,7 +17,7 @@ import assert from 'assert';
 import getProjectionAdjustments, {getProjectionAdjustmentInverted, getScaleAdjustment, getProjectionInterpolationT} from './projection/adjustments.js';
 import {getPixelsToTileUnitsMatrix} from '../source/pixels_to_tile_units.js';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
-import {calculateGlobeMatrix, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
+import {calculateGlobeMatrix, isLngLatBehindGlobe, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
 import {projectClamped} from '../symbol/projection.js';
 
 import type Projection from '../geo/projection/projection.js';
@@ -1390,8 +1390,16 @@ class Transform {
         processSegment(right, bottom, left, bottom);
         processSegment(left, bottom, left, top);
 
-        const sw = new LngLat(lngFromMercatorX(minX), latFromMercatorY(minY));
-        const ne = new LngLat(lngFromMercatorX(maxX), latFromMercatorY(maxY));
+        // Check if minY is behind the globe and the north pole is visible
+        const northPoleIsVisible = latFromMercatorY(minY) < 90 &&
+            !isLngLatBehindGlobe(this, new LngLat(this.center.lat, 90));
+
+        // Check if maxY is behind the globe and the south pole is visible
+        const southPoleIsVisible = latFromMercatorY(maxY) > -90 &&
+            !isLngLatBehindGlobe(this, new LngLat(this.center.lat, -90));
+
+        const ne = new LngLat(lngFromMercatorX(maxX), northPoleIsVisible ? 90 : latFromMercatorY(minY));
+        const sw = new LngLat(lngFromMercatorX(minX), southPoleIsVisible ? -90 : latFromMercatorY(maxY));
         return new LngLatBounds(sw, ne);
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -20,7 +20,7 @@ import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile
 import {calculateGlobeMatrix, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
 import {projectClamped} from '../symbol/projection.js';
 
-import type Projection from '../geo/projection/projection.js';
+import type Projection, {ProjectedPoint} from '../geo/projection/projection.js';
 import type {Elevation} from '../terrain/elevation.js';
 import type {PaddingOptions} from './edge_insets.js';
 import type Tile from '../source/tile.js';
@@ -1350,44 +1350,20 @@ class Transform {
         const bottomRight = new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom);
         const bottomLeft = new Point(this._edgeInsets.left, this.height - this._edgeInsets.bottom);
 
-        // Consider far points at the maximum possible elevation
-        // and near points at the minimum to ensure full coverage.
-        const tl = this.pointCoordinate(topLeft, min);
-        const tr = this.pointCoordinate(topRight, min);
-        const br = this.pointCoordinate(bottomRight, max);
-        const bl = this.pointCoordinate(bottomLeft, max);
-
-        const projection = this.projection;
-        const s = Math.pow(2, -this.zoom);
-
-        const x1 = Math.min(tl.x, bl.x);
-        const x2 = Math.max(tr.x, br.x);
-        const y1 = Math.min(tl.y, tr.y);
-        const y2 = Math.max(bl.y, br.y);
-
-        const lng1 = lngFromMercatorX(x1);
-        const lng2 = lngFromMercatorX(x2);
-        const lat1 = latFromMercatorY(y1);
-        const lat2 = latFromMercatorY(y2);
-
-        const p0 = projection.project(lng1, lat1);
-        const p1 = projection.project(lng2, lat1);
-        const p2 = projection.project(lng2, lat2);
-        const p3 = projection.project(lng1, lat2);
-
-        let minX = Math.min(p0.x, p1.x, p2.x, p3.x);
-        let minY = Math.min(p0.y, p1.y, p2.y, p3.y);
-        let maxX = Math.max(p0.x, p1.x, p2.x, p3.x);
-        let maxY = Math.max(p0.y, p1.y, p2.y, p3.y);
+        const [[lng1, lat1], [lng2, lat2]] = this._getBounds(min, max).toArray();
+        let {x: minX, y: maxY} = this.projection.project(lng1, lat1);
+        let {x: maxX, y: minY} = this.projection.project(lng2, lat2);
 
         // we pick an error threshold for calculating the bbox that balances between performance and precision
+        const s = Math.pow(2, -this.zoom);
         const maxErr = s / 16;
 
-        function processSegment(pa, pb, ax, ay, bx, by) {
+        const processSegment = (pa, pb, ax, ay, bx, by) => {
             const mx = (ax + bx) / 2;
             const my = (ay + by) / 2;
 
-            const pm = projection.project(lngFromMercatorX(mx), latFromMercatorY(my));
+            const {x, y} = this.pointCoordinate3D(new Point(mx, my));
+            const pm = this.projection.project(lngFromMercatorX(x), latFromMercatorY(y));
             const err = Math.max(0, minX - pm.x, minY - pm.y, pm.x - maxX, pm.y - maxY);
 
             minX = Math.min(minX, pm.x);
@@ -1399,12 +1375,12 @@ class Transform {
                 processSegment(pa, pm, ax, ay, mx, my);
                 processSegment(pm, pb, mx, my, bx, by);
             }
-        }
+        };
 
-        processSegment(p0, p1, x1, y1, x2, y1);
-        processSegment(p1, p2, x2, y1, x2, y2);
-        processSegment(p2, p3, x2, y2, x1, y2);
-        processSegment(p3, p0, x1, y2, x1, y1);
+        processSegment(topLeft, topRight, topLeft.x, topLeft.y, topRight.x, topRight.y);
+        processSegment(topRight, bottomRight, topRight.x, topRight.y, bottomRight.x, bottomRight.y);
+        processSegment(bottomRight, bottomLeft, bottomRight.x, bottomRight.y, bottomLeft.x, bottomLeft.y);
+        processSegment(bottomLeft, topLeft, bottomLeft.x, bottomLeft.y, topLeft.x, topLeft.y);
 
         // extend the bbox by max error to make sure coords don't go past tile extent
         minX -= maxErr;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1349,10 +1349,10 @@ class Transform {
         const bottom = this.height - this._edgeInsets.bottom;
         const right = this.width - this._edgeInsets.right;
 
-        const tl = this.pointCoordinate3D(topLeft);
-        const tr = this.pointCoordinate3D(topRight);
-        const br = this.pointCoordinate3D(bottomRight);
-        const bl = this.pointCoordinate3D(bottomLeft);
+        const tl = this.pointCoordinate3D(new Point(left, top));
+        const tr = this.pointCoordinate3D(new Point(right, top));
+        const br = this.pointCoordinate3D(new Point(right, bottom));
+        const bl = this.pointCoordinate3D(new Point(left, bottom));
 
         let minX = Math.min(tl.x, bl.x);
         let maxX = Math.max(tr.x, br.x);
@@ -1369,6 +1369,9 @@ class Transform {
 
             const p = new Point(mx, my);
             const pm = this.pointCoordinate3D(p);
+
+            // The error metric is the maximum distance between the midpoint
+            // and each of the currently calculated bounds
             const err = Math.max(0, minX - pm.x, minY - pm.y, pm.x - maxX, pm.y - maxY);
 
             minX = Math.min(minX, pm.x);
@@ -1382,10 +1385,10 @@ class Transform {
             }
         };
 
-        processSegment(topLeft.x, topLeft.y, topRight.x, topRight.y);
-        processSegment(topRight.x, topRight.y, bottomRight.x, bottomRight.y);
-        processSegment(bottomRight.x, bottomRight.y, bottomLeft.x, bottomLeft.y);
-        processSegment(bottomLeft.x, bottomLeft.y, topLeft.x, topLeft.y);
+        processSegment(left, top, right, top);
+        processSegment(right, top, right, bottom);
+        processSegment(right, bottom, left, bottom);
+        processSegment(left, bottom, left, top);
 
         const sw = new LngLat(lngFromMercatorX(minX), latFromMercatorY(minY));
         const ne = new LngLat(lngFromMercatorX(maxX), latFromMercatorY(maxY));

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1345,10 +1345,9 @@ class Transform {
     }
 
     _getGlobeBounds(): LngLatBounds {
-        const topLeft = new Point(this._edgeInsets.left, this._edgeInsets.top);
-        const topRight = new Point(this.width - this._edgeInsets.right, this._edgeInsets.top);
-        const bottomRight = new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom);
-        const bottomLeft = new Point(this._edgeInsets.left, this.height - this._edgeInsets.bottom);
+        const {top, left} = this._edgeInsets;
+        const bottom = this.height - this._edgeInsets.bottom;
+        const right = this.width - this._edgeInsets.right;
 
         const tl = this.pointCoordinate3D(topLeft);
         const tr = this.pointCoordinate3D(topRight);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -798,9 +798,6 @@ class Map extends Camera {
      * const bounds = map.getBounds();
      */
     getBounds(): LngLatBounds | null {
-        if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support getBounds API, this API may behave unexpectedly."');
-        }
         return this.transform.getBounds();
     }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1426,6 +1426,27 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('globe bounds', (t) => {
+            const map = createMap(t, {zoom: 0, skipCSSStub: true});
+            const mercatorBounds = map.getBounds();
+
+            t.same(
+                toFixed(mercatorBounds.toArray()),
+                toFixed([[ -70.3125000000, -57.3265212252, ], [ 70.3125000000, 57.3265212252]])
+            );
+
+            map.setProjection('globe');
+            t.stub(console, 'warn');
+            const globeBounds = map.getBounds();
+
+            t.same(
+                toFixed(globeBounds.toArray()),
+                toFixed([[ -73.8873304141, 73.8873304141, ], [ 73.8873304141, -73.8873304141]])
+            );
+
+            t.end();
+        });
+
         t.end();
 
         function toFixed(bounds) {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1436,7 +1436,6 @@ test('Map', (t) => {
             );
 
             map.setProjection('globe');
-            t.stub(console, 'warn');
             const globeBounds = map.getBounds();
 
             t.same(

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1441,7 +1441,27 @@ test('Map', (t) => {
 
             t.same(
                 toFixed(globeBounds.toArray()),
-                toFixed([[ -73.8873304141, 73.8873304141, ], [ 73.8873304141, -73.8873304141]])
+                toFixed([[ -73.8873304141, -73.8873304141, ], [ 73.8873304141, 73.8873304141]])
+            );
+
+            map.setBearing(80);
+            map.setCenter({lng: 0, lat: 90});
+
+            const northBounds = map.getBounds();
+            t.same(northBounds.getNorth(), 90);
+            t.same(
+                toFixed(northBounds.toArray()),
+                toFixed([[ -169.7072944003, 11.2373406095 ], [ 175.8448619060, 90 ]])
+            );
+
+            map.setBearing(180);
+            map.setCenter({lng: 0, lat: -90});
+
+            const southBounds = map.getBounds();
+            t.same(southBounds.getSouth(), -90);
+            t.same(
+                toFixed(southBounds.toArray()),
+                toFixed([[ -165.5559158623, -90 ], [ 180, -11.1637985859]])
             );
 
             t.end();


### PR DESCRIPTION
This PR implements the adaptive bounds calculation proposed here https://github.com/mapbox/mapbox-gl-js/pull/12199

> Alternatively, we could do adaptive bounds calculation similar to the one happening in `tile_transform.js` for alternative projections — start with 4 corners, and delve recursively into midpoints while they stray too much from Euclidean midpoints. This might still produce a noticeable error, but will at least be a significant improvement to the current results. We should also be careful of the case where midpoint is in the middle but the line gets curvy on either side of the midpoint.

To calculate the globe bounds, it recursively iterates other midpoints of the canvas and raycasts the screen coordinates to the globe, expanding the bounds. It also expands the bounds if poles are visible.

## Before

<img width="1280" alt="Screen Shot 2022-10-13 at 15 57 55-before" src="https://user-images.githubusercontent.com/533564/195605151-fb1ab43f-d25d-43e5-b529-1e0da4012306.png">

## After

<img width="1280" alt="Screen Shot 2022-10-13 at 15 58 15-after" src="https://user-images.githubusercontent.com/533564/195605205-37e2554c-fd66-4f15-aa69-a202dd06271e.png">

## Before

<img width="1280" alt="Screen Shot 2022-10-17 at 14 12 10" src="https://user-images.githubusercontent.com/533564/196163085-80625f3e-8250-45cc-9ebc-a01d2a2a4fc9.png">


## After

<img width="1280" alt="Screen Shot 2022-10-17 at 14 12 25" src="https://user-images.githubusercontent.com/533564/196163111-2f7fa8e3-eca8-48bd-9896-854a4c1cd0cb.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve the globe bounds calculation</changelog>`
