### PR TITLE
Check if TERRAIN is enabled when using PITCH_WITH_MAP_TERRAIN in symbol shaders

### DIFF
--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -132,9 +132,11 @@ void main() {
 
     float z = 0.0;
     vec2 offset = rotation_matrix * (a_offset / 32.0 * max(a_min_font_scale, font_scale) + a_pxoffset / 16.0);
+#ifdef TERRAIN
 #ifdef PITCH_WITH_MAP_TERRAIN
     vec4 tile_pos = u_label_plane_matrix_inv * vec4(a_projected_pos.xy + offset, 0.0, 1.0);
     z = elevation(tile_pos.xy);
+#endif
 #endif
     // Symbols might end up being behind the camera. Move them AWAY.
     float occlusion_fade = occlusionFade(projected_point) * globe_occlusion_fade;

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -151,9 +151,11 @@ void main() {
 
     float z = 0.0;
     vec2 offset = rotation_matrix * (a_offset / 32.0 * fontScale + a_pxoffset);
+#ifdef TERRAIN
 #ifdef PITCH_WITH_MAP_TERRAIN
     vec4 tile_pos = u_label_plane_matrix_inv * vec4(a_projected_pos.xy + offset, 0.0, 1.0);
     z = elevation(tile_pos.xy);
+#endif
 #endif
     // Symbols might end up being behind the camera. Move them AWAY.
     float occlusion_fade = occlusionFade(projected_point) * globe_occlusion_fade;

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -145,9 +145,11 @@ void main() {
 
     float z = 0.0;
     vec2 offset = rotation_matrix * (a_offset / 32.0 * font_scale);
+#ifdef TERRAIN
 #ifdef PITCH_WITH_MAP_TERRAIN
     vec4 tile_pos = u_label_plane_matrix_inv * vec4(a_projected_pos.xy + offset, 0.0, 1.0);
     z = elevation(tile_pos.xy);
+#endif
 #endif
     float occlusion_fade = occlusionFade(projected_point) * globe_occlusion_fade;
 #ifdef PROJECTION_GLOBE_VIEW


### PR DESCRIPTION
In some rare cases we got crashes in GL-Native when `PITCH_WITH_MAP_TERRAIN` was defined but `TERRAIN` was not, since the `u_label_plane_matrix_inv` uniform inside the block is dependant on `TERRAIN`. This PR prevents this type of issues in the future.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
