### PR TITLE
Add poles support in `getBounds` on the Globe

### DIFF
--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -655,6 +655,14 @@ export function isLngLatBehindGlobe(tr: Transform, lngLat: LngLat): boolean {
     return (globeTiltAtLngLat(tr, lngLat) > Math.PI / 2 * 1.01);
 }
 
+export function isLngLatInViewport(tr: Transform, lngLat: LngLat): boolean {
+    const lngLatToPoint = latLngToECEF(lngLat.lat, lngLat.lng);
+    const aabb = Aabb.fromPoints([lngLatToPoint]);
+    const cameraFrustum = tr.getCameraFrustum();
+    const intersectResult = aabb.intersects(cameraFrustum);
+    return intersectResult > 0;
+}
+
 const POLE_RAD = degToRad(85.0);
 const POLE_COS = Math.cos(POLE_RAD);
 const POLE_SIN = Math.sin(POLE_RAD);

--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -656,8 +656,15 @@ export function isLngLatBehindGlobe(tr: Transform, lngLat: LngLat): boolean {
 }
 
 export function isLngLatInViewport(tr: Transform, lngLat: LngLat): boolean {
-    const lngLatToPoint = latLngToECEF(lngLat.lat, lngLat.lng);
-    const aabb = Aabb.fromPoints([lngLatToPoint]);
+    // Create an array with one point in ECEF from the location at lngLat
+    const ecef = latLngToECEF(lngLat.lat, lngLat.lng);
+    const corners = [ecef];
+
+    // Translate points from ECEF to world coords
+    transformPoints(corners, tr.globeMatrix, 1);
+    const aabb = Aabb.fromPoints(corners);
+
+    // Create Frustum in world coords
     const cameraFrustum = tr.getCameraFrustum();
     const intersectResult = aabb.intersects(cameraFrustum);
     return intersectResult > 0;

--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -663,15 +663,15 @@ export function isLngLatBehindGlobe(tr: Transform, lngLat: LngLat): boolean {
  */
 export function polesInViewport(tr: Transform): [boolean, boolean] {
     // Create matrix from ECEF to screen coordinates
-    const matrix = mat4.identity(new Float64Array(16));
-    mat4.multiply(matrix, tr.pixelMatrix, tr.globeMatrix);
+    const ecefToScreenMatrix = mat4.identity(new Float64Array(16));
+    mat4.multiply(ecefToScreenMatrix, tr.pixelMatrix, tr.globeMatrix);
 
     const north = [0, GLOBE_MIN, 0];
     const south = [0, GLOBE_MAX, 0];
 
-    // Translate the pole coordinates to screen coordinates
-    vec3.transformMat4(north, north, matrix);
-    vec3.transformMat4(south, south, matrix);
+    // Translate the poles from ECEF to screen coordinates
+    vec3.transformMat4(north, north, ecefToScreenMatrix);
+    vec3.transformMat4(south, south, ecefToScreenMatrix);
 
     // Check if the poles are inside the viewport and not behind the globe surface
     const northInViewport =

--- a/src/geo/projection/globe_util.js
+++ b/src/geo/projection/globe_util.js
@@ -662,7 +662,7 @@ export function isLngLatBehindGlobe(tr: Transform, lngLat: LngLat): boolean {
  * @returns {[boolean, boolean]} A tuple of booleans [northInViewport, southInViewport]
  */
 export function polesInViewport(tr: Transform): [boolean, boolean] {
-    // Create matrix to screen coordinates
+    // Create matrix from ECEF to screen coordinates
     const matrix = mat4.identity(new Float64Array(16));
     mat4.multiply(matrix, tr.pixelMatrix, tr.globeMatrix);
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1391,10 +1391,14 @@ class Transform {
         processSegment(left, bottom, left, top);
 
         const [northPoleIsVisible, southPoleIsVisible] = polesInViewport(this);
+        const poleIsVisible = northPoleIsVisible || southPoleIsVisible;
 
-        const ne = new LngLat(lngFromMercatorX(maxX), northPoleIsVisible ? 90 : latFromMercatorY(minY));
-        const sw = new LngLat(lngFromMercatorX(minX), southPoleIsVisible ? -90 : latFromMercatorY(maxY));
-        return new LngLatBounds(sw, ne);
+        const north = northPoleIsVisible ? 90 : latFromMercatorY(minY);
+        const east = poleIsVisible ? 180 : lngFromMercatorX(maxX);
+        const south = southPoleIsVisible ? -90 : latFromMercatorY(maxY);
+        const west = poleIsVisible ? -180 : lngFromMercatorX(minX);
+
+        return new LngLatBounds(new LngLat(west, south), new LngLat(east, north));
     }
 
     _getBounds(min: number, max: number): LngLatBounds {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -715,10 +715,6 @@ class Transform {
         return result;
     }
 
-    getPerspectiveCameraMatrix(): Float64Array {
-        return this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, this._nearZ, this._farZ);
-    }
-
     /**
      * Return all coordinates that could cover this transform for a covering
      * zoom level.
@@ -1809,7 +1805,7 @@ class Transform {
 
         const zUnit = this.projection.zAxisUnit === "meters" ? pixelsPerMeter : 1.0;
         const worldToCamera = this._camera.getWorldToCamera(this.worldSize, zUnit);
-        const cameraToClip = this.getPerspectiveCameraMatrix();
+        const cameraToClip = this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, this._nearZ, this._farZ);
 
         // Apply center of perspective offset
         cameraToClip[8] = -offset.x * 2 / this.width;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -17,7 +17,7 @@ import assert from 'assert';
 import getProjectionAdjustments, {getProjectionAdjustmentInverted, getScaleAdjustment, getProjectionInterpolationT} from './projection/adjustments.js';
 import {getPixelsToTileUnitsMatrix} from '../source/pixels_to_tile_units.js';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
-import {calculateGlobeMatrix, isLngLatInViewport, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
+import {calculateGlobeMatrix, polesInViewport, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
 import {projectClamped} from '../symbol/projection.js';
 
 import type Projection from '../geo/projection/projection.js';
@@ -1401,15 +1401,8 @@ class Transform {
         processSegment(right, bottom, left, bottom);
         processSegment(left, bottom, left, top);
 
-        // Check if the north pole is visible and minY is behind the pole
-        const northPoleLocation = new LngLat(this.center.lat, MAX_MERCATOR_LATITUDE);
-        const northPoleIsVisible = isLngLatInViewport(this, northPoleLocation) &&
-            latFromMercatorY(minY) < MAX_MERCATOR_LATITUDE;
-
-        // Check if the south pole is visible and maxY is behind the pole
-        const southPoleLocation = new LngLat(this.center.lat, -MAX_MERCATOR_LATITUDE);
-        const southPoleIsVisible = isLngLatInViewport(this, southPoleLocation) &&
-            latFromMercatorY(maxY) > -MAX_MERCATOR_LATITUDE;
+        // Include poles in bounds if visible
+        const [northPoleIsVisible, southPoleIsVisible] = polesInViewport(this);
 
         const ne = new LngLat(lngFromMercatorX(maxX), northPoleIsVisible ? 90 : latFromMercatorY(minY));
         const sw = new LngLat(lngFromMercatorX(minX), southPoleIsVisible ? -90 : latFromMercatorY(maxY));

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -719,13 +719,6 @@ class Transform {
         return this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, this._nearZ, this._farZ);
     }
 
-    getCameraFrustum(): Frustum {
-        const perspectiveCameraMatrix = this.getPerspectiveCameraMatrix();
-        // Create a matrix from clip space to world coords (inverse perspective matrix)
-        const invPerspectiveMatrix = mat4.invert(new Float64Array(16), perspectiveCameraMatrix);
-        return Frustum.fromInvPerspectiveMatrix(invPerspectiveMatrix);
-    }
-
     /**
      * Return all coordinates that could cover this transform for a covering
      * zoom level.

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -715,10 +715,15 @@ class Transform {
         return result;
     }
 
+    getPerspectiveCameraMatrix(): Float64Array {
+        return this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, this._nearZ, this._farZ);
+    }
+
     getCameraFrustum(): Frustum {
-        const z = Math.floor(this.zoom);
-        const zInMeters = this.projection.name !== 'globe';
-        return Frustum.fromInvProjectionMatrix(this.invProjMatrix, this.worldSize, z, zInMeters);
+        const perspectiveCameraMatrix = this.getPerspectiveCameraMatrix();
+        // Create a matrix from clip space to world coords (inverse perspective matrix)
+        const invPerspectiveMatrix = mat4.invert(new Float64Array(16), perspectiveCameraMatrix);
+        return Frustum.fromInvPerspectiveMatrix(invPerspectiveMatrix);
     }
 
     /**
@@ -1818,7 +1823,7 @@ class Transform {
 
         const zUnit = this.projection.zAxisUnit === "meters" ? pixelsPerMeter : 1.0;
         const worldToCamera = this._camera.getWorldToCamera(this.worldSize, zUnit);
-        const cameraToClip = this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, this._nearZ, this._farZ);
+        const cameraToClip = this.getPerspectiveCameraMatrix();
 
         // Apply center of perspective offset
         cameraToClip[8] = -offset.x * 2 / this.width;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1390,7 +1390,6 @@ class Transform {
         processSegment(right, bottom, left, bottom);
         processSegment(left, bottom, left, top);
 
-        // Include poles in bounds if visible
         const [northPoleIsVisible, southPoleIsVisible] = polesInViewport(this);
 
         const ne = new LngLat(lngFromMercatorX(maxX), northPoleIsVisible ? 90 : latFromMercatorY(minY));

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -17,7 +17,7 @@ import assert from 'assert';
 import getProjectionAdjustments, {getProjectionAdjustmentInverted, getScaleAdjustment, getProjectionInterpolationT} from './projection/adjustments.js';
 import {getPixelsToTileUnitsMatrix} from '../source/pixels_to_tile_units.js';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
-import {calculateGlobeMatrix, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
+import {calculateGlobeMatrix, isLngLatInViewport, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
 import {projectClamped} from '../symbol/projection.js';
 
 import type Projection from '../geo/projection/projection.js';
@@ -715,6 +715,12 @@ class Transform {
         return result;
     }
 
+    getCameraFrustum(): Frustum {
+        const z = Math.floor(this.zoom);
+        const zInMeters = this.projection.name !== 'globe';
+        return Frustum.fromInvProjectionMatrix(this.invProjMatrix, this.worldSize, z, zInMeters);
+    }
+
     /**
      * Return all coordinates that could cover this transform for a covering
      * zoom level.
@@ -1390,8 +1396,18 @@ class Transform {
         processSegment(right, bottom, left, bottom);
         processSegment(left, bottom, left, top);
 
-        const ne = new LngLat(lngFromMercatorX(maxX), latFromMercatorY(minY));
-        const sw = new LngLat(lngFromMercatorX(minX), latFromMercatorY(maxY));
+        // Check if the north pole is visible and minY is behind the pole
+        const northPoleLocation = new LngLat(this.center.lat, MAX_MERCATOR_LATITUDE);
+        const northPoleIsVisible = isLngLatInViewport(this, northPoleLocation) &&
+            latFromMercatorY(minY) < MAX_MERCATOR_LATITUDE;
+
+        // Check if the south pole is visible and maxY is behind the pole
+        const southPoleLocation = new LngLat(this.center.lat, -MAX_MERCATOR_LATITUDE);
+        const southPoleIsVisible = isLngLatInViewport(this, southPoleLocation) &&
+            latFromMercatorY(maxY) > -MAX_MERCATOR_LATITUDE;
+
+        const ne = new LngLat(lngFromMercatorX(maxX), northPoleIsVisible ? 90 : latFromMercatorY(minY));
+        const sw = new LngLat(lngFromMercatorX(minX), southPoleIsVisible ? -90 : latFromMercatorY(maxY));
         return new LngLatBounds(sw, ne);
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -791,16 +791,14 @@ class Map extends Camera {
      * Returns the map's geographical bounds. When the bearing or pitch is non-zero, the visible region is not
      * an axis-aligned rectangle, and the result is the smallest bounds that encompasses the visible region.
      * If a padding is set on the map, the bounds returned are for the inset.
-     * This function isn't supported with globe projection.
+     * With globe projection, the smallest bounds encompassing the visible region
+     * may not precisely represent the visible region due to the earth's curvature.
      *
      * @returns {LngLatBounds} The geographical bounds of the map as {@link LngLatBounds}.
      * @example
      * const bounds = map.getBounds();
      */
     getBounds(): LngLatBounds | null {
-        if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support getBounds API, this API may behave unexpectedly when viewing the poles."');
-        }
         return this.transform.getBounds();
     }
 

--- a/src/util/primitives.js
+++ b/src/util/primitives.js
@@ -166,42 +166,6 @@ class Frustum {
 
         return new Frustum(frustumCoords, frustumPlanes);
     }
-
-    static fromInvPerspectiveMatrix(invPerspective: Float64Array): Frustum {
-        const clipSpaceCorners = [
-            [-1, 1, -1, 1],
-            [ 1, 1, -1, 1],
-            [ 1, -1, -1, 1],
-            [-1, -1, -1, 1],
-            [-1, 1, 1, 1],
-            [ 1, 1, 1, 1],
-            [ 1, -1, 1, 1],
-            [-1, -1, 1, 1]
-        ];
-
-        // Transform frustum corner points from clip space to world coords space
-        const frustumCoords = clipSpaceCorners
-            .map(v => vec4.transformMat4([], v, invPerspective));
-
-        const frustumPlanePointIndices = [
-            [0, 1, 2],  // near
-            [6, 5, 4],  // far
-            [0, 3, 7],  // left
-            [2, 1, 5],  // right
-            [3, 2, 6],  // bottom
-            [0, 4, 5]   // top
-        ];
-
-        const frustumPlanes = frustumPlanePointIndices.map((p: Array<number>) => {
-            const a = vec3.sub([], frustumCoords[p[0]], frustumCoords[p[1]]);
-            const b = vec3.sub([], frustumCoords[p[2]], frustumCoords[p[1]]);
-            const n = vec3.normalize([], vec3.cross([], a, b));
-            const d = -vec3.dot(n, frustumCoords[p[1]]);
-            return n.concat(d);
-        });
-
-        return new Frustum(frustumCoords, frustumPlanes);
-    }
 }
 
 class Aabb {

--- a/src/util/primitives.js
+++ b/src/util/primitives.js
@@ -166,6 +166,42 @@ class Frustum {
 
         return new Frustum(frustumCoords, frustumPlanes);
     }
+
+    static fromInvPerspectiveMatrix(invPerspective: Float64Array): Frustum {
+        const clipSpaceCorners = [
+            [-1, 1, -1, 1],
+            [ 1, 1, -1, 1],
+            [ 1, -1, -1, 1],
+            [-1, -1, -1, 1],
+            [-1, 1, 1, 1],
+            [ 1, 1, 1, 1],
+            [ 1, -1, 1, 1],
+            [-1, -1, 1, 1]
+        ];
+
+        // Transform frustum corner points from clip space to world coords space
+        const frustumCoords = clipSpaceCorners
+            .map(v => vec4.transformMat4([], v, invPerspective));
+
+        const frustumPlanePointIndices = [
+            [0, 1, 2],  // near
+            [6, 5, 4],  // far
+            [0, 3, 7],  // left
+            [2, 1, 5],  // right
+            [3, 2, 6],  // bottom
+            [0, 4, 5]   // top
+        ];
+
+        const frustumPlanes = frustumPlanePointIndices.map((p: Array<number>) => {
+            const a = vec3.sub([], frustumCoords[p[0]], frustumCoords[p[1]]);
+            const b = vec3.sub([], frustumCoords[p[2]], frustumCoords[p[1]]);
+            const n = vec3.normalize([], vec3.cross([], a, b));
+            const d = -vec3.dot(n, frustumCoords[p[1]]);
+            return n.concat(d);
+        });
+
+        return new Frustum(frustumCoords, frustumPlanes);
+    }
 }
 
 class Aabb {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1441,7 +1441,7 @@ test('Map', (t) => {
             t.same(bounds.getNorth(), 90);
             t.same(
                 toFixed(bounds.toArray()),
-                toFixed([[ -180, 11.1637985859 ], [ 152.6922385164, 90 ]])
+                toFixed([[ -180, 11.1637985859 ], [ 180, 90 ]])
             );
 
             map.jumpTo({zoom: 0, center: [0, -90]});
@@ -1449,7 +1449,7 @@ test('Map', (t) => {
             t.same(bounds.getSouth(), -90);
             t.same(
                 toFixed(bounds.toArray()),
-                toFixed([[ -180, -90 ], [ 152.6922385164, -11.1637985859]])
+                toFixed([[ -180, -90 ], [ 180, -11.1637985859]])
             );
 
             map.jumpTo({zoom: 2, center: [0, 45], bearing: 0, pitch: 20});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1428,48 +1428,44 @@ test('Map', (t) => {
 
         t.test('globe bounds', (t) => {
             const map = createMap(t, {zoom: 0, skipCSSStub: true});
-            const mercatorBounds = map.getBounds();
+            let bounds = map.getBounds();
 
             t.same(
-                toFixed(mercatorBounds.toArray()),
+                toFixed(bounds.toArray()),
                 toFixed([[ -70.3125000000, -57.3265212252, ], [ 70.3125000000, 57.3265212252]])
             );
 
             t.stub(console, 'warn');
             map.setProjection('globe');
-            const globeBounds = map.getBounds();
-
+            bounds = map.getBounds();
             t.same(
-                toFixed(globeBounds.toArray()),
+                toFixed(bounds.toArray()),
                 toFixed([[ -73.8873304141, -73.8873304141, ], [ 73.8873304141, 73.8873304141]])
             );
 
-            map.setBearing(80);
-            map.setCenter({lng: 0, lat: 90});
-
-            const northBounds = map.getBounds();
-            t.same(northBounds.getNorth(), 90);
+            map.jumpTo({zoom: 0, center: [0, 90]});
+            bounds = map.getBounds();
+            t.same(bounds.getNorth(), 90);
             t.same(
-                toFixed(northBounds.toArray()),
-                toFixed([[ -169.7072944003, 11.2373406095 ], [ 175.8448619060, 90 ]])
+                toFixed(bounds.toArray()),
+                toFixed([[ -180, 11.1637985859 ], [ 152.6922385164, 90 ]])
             );
 
-            map.setBearing(180);
-            map.setCenter({lng: 0, lat: -90});
-
-            const southBounds = map.getBounds();
-            t.same(southBounds.getSouth(), -90);
+            map.jumpTo({zoom: 0, center: [0, -90]});
+            bounds = map.getBounds();
+            t.same(bounds.getSouth(), -90);
             t.same(
-                toFixed(southBounds.toArray()),
-                toFixed([[ -165.5559158623, -90 ], [ 180, -11.1637985859]])
+                toFixed(bounds.toArray()),
+                toFixed([[ -180, -90 ], [ 152.6922385164, -11.1637985859]])
             );
 
-            map.setZoom(3);
-            map.setBearing(0);
-            map.setCenter({lng: 0, lat: 45});
+            map.jumpTo({zoom: 2, center: [0, 45], bearing: 0, pitch: 20});
+            bounds = map.getBounds();
+            t.notSame(bounds.getNorth(), 90);
 
-            const europeBounds = map.getBounds();
-            t.notSame(europeBounds.getNorth(), 90);
+            map.jumpTo({zoom: 2, center: [0, -45], bearing: 180, pitch: -20});
+            bounds = map.getBounds();
+            t.notSame(bounds.getSouth(), -90);
 
             t.end();
         });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1444,6 +1444,33 @@ test('Map', (t) => {
                 toFixed([[ -73.8873304141, -73.8873304141, ], [ 73.8873304141, 73.8873304141]])
             );
 
+            map.setBearing(80);
+            map.setCenter({lng: 0, lat: 90});
+
+            const northBounds = map.getBounds();
+            t.same(northBounds.getNorth(), 90);
+            t.same(
+                toFixed(northBounds.toArray()),
+                toFixed([[ -169.7072944003, 11.2373406095 ], [ 175.8448619060, 90 ]])
+            );
+
+            map.setBearing(180);
+            map.setCenter({lng: 0, lat: -90});
+
+            const southBounds = map.getBounds();
+            t.same(southBounds.getSouth(), -90);
+            t.same(
+                toFixed(southBounds.toArray()),
+                toFixed([[ -165.5559158623, -90 ], [ 180, -11.1637985859]])
+            );
+
+            map.setZoom(3);
+            map.setBearing(0);
+            map.setCenter({lng: 0, lat: 45});
+
+            const europeBounds = map.getBounds();
+            t.notSame(europeBounds.getNorth(), 90);
+
             t.end();
         });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1427,17 +1427,10 @@ test('Map', (t) => {
         });
 
         t.test('globe bounds', (t) => {
-            const map = createMap(t, {zoom: 0, skipCSSStub: true});
-            let bounds = map.getBounds();
-
-            t.same(
-                toFixed(bounds.toArray()),
-                toFixed([[ -70.3125000000, -57.3265212252, ], [ 70.3125000000, 57.3265212252]])
-            );
-
+            const map = createMap(t, {zoom: 0, projection: 'globe', skipCSSStub: true});
             t.stub(console, 'warn');
-            map.setProjection('globe');
-            bounds = map.getBounds();
+
+            let bounds = map.getBounds();
             t.same(
                 toFixed(bounds.toArray()),
                 toFixed([[ -73.8873304141, -73.8873304141, ], [ 73.8873304141, 73.8873304141]])

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1428,7 +1428,6 @@ test('Map', (t) => {
 
         t.test('globe bounds', (t) => {
             const map = createMap(t, {zoom: 0, projection: 'globe', skipCSSStub: true});
-            t.stub(console, 'warn');
 
             let bounds = map.getBounds();
             t.same(


### PR DESCRIPTION
This PR adds the pole support in `getBounds` on the Globe. It adds a new util function `polesInViewport`, that detects if the poles are visible in the current viewport by intersecting the location with the viewport in screen coordinates and checking if they are behind the globe surface.

Previously the poles support was removed in https://github.com/mapbox/mapbox-gl-js/pull/12318

## Before

<img width="1280" alt="Screen Shot 2022-10-21 at 18 13 10" src="https://user-images.githubusercontent.com/533564/197229619-577e37a0-3d40-4ce7-a724-7e871433f616.png">

## After

<img width="1280" alt="Screen Shot 2022-10-21 at 18 12 31" src="https://user-images.githubusercontent.com/533564/197229652-cf27ba4d-ca8e-4ca3-aba3-03890edb0016.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve poles support in getBounds when projection is set to globe</changelog>`
