### PR TITLE
Revert the poles support in Globe `getBounds`

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1390,16 +1390,8 @@ class Transform {
         processSegment(right, bottom, left, bottom);
         processSegment(left, bottom, left, top);
 
-        // Check if minY is behind the globe and the north pole is visible
-        const northPoleIsVisible = latFromMercatorY(minY) < 90 &&
-            !isLngLatBehindGlobe(this, new LngLat(this.center.lat, 90));
-
-        // Check if maxY is behind the globe and the south pole is visible
-        const southPoleIsVisible = latFromMercatorY(maxY) > -90 &&
-            !isLngLatBehindGlobe(this, new LngLat(this.center.lat, -90));
-
-        const ne = new LngLat(lngFromMercatorX(maxX), northPoleIsVisible ? 90 : latFromMercatorY(minY));
-        const sw = new LngLat(lngFromMercatorX(minX), southPoleIsVisible ? -90 : latFromMercatorY(maxY));
+        const ne = new LngLat(lngFromMercatorX(maxX), latFromMercatorY(minY));
+        const sw = new LngLat(lngFromMercatorX(minX), latFromMercatorY(maxY));
         return new LngLatBounds(sw, ne);
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -17,7 +17,7 @@ import assert from 'assert';
 import getProjectionAdjustments, {getProjectionAdjustmentInverted, getScaleAdjustment, getProjectionInterpolationT} from './projection/adjustments.js';
 import {getPixelsToTileUnitsMatrix} from '../source/pixels_to_tile_units.js';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
-import {calculateGlobeMatrix, isLngLatBehindGlobe, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
+import {calculateGlobeMatrix, GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_SCALE_MATCH_LATITUDE} from '../geo/projection/globe_util.js';
 import {projectClamped} from '../symbol/projection.js';
 
 import type Projection from '../geo/projection/projection.js';

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -799,7 +799,7 @@ class Map extends Camera {
      */
     getBounds(): LngLatBounds | null {
         if (this.transform.projection.name === 'globe') {
-            warnOnce('Globe projection does not support getBounds API, this API may behave unexpectedly."');
+            warnOnce('Globe projection does not support getBounds API, this API may behave unexpectedly when viewing the poles."');
         }
         return this.transform.getBounds();
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -798,6 +798,9 @@ class Map extends Camera {
      * const bounds = map.getBounds();
      */
     getBounds(): LngLatBounds | null {
+        if (this.transform.projection.name === 'globe') {
+            warnOnce('Globe projection does not support getBounds API, this API may behave unexpectedly."');
+        }
         return this.transform.getBounds();
     }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1435,32 +1435,13 @@ test('Map', (t) => {
                 toFixed([[ -70.3125000000, -57.3265212252, ], [ 70.3125000000, 57.3265212252]])
             );
 
+            t.stub(console, 'warn');
             map.setProjection('globe');
             const globeBounds = map.getBounds();
 
             t.same(
                 toFixed(globeBounds.toArray()),
                 toFixed([[ -73.8873304141, -73.8873304141, ], [ 73.8873304141, 73.8873304141]])
-            );
-
-            map.setBearing(80);
-            map.setCenter({lng: 0, lat: 90});
-
-            const northBounds = map.getBounds();
-            t.same(northBounds.getNorth(), 90);
-            t.same(
-                toFixed(northBounds.toArray()),
-                toFixed([[ -169.7072944003, 11.2373406095 ], [ 175.8448619060, 90 ]])
-            );
-
-            map.setBearing(180);
-            map.setCenter({lng: 0, lat: -90});
-
-            const southBounds = map.getBounds();
-            t.same(southBounds.getSouth(), -90);
-            t.same(
-                toFixed(southBounds.toArray()),
-                toFixed([[ -165.5559158623, -90 ], [ 180, -11.1637985859]])
             );
 
             t.end();


### PR DESCRIPTION
This PR reverts the poles support in Globe `getBounds` added in https://github.com/mapbox/mapbox-gl-js/pull/12286

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
