### PR TITLE
Remove line atlas leftover from style/painter

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -68,7 +68,6 @@ import type {OverscaledTileID, UnwrappedTileID} from '../source/tile_id.js';
 import type Style from '../style/style.js';
 import type StyleLayer from '../style/style_layer.js';
 import type {CrossFaded} from '../style/properties.js';
-import type LineAtlas from './line_atlas.js';
 import type ImageManager from './image_manager.js';
 import type GlyphManager from './glyph_manager.js';
 import type VertexBuffer from '../gl/vertex_buffer.js';
@@ -137,7 +136,6 @@ class Painter {
     stencilClearMode: StencilMode;
     style: Style;
     options: PainterOptions;
-    lineAtlas: LineAtlas;
     imageManager: ImageManager;
     glyphManager: GlyphManager;
     depthRangeFor3D: DepthRangeType;
@@ -484,7 +482,6 @@ class Painter {
         this.style = style;
         this.options = options;
 
-        this.lineAtlas = style.lineAtlas;
         this.imageManager = style.imageManager;
         this.glyphManager = style.glyphManager;
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -11,7 +11,6 @@ import GlyphManager, {LocalGlyphMode} from '../render/glyph_manager.js';
 import Light from './light.js';
 import Terrain, {DrapeRenderMode} from './terrain.js';
 import Fog from './fog.js';
-import LineAtlas from '../render/line_atlas.js';
 import {pick, clone, extend, deepEqual, filterObject} from '../util/util.js';
 import {getJSON, getReferrer, makeRequest, ResourceType} from '../util/ajax.js';
 import {isMapboxURL} from '../util/mapbox.js';
@@ -138,7 +137,6 @@ class Style extends Evented {
     dispatcher: Dispatcher;
     imageManager: ImageManager;
     glyphManager: GlyphManager;
-    lineAtlas: LineAtlas;
     light: Light;
     terrain: ?Terrain;
     fog: ?Fog;
@@ -190,7 +188,6 @@ class Style extends Evented {
                 LocalGlyphMode.all :
                 (options.localIdeographFontFamily ? LocalGlyphMode.ideographs : LocalGlyphMode.none),
             options.localFontFamily || options.localIdeographFontFamily);
-        this.lineAtlas = new LineAtlas(256, 512);
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
         this._layers = {};


### PR DESCRIPTION
Discovered some leftover code from pre-data-driven line-dasharray time after a pointer from @galinelle. It's unused so safe to remove for now — we might want to reintroduce it later for some optimizations.
