### PR TITLE
Cleanup in shaders to fix warnings

### DIFF
--- a/src/shaders/_prelude_terrain.vertex.glsl
+++ b/src/shaders/_prelude_terrain.vertex.glsl
@@ -180,7 +180,6 @@ float flatElevation(vec2 pack) {
 
     vec2 w = floor(0.5 * (span * u_meter_to_dem - 1.0));
     vec2 d = dd * w;
-    vec4 bounds = vec4(d, vec2(1.0) - d);
 
     // Get building wide sample, to get better slope estimate.
     h = fourSample(pos - d, 2.0 * d + vec2(dd));

--- a/src/shaders/hillshade_prepare.fragment.glsl
+++ b/src/shaders/hillshade_prepare.fragment.glsl
@@ -29,11 +29,11 @@ void main() {
     // |   |   |   |
     // +-----------+
     // |   |   |   |
-    // | d | e | f |
+    // | d |   | e |
     // |   |   |   |
     // +-----------+
     // |   |   |   |
-    // | g | h | i |
+    // | f | g | h |
     // |   |   |   |
     // +-----------+
 
@@ -41,11 +41,10 @@ void main() {
     float b = getElevation(v_pos + vec2(0, -epsilon.y));
     float c = getElevation(v_pos + vec2(epsilon.x, -epsilon.y));
     float d = getElevation(v_pos + vec2(-epsilon.x, 0));
-    float e = getElevation(v_pos);
-    float f = getElevation(v_pos + vec2(epsilon.x, 0));
-    float g = getElevation(v_pos + vec2(-epsilon.x, epsilon.y));
-    float h = getElevation(v_pos + vec2(0, epsilon.y));
-    float i = getElevation(v_pos + vec2(epsilon.x, epsilon.y));
+    float e = getElevation(v_pos + vec2(epsilon.x, 0));
+    float f = getElevation(v_pos + vec2(-epsilon.x, epsilon.y));
+    float g = getElevation(v_pos + vec2(0, epsilon.y));
+    float h = getElevation(v_pos + vec2(epsilon.x, epsilon.y));
 
     // Here we divide the x and y slopes by 8 * pixel size
     // where pixel size (aka meters/pixel) is:
@@ -63,8 +62,8 @@ void main() {
     float exaggeration = u_zoom < 15.0 ? (u_zoom - 15.0) * exaggerationFactor : 0.0;
 
     vec2 deriv = vec2(
-        (c + f + f + i) - (a + d + d + g),
-        (g + h + h + i) - (a + b + b + c)
+        (c + e + e + h) - (a + d + d + f),
+        (f + g + g + h) - (a + b + b + c)
     ) / pow(2.0, exaggeration + (19.2562 - u_zoom));
 
     gl_FragColor = clamp(vec4(

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -58,11 +58,12 @@ void main() {
     alpha *= smoothstep(0.5 - sdfgamma / floorwidth, 0.5 + sdfgamma / floorwidth, sdfdist);
 #endif
 
+    highp vec4 out_color;
 #ifdef RENDER_LINE_GRADIENT
     // For gradient lines, v_uv.xy are the coord specify where the texture will be simpled.
-    highp vec4 out_color = texture2D(u_gradient_image, v_uv.xy);
+    out_color = texture2D(u_gradient_image, v_uv.xy);
 #else
-    vec4 out_color = color;
+    out_color = color;
 #endif
 
 #ifdef RENDER_LINE_TRIM_OFFSET


### PR DESCRIPTION
We got a couple of small warnings in GL-Native after updating our cross-compilation setup. This PR removes two unused variables to fix those and also adds one more extra refactoring for the conditional blocks similar to https://github.com/mapbox/mapbox-gl-js/pull/12249

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
