### PR TITLE
no-op if geolocation query returns after control has been removed

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -417,6 +417,11 @@ class GeolocateControl extends Evented {
     }
 
     _setupUI(supported: boolean) {
+        if (this._map === undefined) {
+            // This control was removed from the map before geolocation
+            // support was determined.
+            return;
+        }
         this._container.addEventListener('contextmenu', (e: MouseEvent) => e.preventDefault());
         this._geolocateButton = DOM.create('button', `mapboxgl-ctrl-geolocate`, this._container);
         DOM.create('span', `mapboxgl-ctrl-icon`, this._geolocateButton).setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Launch Checklist

- Fixes #12073

As described in the linked issue, there's a race condition in which a map can be set up, a geolocate control added, and then removed before the geolocate control's query for geolocation support finishes, which will throw an error. This PR fixes that race condition by making `_setupUI` a no-op if the a map is no longer attached to the control.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix an issue where Geolocate control would throw an error if it's removed before determining geolocation support</changelog>`
