### PR TITLE
Add live performance counters

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -15,6 +15,7 @@
 <div id='map'></div>
 
 <script src='../dist/mapbox-gl-dev.js'></script>
+<!-- <script src='../dist/mapbox-gl.js'></script> -->
 <script src='../debug/access_token_generated.js'></script>
 <script>
 

--- a/debug/index.html
+++ b/debug/index.html
@@ -15,7 +15,6 @@
 <div id='map'></div>
 
 <script src='../dist/mapbox-gl-dev.js'></script>
-<!-- <script src='../dist/mapbox-gl.js'></script> -->
 <script src='../debug/access_token_generated.js'></script>
 <script>
 

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -60,12 +60,15 @@ class Context {
     pixelStoreUnpack: PixelStoreUnpack;
     pixelStoreUnpackPremultiplyAlpha: PixelStoreUnpackPremultiplyAlpha;
     pixelStoreUnpackFlipY: PixelStoreUnpackFlipY;
+    renderer: ?string;
+    vendor: ?string;
 
     extTextureFilterAnisotropic: any;
     extTextureFilterAnisotropicMax: any;
     extTextureHalfFloat: any;
     extRenderToTextureHalfFloat: any;
     extStandardDerivatives: any;
+    extDebugRendererInfo: any;
     extTimerQuery: any;
 
     extTextureFilterAnisotropicForceOff: boolean;
@@ -117,6 +120,12 @@ class Context {
         }
         this.extTextureFilterAnisotropicForceOff = false;
         this.extStandardDerivativesForceOff = false;
+
+        this.extDebugRendererInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        if (this.extDebugRendererInfo) {
+            this.renderer = gl.getParameter(this.extDebugRendererInfo.UNMASKED_VENDOR_WEBGL);
+            this.vendor = gl.getParameter(this.extDebugRendererInfo.UNMASKED_RENDERER_WEBGL);
+        }
 
         this.extTextureHalfFloat = gl.getExtension('OES_texture_half_float');
         if (this.extTextureHalfFloat) {

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -123,8 +123,8 @@ class Context {
 
         this.extDebugRendererInfo = gl.getExtension('WEBGL_debug_renderer_info');
         if (this.extDebugRendererInfo) {
-            this.renderer = gl.getParameter(this.extDebugRendererInfo.UNMASKED_VENDOR_WEBGL);
-            this.vendor = gl.getParameter(this.extDebugRendererInfo.UNMASKED_RENDERER_WEBGL);
+            this.renderer = gl.getParameter(this.extDebugRendererInfo.UNMASKED_RENDERER_WEBGL);
+            this.vendor = gl.getParameter(this.extDebugRendererInfo.UNMASKED_VENDOR_WEBGL);
         }
 
         this.extTextureHalfFloat = gl.getExtension('OES_texture_half_float');

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -25,7 +25,8 @@ import {Event, ErrorEvent} from '../util/evented.js';
 import {MapMouseEvent} from './events.js';
 import TaskQueue from '../util/task_queue.js';
 import webpSupported from '../util/webp_supported.js';
-import {PerformanceMarkers, PerformanceUtils} from '../util/performance.js';
+import {PerformanceUtils} from '../util/performance.js';
+import {PerformanceMarkers, LivePerformanceUtils} from '../util/live_performance.js';
 import Marker from '../ui/marker.js';
 import Popup from '../ui/popup.js';
 import EasedVariable from '../util/eased_variable.js';
@@ -449,7 +450,7 @@ class Map extends Camera {
     touchPitch: TouchPitchHandler;
 
     constructor(options: MapOptions) {
-        PerformanceUtils.mark(PerformanceMarkers.create);
+        LivePerformanceUtils.mark(PerformanceMarkers.create);
 
         options = extend({}, defaultOptions, options);
 
@@ -3289,12 +3290,13 @@ class Map extends Camera {
                     terrainEnabled: !!this.painter.style.getTerrain(),
                     fogEnabled: !!this.painter.style.getFog(),
                     projection: this.painter.transform.projection,
+                    zoom: this.transform.zoom,
                     renderer: this.painter.context.renderer,
                     vendor: this.painter.context.vendor
                 });
             }
             this._authenticate();
-            PerformanceUtils.mark(PerformanceMarkers.fullLoad);
+            LivePerformanceUtils.mark(PerformanceMarkers.fullLoad);
         }
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3286,8 +3286,8 @@ class Map extends Camera {
                     width: this.painter.width,
                     height: this.painter.height,
                     interactionRange: this._interactionRange,
-                    terrain: this.painter.style.getTerrain(),
-                    fog: this.painter.style.getFog(),
+                    terrainEnabled: !!this.painter.style.getTerrain(),
+                    fogEnabled: !!this.painter.style.getFog(),
                     projection: this.painter.transform.projection,
                     renderer: this.painter.context.renderer,
                     vendor: this.painter.context.vendor

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -160,7 +160,7 @@ const defaultOptions = {
     touchZoomRotate: true,
     touchPitch: true,
     cooperativeGestures: false,
-    enablePerformanceMetricsCollection: true,
+    performanceMetricsCollection: true,
 
     bearingSnap: 7,
     clickTolerance: 3,
@@ -250,7 +250,7 @@ const defaultOptions = {
  * @param {boolean | Object} [options.touchPitch=true] If `true`, the "drag to pitch" interaction is enabled. An `Object` value is passed as options to {@link TouchPitchHandler}.
  * @param {boolean} [options.cooperativeGestures] If `true`, scroll zoom will require pressing the ctrl or ⌘ key while scrolling to zoom map, and touch pan will require using two fingers while panning to move the map. Touch pitch will require three fingers to activate if enabled.
  * @param {boolean} [options.trackResize=true] If `true`, the map will automatically resize when the browser window resizes.
- * @param {boolean} [options.enablePerformanceMetricsCollection=true] If `true`, mapbox-gl will collect and send performance metrics.
+ * @param {boolean} [options.performanceMetricsCollection=true] If `true`, mapbox-gl will collect and send performance metrics.
  * @param {LngLatLike} [options.center=[0, 0]] The initial geographical [centerpoint](https://docs.mapbox.com/help/glossary/camera#center) of the map. If `center` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `[0, 0]` Note: Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match GeoJSON.
  * @param {number} [options.zoom=0] The initial [zoom](https://docs.mapbox.com/help/glossary/camera#zoom) level of the map. If `zoom` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.bearing=0] The initial [bearing](https://docs.mapbox.com/help/glossary/camera#bearing) (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
@@ -392,7 +392,7 @@ class Map extends Camera {
     _language: ?string | ?string[];
     _worldview: ?string;
     _interactionRange: [number, number];
-    _enablePerformanceMetricsCollection: boolean;
+    _performanceMetricsCollection: boolean;
 
     // `_useExplicitProjection` indicates that a projection is set by a call to map.setProjection()
     _useExplicitProjection: boolean;
@@ -504,7 +504,7 @@ class Map extends Camera {
         this._locale = extend({}, defaultLocale, options.locale);
         this._clickTolerance = options.clickTolerance;
         this._cooperativeGestures = options.cooperativeGestures;
-        this._enablePerformanceMetricsCollection = options.enablePerformanceMetricsCollection;
+        this._performanceMetricsCollection = options.performanceMetricsCollection;
         this._containerWidth = 0;
         this._containerHeight = 0;
 
@@ -3281,7 +3281,7 @@ class Map extends Camera {
         if (this._loaded && !this._fullyLoaded && !somethingDirty) {
             this._fullyLoaded = true;
             // Following lines are billing and metrics related code. Do not change. See LICENSE.txt
-            if (this._enablePerformanceMetricsCollection) {
+            if (this._performanceMetricsCollection) {
                 postPerformanceEvent(this._requestManager._customAccessToken, {
                     width: this.painter.width,
                     height: this.painter.height,
@@ -3291,7 +3291,7 @@ class Map extends Camera {
                     projection: this.painter.transform.projection,
                     renderer: this.painter.context.renderer,
                     vendor: this.painter.context.vendor
-                }, () => {});
+                });
             }
             this._authenticate();
             PerformanceUtils.mark(PerformanceMarkers.fullLoad);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -160,6 +160,7 @@ const defaultOptions = {
     touchZoomRotate: true,
     touchPitch: true,
     cooperativeGestures: false,
+    enablePerformanceMetricsCollection: true,
 
     bearingSnap: 7,
     clickTolerance: 3,
@@ -249,6 +250,7 @@ const defaultOptions = {
  * @param {boolean | Object} [options.touchPitch=true] If `true`, the "drag to pitch" interaction is enabled. An `Object` value is passed as options to {@link TouchPitchHandler}.
  * @param {boolean} [options.cooperativeGestures] If `true`, scroll zoom will require pressing the ctrl or ⌘ key while scrolling to zoom map, and touch pan will require using two fingers while panning to move the map. Touch pitch will require three fingers to activate if enabled.
  * @param {boolean} [options.trackResize=true] If `true`, the map will automatically resize when the browser window resizes.
+ * @param {boolean} [options.enablePerformanceMetricsCollection=true] If `true`, mapbox-gl will collect and send performance metrics.
  * @param {LngLatLike} [options.center=[0, 0]] The initial geographical [centerpoint](https://docs.mapbox.com/help/glossary/camera#center) of the map. If `center` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `[0, 0]` Note: Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match GeoJSON.
  * @param {number} [options.zoom=0] The initial [zoom](https://docs.mapbox.com/help/glossary/camera#zoom) level of the map. If `zoom` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.bearing=0] The initial [bearing](https://docs.mapbox.com/help/glossary/camera#bearing) (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
@@ -390,6 +392,7 @@ class Map extends Camera {
     _language: ?string | ?string[];
     _worldview: ?string;
     _interactionRange: [number, number];
+    _enablePerformanceMetricsCollection: boolean;
 
     // `_useExplicitProjection` indicates that a projection is set by a call to map.setProjection()
     _useExplicitProjection: boolean;
@@ -501,6 +504,7 @@ class Map extends Camera {
         this._locale = extend({}, defaultLocale, options.locale);
         this._clickTolerance = options.clickTolerance;
         this._cooperativeGestures = options.cooperativeGestures;
+        this._enablePerformanceMetricsCollection = options.enablePerformanceMetricsCollection;
         this._containerWidth = 0;
         this._containerHeight = 0;
 
@@ -3277,16 +3281,18 @@ class Map extends Camera {
         if (this._loaded && !this._fullyLoaded && !somethingDirty) {
             this._fullyLoaded = true;
             // Following lines are billing and metrics related code. Do not change. See LICENSE.txt
-            postPerformanceEvent(this._requestManager._customAccessToken, {
-                width: this.painter.width,
-                height: this.painter.height,
-                interactionRange: this._interactionRange,
-                terrain: this.painter.style.getTerrain(),
-                fog: this.painter.style.getFog(),
-                projection: this.painter.transform.projection,
-                renderer: this.painter.context.renderer,
-                vendor: this.painter.context.vendor
-            }, () => {});
+            if (this._enablePerformanceMetricsCollection) {
+                postPerformanceEvent(this._requestManager._customAccessToken, {
+                    width: this.painter.width,
+                    height: this.painter.height,
+                    interactionRange: this._interactionRange,
+                    terrain: this.painter.style.getTerrain(),
+                    fog: this.painter.style.getFog(),
+                    projection: this.painter.transform.projection,
+                    renderer: this.painter.context.renderer,
+                    vendor: this.painter.context.vendor
+                }, () => {});
+            }
             this._authenticate();
             PerformanceUtils.mark(PerformanceMarkers.fullLoad);
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3281,6 +3281,7 @@ class Map extends Camera {
 
         if (this._loaded && !this._fullyLoaded && !somethingDirty) {
             this._fullyLoaded = true;
+            LivePerformanceUtils.mark(PerformanceMarkers.fullLoad);
             // Following lines are billing and metrics related code. Do not change. See LICENSE.txt
             if (this._performanceMetricsCollection) {
                 postPerformanceEvent(this._requestManager._customAccessToken, {
@@ -3296,7 +3297,6 @@ class Map extends Camera {
                 });
             }
             this._authenticate();
-            LivePerformanceUtils.mark(PerformanceMarkers.fullLoad);
         }
     }
 

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -35,19 +35,19 @@ const config: Config = {
     },
     get API_TILEJSON_REGEX() {
         // https://docs.mapbox.com/api/maps/mapbox-tiling-service/#retrieve-tilejson-metadata
-        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/v4\/.*\.json.*$)/i;
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/v[0-9]*\/.*\.json.*$)/i;
     },
     get API_SPRITE_REGEX() {
         // https://docs.mapbox.com/api/maps/styles/#retrieve-a-sprite-image-or-json
-        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/styles\/v1\/)(.*\/sprite.*\..*$)/i;
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/styles\/v[0-9]*\/)(.*\/sprite.*\..*$)/i;
     },
     get API_FONTS_REGEX() {
         // https://docs.mapbox.com/api/maps/fonts/#retrieve-font-glyph-ranges
-        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/fonts\/v1\/)(.*\.pbf.*$)/i;
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/fonts\/v[0-9]*\/)(.*\.pbf.*$)/i;
     },
     get API_STYLE_REGEX() {
         // https://docs.mapbox.com/api/maps/styles/#retrieve-a-style
-        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/styles\/v1\/)(.*$)/i;
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/styles\/v[0-9]*\/)(.*$)/i;
     },
     get EVENTS_URL() {
         if (!this.API_URL) { return null; }

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -3,6 +3,10 @@
 type Config = {|
   API_URL: string,
   API_URL_REGEX: RegExp,
+  API_TILEJSON_REGEX: RegExp,
+  API_FONTS_REGEX: RegExp,
+  API_SPRITE_REGEX: RegExp,
+  API_STYLE_REGEX: RegExp,
   EVENTS_URL: ?string,
   SESSION_PATH: string,
   FEEDBACK_URL: string,
@@ -28,6 +32,22 @@ const config: Config = {
         }
 
         return mapboxHTTPURLRegex;
+    },
+    get API_TILEJSON_REGEX() {
+        // https://docs.mapbox.com/api/maps/mapbox-tiling-service/#retrieve-tilejson-metadata
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/v4\/.*\.json.*$)/i;
+    },
+    get API_SPRITE_REGEX() {
+        // https://docs.mapbox.com/api/maps/styles/#retrieve-a-sprite-image-or-json
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/styles\/v1\/)(.*\/sprite.*\..*$)/i;
+    },
+    get API_FONTS_REGEX() {
+        // https://docs.mapbox.com/api/maps/fonts/#retrieve-font-glyph-ranges
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/fonts\/v1\/)(.*\.pbf.*$)/i;
+    },
+    get API_STYLE_REGEX() {
+        // https://docs.mapbox.com/api/maps/styles/#retrieve-a-style
+        return /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/styles\/v1\/)(.*$)/i;
     },
     get EVENTS_URL() {
         if (!this.API_URL) { return null; }

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -84,7 +84,7 @@ function getStyle(resourceTimers: Array<PerformanceEntry>): ?string {
             if (isMapboxHTTPStyleURL(url)) {
                 const split = url.split('/').slice(-2);
                 if (split.length === 2) {
-                    return `${split[0]}:${split[1]}`;
+                    return `mapbox://styles/${split[0]}/${split[1]}`;
                 }
             }
         }

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -45,7 +45,7 @@ function categorize(arr, fn) {
     return obj;
 }
 
-function getTransferRangePerResourceCategory(resourceTimers) {
+function getTransferRangePerResourceType(resourceTimers) {
     const obj = {};
     if (resourceTimers) {
         for (const category in resourceTimers) {
@@ -67,16 +67,11 @@ function getTransferRangePerResourceCategory(resourceTimers) {
 
 function getResourceCategory(entry: PerformanceResourceTiming): string {
     const url = entry.name.split('?')[0];
-    console.log(url);
+
     // Code may be hosted on various endpoints: CDN, self-hosted,
     // from unpkg... so this check doesn't include mapbox HTTP URL
-    if (url.includes('mapbox-gl')) {
-        if (url.endsWith('.js')) {
-            return 'javascript';
-        } else if (url.endsWith('.css')) {
-            return 'css';
-        }
-    }
+    if (url.includes('mapbox-gl.js')) return 'javascript';
+    if (url.includes('mapbox-gl.css')) return 'css';
 
     if (isMapboxHTTPFontsURL(url)) return 'font';
     if (isMapboxHTTPSpriteURL(url)) return 'sprite';
@@ -103,7 +98,7 @@ function getStyle(resourceTimers: Array<PerformanceEntry>): ?string {
 export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerformanceMetrics {
     const resourceTimers = window.performance.getEntriesByType('resource');
     const resourcesByType = categorize(resourceTimers, getResourceCategory);
-    const counters = getTransferRangePerResourceCategory(resourcesByType);
+    const counters = getTransferRangePerResourceType(resourcesByType);
     const devicePixelRatio = window.devicePixelRatio;
     const connection = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
     const metrics = {counters: [], metadata: [], attributes: []};

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -2,10 +2,6 @@
 
 import window from './window.js';
 import {version as sdkVersion} from '../../package.json';
-import type {
-    TerrainSpecification,
-    FogSpecification,
-} from '../style-spec/types.js';
 import type Projection from '../geo/projection/projection.js';
 import {
     isMapboxHTTPStyleURL,
@@ -24,8 +20,8 @@ export type LivePerformanceData = {
     interactionRange: [number, number],
     width: number,
     height: number,
-    terrain: ?TerrainSpecification,
-    fog: ?FogSpecification,
+    terrainEnabled: boolean,
+    fogEnabled: boolean,
     projection: Projection,
     renderer: ?string,
     vendor: ?string
@@ -118,8 +114,8 @@ export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerfor
     }
 
     addMetric(metrics.attributes, "style", getStyle(resourceTimers));
-    addMetric(metrics.attributes, "terrain", data.terrain ? "true" : "false");
-    addMetric(metrics.attributes, "fog", data.fog ? "true" : "false");
+    addMetric(metrics.attributes, "terrainEnabled", data.terrainEnabled ? "true" : "false");
+    addMetric(metrics.attributes, "fogEnabled", data.fogEnabled ? "true" : "false");
     addMetric(metrics.attributes, "projection", data.projection.name);
 
     addMetric(metrics.metadata, "devicePixelRatio", devicePixelRatio);

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -1,0 +1,153 @@
+// @flow
+
+import window from '../util/window.js';
+import {version as sdkVersion} from '../../package.json';
+import type {
+    TerrainSpecification,
+    FogSpecification,
+} from '../style-spec/types.js';
+import type Projection from '../geo/projection/projection.js';
+
+type LivePerformanceMetrics = {
+    counters: Array<Object>,
+    metadata: Array<Object>,
+    attributes: Array<Object>
+};
+
+export type LivePerformanceData = {
+    interactionRange: [number, number],
+    width: number,
+    height: number,
+    terrain: ?TerrainSpecification,
+    fog: ?FogSpecification,
+    projection: Projection,
+    renderer: ?string,
+    vendor: ?string
+};
+
+function categorize(arr, fn) {
+    const obj = {};
+    if (arr) {
+        for (const item of arr) {
+            const category = fn(item);
+            if (obj[category] === undefined) {
+                obj[category] = [];
+            }
+            obj[category].push(item);
+        }
+    }
+    return obj;
+}
+
+function getTransferRangePerResourceCategory(resourceTimers) {
+    const obj = {};
+    if (resourceTimers) {
+        for (const category in resourceTimers) {
+            if (category !== 'other') {
+                for (const timer of resourceTimers[category]) {
+                    const min = `${category}TransferStart`;
+                    const max = `${category}TransferEnd`;
+
+                    // Resource -TransferStart and -TransferEnd represent the wall time
+                    // between the start of a request to when the data is available
+                    obj[min] = Math.min(obj[min] || +Infinity, timer.startTime);
+                    obj[max] = Math.max(obj[max] || -Infinity, timer.responseEnd);
+                }
+            }
+        }
+    }
+    return obj;
+}
+
+function getResourceCategory(entry) {
+    const path = entry.name.split('?')[0];
+
+    // Code may be hosted on various endpoints: CDN, self-hosted,
+    // from unpkg... so this check doesn't include mapbox specifics
+    if (path.includes('mapbox-gl')) {
+        if (path.endsWith('.js')) {
+            return 'javascript';
+        } else if (path.endsWith('.css')) {
+            return 'css';
+        }
+    }
+    // Per https://docs.mapbox.com/api/maps/fonts/#retrieve-font-glyph-ranges
+    if (path.includes('api.mapbox.com/fonts')) {
+        return 'font';
+    }
+    // Per
+    // - https://docs.mapbox.com/api/maps/styles/#retrieve-a-style
+    // - https://docs.mapbox.com/api/maps/styles/#retrieve-a-sprite-image-or-json
+    if (path.includes('api.mapbox.com/styles')) {
+        if (path.includes('sprite')) {
+            return 'sprite';
+        } else {
+            return 'style';
+        }
+    }
+    // Per https://docs.mapbox.com/api/maps/mapbox-tiling-service/#retrieve-tilejson-metadata
+    if (path.includes('api.mapbox.com/v4') && path.endsWith('.json')) {
+        return 'tilejson';
+    }
+
+    return 'other';
+}
+
+function getStyle(resourceTimers: Array<PerformanceEntry>): ?string {
+    if (resourceTimers) {
+        for (const timer of resourceTimers) {
+            const path = timer.name.split('?')[0];
+            if (path.includes('api.mapbox.com/styles') && !path.includes('sprite')) {
+                const split = path.split('/').slice(-2);
+                if (split.length === 2) {
+                    return `${split[0]}:${split[1]}`;
+                }
+            }
+        }
+    }
+}
+
+export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerformanceMetrics {
+    const resourceTimers = window.performance.getEntriesByType('resource');
+    const resourcesByType = categorize(resourceTimers, getResourceCategory);
+    const counters = getTransferRangePerResourceCategory(resourcesByType);
+    const devicePixelRatio = window.devicePixelRatio;
+    const connection = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+    const metrics = {counters: [], metadata: [], attributes: []};
+
+    const addMetric = (arr, name, value) => {
+        if (value) {
+            arr.push({name, value: value.toString()});
+        }
+    };
+
+    for (const counter in counters) {
+        addMetric(metrics.counters, counter, counters[counter]);
+    }
+    if (data.interactionRange[0] !== +Infinity && data.interactionRange[1] !== -Infinity) {
+        addMetric(metrics.counters, "interactionRangeMin", data.interactionRange[0]);
+        addMetric(metrics.counters, "interactionRangeMax", data.interactionRange[1]);
+    }
+
+    addMetric(metrics.attributes, "style", getStyle(resourceTimers));
+    addMetric(metrics.attributes, "terrain", data.terrain ? "true" : "false");
+    addMetric(metrics.attributes, "fog", data.fog ? "true" : "false");
+    addMetric(metrics.attributes, "projection", data.projection.name);
+
+    addMetric(metrics.metadata, "devicePixelRatio", devicePixelRatio);
+    addMetric(metrics.metadata, "connectionEffectiveType", connection ? connection.effectiveType : undefined);
+    addMetric(metrics.metadata, "cpuCores", window.navigator.hardwareConcurrency);
+    addMetric(metrics.metadata, "userAgent", window.navigator.userAgent);
+    addMetric(metrics.metadata, "screenWidth", window.screen.width * devicePixelRatio);
+    addMetric(metrics.metadata, "screenHeight", window.screen.height * devicePixelRatio);
+    addMetric(metrics.metadata, "windowWidth", window.innerWidth * devicePixelRatio);
+    addMetric(metrics.metadata, "windowHeight", window.innerHeight * devicePixelRatio);
+    addMetric(metrics.metadata, "mapWidth", data.width);
+    addMetric(metrics.metadata, "mapHeight", data.height);
+    addMetric(metrics.metadata, "webglRenderer", data.renderer);
+    addMetric(metrics.metadata, "webglVendor", data.vendor);
+    addMetric(metrics.metadata, "sdkVersion", sdkVersion);
+    addMetric(metrics.metadata, "sdkIdentifier", "mapbox-gl-js");
+
+    return metrics;
+}

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -120,7 +120,6 @@ export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerfor
 
     addMetric(metrics.metadata, "devicePixelRatio", devicePixelRatio);
     addMetric(metrics.metadata, "connectionEffectiveType", connection ? connection.effectiveType : undefined);
-    addMetric(metrics.metadata, "navigatorHardwareConcurrency", window.navigator.hardwareConcurrency);
     addMetric(metrics.metadata, "navigatorUserAgent", window.navigator.userAgent);
     addMetric(metrics.metadata, "screenWidth", window.screen.width);
     addMetric(metrics.metadata, "screenHeight", window.screen.height);

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -67,7 +67,7 @@ function getTransferRangePerResourceCategory(resourceTimers) {
 
 function getResourceCategory(entry: PerformanceResourceTiming): string {
     const url = entry.name.split('?')[0];
-
+    console.log(url);
     // Code may be hosted on various endpoints: CDN, self-hosted,
     // from unpkg... so this check doesn't include mapbox HTTP URL
     if (url.includes('mapbox-gl')) {

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -100,7 +100,7 @@ export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerfor
     const metrics = {counters: [], metadata: [], attributes: []};
 
     const addMetric = (arr, name, value) => {
-        if (value) {
+        if (value !== undefined) {
             arr.push({name, value: value.toString()});
         }
     };
@@ -120,14 +120,14 @@ export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerfor
 
     addMetric(metrics.metadata, "devicePixelRatio", devicePixelRatio);
     addMetric(metrics.metadata, "connectionEffectiveType", connection ? connection.effectiveType : undefined);
-    addMetric(metrics.metadata, "cpuCores", window.navigator.hardwareConcurrency);
-    addMetric(metrics.metadata, "userAgent", window.navigator.userAgent);
-    addMetric(metrics.metadata, "screenWidth", window.screen.width * devicePixelRatio);
-    addMetric(metrics.metadata, "screenHeight", window.screen.height * devicePixelRatio);
-    addMetric(metrics.metadata, "windowWidth", window.innerWidth * devicePixelRatio);
-    addMetric(metrics.metadata, "windowHeight", window.innerHeight * devicePixelRatio);
-    addMetric(metrics.metadata, "mapWidth", data.width);
-    addMetric(metrics.metadata, "mapHeight", data.height);
+    addMetric(metrics.metadata, "navigatorHardwareConcurrency", window.navigator.hardwareConcurrency);
+    addMetric(metrics.metadata, "navigatorUserAgent", window.navigator.userAgent);
+    addMetric(metrics.metadata, "screenWidth", window.screen.width);
+    addMetric(metrics.metadata, "screenHeight", window.screen.height);
+    addMetric(metrics.metadata, "windowWidth", window.innerWidth);
+    addMetric(metrics.metadata, "windowHeight", window.innerHeight);
+    addMetric(metrics.metadata, "mapWidth", data.width / devicePixelRatio);
+    addMetric(metrics.metadata, "mapHeight", data.height / devicePixelRatio);
     addMetric(metrics.metadata, "webglRenderer", data.renderer);
     addMetric(metrics.metadata, "webglVendor", data.vendor);
     addMetric(metrics.metadata, "sdkVersion", sdkVersion);

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -410,12 +410,10 @@ class TelemetryEvent {
 }
 
 export class PerformanceEvent extends TelemetryEvent {
-    +success: {[_: number]: boolean};
     errorCb: EventCallback;
 
     constructor() {
         super('gljs.performance');
-        this.success = {};
     }
 
     postPerformanceEvent(customAccessToken: ?string, performanceData: LivePerformanceData, callback: EventCallback) {
@@ -431,7 +429,10 @@ export class PerformanceEvent extends TelemetryEvent {
     }
 
     processRequests(customAccessToken?: ?string) {
-        if (this.pendingRequest || this.queue.length === 0) return;
+        if (this.pendingRequest || this.queue.length === 0) {
+            return;
+        }
+
         const {timestamp, performanceData} = this.queue.shift();
 
         const additionalPayload = getLivePerformanceMetrics(performanceData);

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -230,6 +230,22 @@ export function isMapboxHTTPURL(url: string): boolean {
     return config.API_URL_REGEX.test(url);
 }
 
+export function isMapboxHTTPStyleURL(url: string): boolean {
+    return config.API_STYLE_REGEX.test(url) && !isMapboxHTTPSpriteURL(url);
+}
+
+export function isMapboxHTTPTileJSONURL(url: string): boolean {
+    return config.API_TILEJSON_REGEX.test(url);
+}
+
+export function isMapboxHTTPSpriteURL(url: string): boolean {
+    return config.API_SPRITE_REGEX.test(url);
+}
+
+export function isMapboxHTTPFontsURL(url: string): boolean {
+    return config.API_FONTS_REGEX.test(url);
+}
+
 export function hasCacheDefeatingSku(url: string): boolean {
     return url.indexOf('sku=') > 0 && isMapboxHTTPURL(url);
 }

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -410,20 +410,14 @@ class TelemetryEvent {
 }
 
 export class PerformanceEvent extends TelemetryEvent {
-    errorCb: EventCallback;
-
     constructor() {
         super('gljs.performance');
     }
 
-    postPerformanceEvent(customAccessToken: ?string, performanceData: LivePerformanceData, callback: EventCallback) {
-        this.errorCb = callback;
-
+    postPerformanceEvent(customAccessToken: ?string, performanceData: LivePerformanceData) {
         if (config.EVENTS_URL) {
             if (customAccessToken || config.ACCESS_TOKEN) {
                 this.queueRequest({timestamp: Date.now(), performanceData}, customAccessToken);
-            } else {
-                this.errorCb(new Error(AUTH_ERR_MSG));
             }
         }
     }
@@ -448,11 +442,7 @@ export class PerformanceEvent extends TelemetryEvent {
             assert(typeof attribute.value === 'string');
         }
 
-        this.postEvent(timestamp, additionalPayload, (err) => {
-            if (err) {
-                this.errorCb(err);
-            }
-        }, customAccessToken);
+        this.postEvent(timestamp, additionalPayload, () => {}, customAccessToken);
     }
 }
 
@@ -653,7 +643,7 @@ const mapLoadEvent_ = new MapLoadEvent();
 export const postMapLoadEvent: (number, string, ?string, EventCallback) => void = mapLoadEvent_.postMapLoadEvent.bind(mapLoadEvent_);
 
 const performanceEvent_ = new PerformanceEvent();
-export const postPerformanceEvent: (?string, LivePerformanceData, EventCallback) => void = performanceEvent_.postPerformanceEvent.bind(performanceEvent_);
+export const postPerformanceEvent: (?string, LivePerformanceData) => void = performanceEvent_.postPerformanceEvent.bind(performanceEvent_);
 
 const mapSessionAPI_ = new MapSessionAPI();
 export const getMapSessionAPI: (number, string, ?string, EventCallback) => void = mapSessionAPI_.getSessionAPI.bind(mapSessionAPI_);

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -1,6 +1,10 @@
 // @flow
 
 import window from '../util/window.js';
+import {
+    PerformanceMarkers,
+    LivePerformanceUtils
+} from '../util/live_performance.js';
 const performance = window.performance;
 
 performance.mark('library-evaluate');
@@ -26,25 +30,19 @@ export type PerformanceMetrics = {
 
 export type PerformanceMark = {mark: string, name: string};
 
-export const PerformanceMarkers = {
-    create: 'create',
-    load: 'load',
-    fullLoad: 'fullLoad'
-};
-
 let fullLoadFinished = false;
 let placementTime = 0;
 
 export const PerformanceUtils = {
     mark(marker: $Keys<typeof PerformanceMarkers>) {
-        performance.mark(marker);
+        LivePerformanceUtils.mark(marker);
 
         if (marker === PerformanceMarkers.fullLoad) {
             fullLoadFinished = true;
         }
     },
     measure(name: string, begin?: string, end?: string) {
-        performance.measure(name, begin, end);
+        LivePerformanceUtils.measure(name, begin, end);
     },
     beginMeasure(name: string): PerformanceMark {
         const mark = name;

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -90,6 +90,7 @@ function restore(): Window {
     window.restore = restore;
 
     window.performance.getEntriesByName = function() {};
+    window.performance.getEntriesByType = function() {};
     window.performance.mark = function() {};
     window.performance.measure = function() {};
     window.performance.clearMarks = function() {};

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -79,6 +79,35 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('disablePerformanceMetricsCollection', (t) => {
+        const map = createMap(t, {enablePerformanceMetricsCollection: false});
+        map.once('idle', () => {
+            map.triggerRepaint();
+            map.once('idle', () => {
+                t.ok(map._fullyLoaded);
+                t.ok(map._loaded);
+                t.equals(window.server.requests.length, 0);
+                t.end();
+            });
+        });
+    });
+
+    t.test('default performance metrics collection', (t) => {
+        const map = createMap(t);
+        map._requestManager._customAccessToken = 'access-token';
+        map.once('idle', () => {
+            map.triggerRepaint();
+            map.once('idle', () => {
+                t.ok(map._fullyLoaded);
+                t.ok(map._loaded);
+                const reqBody = window.server.requests[0].requestBody;
+                const performanceEvent = JSON.parse(reqBody.slice(1, reqBody.length - 1));
+                t.equals(performanceEvent.event, 'gljs.performance');
+                t.end();
+            });
+        });
+    });
+
     t.test('warns when map container is not empty', (t) => {
         const container = window.document.createElement('div');
         container.textContent = 'Hello World';

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -80,7 +80,7 @@ test('Map', (t) => {
     });
 
     t.test('disablePerformanceMetricsCollection', (t) => {
-        const map = createMap(t, {enablePerformanceMetricsCollection: false});
+        const map = createMap(t, {performanceMetricsCollection: false});
         map.once('idle', () => {
             map.triggerRepaint();
             map.once('idle', () => {

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -52,7 +52,7 @@ test('LivePerformance', (t) => {
                         "startTime": 112120.10000002384,
                         "duration": 0
                     }
-                ]
+                ];
             } else if (type === 'resource') {
                 return [
                     {

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -107,7 +107,7 @@ test('LivePerformance', (t) => {
         const metrics = getLivePerformanceMetrics({
             width: 100,
             height: 50,
-            interactionRange: [0, 0],
+            interactionRange: [Infinity, -Infinity],
             projection: 'mercator',
             vendor: 'webgl vendor',
             renderer: 'webgl renderer'
@@ -128,11 +128,13 @@ test('LivePerformance', (t) => {
         ]);
         t.deepEqual(metrics.metadata, [
             {name: 'devicePixelRatio', value: '1'},
-            {name: 'cpuCores', value: window.navigator.hardwareConcurrency.toString()},
+            {name: 'navigatorHardwareConcurrency', value: window.navigator.hardwareConcurrency.toString()},
             {
-                name: 'userAgent',
+                name: 'navigatorUserAgent',
                 value: window.navigator.userAgent
             },
+            {name: 'screenWidth', value: window.screen.width.toString()},
+            {name: 'screenHeight', value: window.screen.height.toString()},
             {name: 'windowWidth', value: '1024'},
             {name: 'windowHeight', value: '768'},
             {name: 'mapWidth', value: '100'},

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -1,0 +1,153 @@
+import {test} from '../../util/test.js';
+import window from '../../../src/util/window.js';
+import {getLivePerformanceMetrics} from '../../../src/util/live_performance.js'
+
+test('LivePerformance', (t) => {
+    t.beforeEach(() => {
+        window.useFakeXMLHttpRequest();
+    });
+
+    t.afterEach(() => {
+        window.restore();
+    });
+
+    t.test('getLivePerformanceMetrics', (t) => {
+        window.performance.getEntriesByType = (type) => {
+            if (type === 'resource') {
+                return [
+                    {
+                        "name": "https://api.mapbox.com/mapbox-gl-js/v2.10.0/mapbox-gl.css",
+                        "startTime": 25,
+                        "responseEnd": 52
+                    },
+                    {
+                        "name": "https://api.mapbox.com/mapbox-gl-js/v2.10.0/mapbox-gl.js",
+                        "startTime": 25,
+                        "responseEnd": 417
+                    },
+                    {
+                        "name": "https://api.mapbox.com/styles/v1/mapbox/streets-v11?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 784,
+                        "responseEnd": 795
+                    },
+                    {
+                        "name": "https://api.mapbox.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json?secure&access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 809,
+                        "responseEnd": 870
+                    },
+                    {
+                        "name": "https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite@2x.json?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 810,
+                        "responseEnd": 863
+                    },
+                    {
+                        "name": "https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite@2x.png?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 810,
+                        "responseEnd": 900
+                    },
+                    {
+                        "name": "https://events.mapbox.com/events/v2?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 1190,
+                        "responseEnd": 1264
+                    },
+                    {
+                        "name": "https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Regular,Arial%20Unicode%20MS%20Regular/0-255.pbf?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 1509.5,
+                        "responseEnd": 1532.5
+                    },
+                    {
+                        "name": "https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Regular,Arial%20Unicode%20MS%20Regular/8192-8447.pbf?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 1510,
+                        "responseEnd": 1520.5
+                    },
+                    {
+                        "name": "https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Bold,Arial%20Unicode%20MS%20Bold/0-255.pbf?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 1510.5,
+                        "responseEnd": 1530
+                    },
+                    {
+                        "name": "https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Medium,Arial%20Unicode%20MS%20Regular/0-255.pbf?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 1511,
+                        "responseEnd": 1536
+                    },
+                    {
+                        "name": "https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Medium,Arial%20Unicode%20MS%20Regular/8192-8447.pbf?access_token=pk.eyJ1IjoiY2x",
+                        "startTime": 1528,
+                        "responseEnd": 1544.5
+                    },
+                    {
+                        "name": "https://docs.mapbox.com/mapbox-gl-js/assets/vendor-4bc283c6a472dc89ca08.chunk.js",
+                        "startTime": 407.20000000298023,
+                        "responseEnd": 493.70000000298023
+                    },
+                    {
+                        "name": "https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff2",
+                        "startTime": 475.1000000089407,
+                        "responseEnd": 479
+                    },
+                    {
+                        "name": "https://www.mapbox.com/api/session",
+                        "startTime": 1208.800000011921,
+                        "responseEnd": 1488.5
+                    },
+                    {
+                        "name": "https://www.google-analytics.com/analytics.js",
+                        "startTime": 1273.5,
+                        "responseEnd": 1287
+                    },
+                    {
+                        "name": "https://static-assets.mapbox.com/branding/favicon/v1/site.webmanifest?v=gAd4JjrGWl",
+                        "startTime": 1679.4000000059605,
+                        "responseEnd": 1685
+                    }
+                ]
+            }
+        };
+        const metrics = getLivePerformanceMetrics({
+            width: 100,
+            height: 50,
+            interactionRange: [0, 0],
+            projection: 'mercator',
+            vendor: 'webgl vendor',
+            renderer: 'webgl renderer'
+        });
+        t.deepEqual(metrics.counters, [
+            { name: 'cssTransferStart', value: '25' },
+            { name: 'cssTransferEnd', value: '52' },
+            { name: 'javascriptTransferStart', value: '25' },
+            { name: 'javascriptTransferEnd', value: '417' },
+            { name: 'styleTransferStart', value: '784' },
+            { name: 'styleTransferEnd', value: '795' },
+            { name: 'tilejsonTransferStart', value: '809' },
+            { name: 'tilejsonTransferEnd', value: '870' },
+            { name: 'spriteTransferStart', value: '810' },
+            { name: 'spriteTransferEnd', value: '900' },
+            { name: 'fontTransferStart', value: '1509.5' },
+            { name: 'fontTransferEnd', value: '1544.5' }
+        ]);
+        t.deepEqual(metrics.metadata, [
+            { name: 'devicePixelRatio', value: '1' },
+            { name: 'cpuCores', value: '8' },
+            {
+            name: 'userAgent',
+            value: 'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/15.2.1'
+            },
+            { name: 'windowWidth', value: '1024' },
+            { name: 'windowHeight', value: '768' },
+            { name: 'mapWidth', value: '100' },
+            { name: 'mapHeight', value: '50' },
+            { name: 'webglRenderer', value: 'webgl renderer' },
+            { name: 'webglVendor', value: 'webgl vendor' },
+            { name: 'sdkVersion', value: '2.12.0-dev' },
+            { name: 'sdkIdentifier', value: 'mapbox-gl-js' }
+        ]);
+        t.deepEqual(metrics.attributes, [
+            { name: 'style', value: 'mapbox:streets-v11' },
+            { name: 'terrain', value: 'false' },
+            { name: 'fog', value: 'false' }
+        ]);
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -1,6 +1,7 @@
 import {test} from '../../util/test.js';
 import window from '../../../src/util/window.js';
 import {getLivePerformanceMetrics} from '../../../src/util/live_performance.js';
+import {version} from '../../../package.json';
 
 test('LivePerformance', (t) => {
     t.beforeEach(() => {
@@ -138,13 +139,13 @@ test('LivePerformance', (t) => {
             {name: 'mapHeight', value: '50'},
             {name: 'webglRenderer', value: 'webgl renderer'},
             {name: 'webglVendor', value: 'webgl vendor'},
-            {name: 'sdkVersion', value: '2.12.0-dev'},
+            {name: 'sdkVersion', value: version},
             {name: 'sdkIdentifier', value: 'mapbox-gl-js'}
         ]);
         t.deepEqual(metrics.attributes, [
             {name: 'style', value: 'mapbox:streets-v11'},
-            {name: 'terrain', value: 'false'},
-            {name: 'fog', value: 'false'}
+            {name: 'terrainEnabled', value: 'false'},
+            {name: 'fogEnabled', value: 'false'}
         ]);
         t.end();
     });

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -1,6 +1,6 @@
 import {test} from '../../util/test.js';
 import window from '../../../src/util/window.js';
-import {getLivePerformanceMetrics} from '../../../src/util/live_performance.js'
+import {getLivePerformanceMetrics} from '../../../src/util/live_performance.js';
 
 test('LivePerformance', (t) => {
     t.beforeEach(() => {
@@ -100,7 +100,7 @@ test('LivePerformance', (t) => {
                         "startTime": 1679.4000000059605,
                         "responseEnd": 1685
                     }
-                ]
+                ];
             }
         };
         const metrics = getLivePerformanceMetrics({
@@ -112,39 +112,39 @@ test('LivePerformance', (t) => {
             renderer: 'webgl renderer'
         });
         t.deepEqual(metrics.counters, [
-            { name: 'cssTransferStart', value: '25' },
-            { name: 'cssTransferEnd', value: '52' },
-            { name: 'javascriptTransferStart', value: '25' },
-            { name: 'javascriptTransferEnd', value: '417' },
-            { name: 'styleTransferStart', value: '784' },
-            { name: 'styleTransferEnd', value: '795' },
-            { name: 'tilejsonTransferStart', value: '809' },
-            { name: 'tilejsonTransferEnd', value: '870' },
-            { name: 'spriteTransferStart', value: '810' },
-            { name: 'spriteTransferEnd', value: '900' },
-            { name: 'fontTransferStart', value: '1509.5' },
-            { name: 'fontTransferEnd', value: '1544.5' }
+            {name: 'cssTransferStart', value: '25'},
+            {name: 'cssTransferEnd', value: '52'},
+            {name: 'javascriptTransferStart', value: '25'},
+            {name: 'javascriptTransferEnd', value: '417'},
+            {name: 'styleTransferStart', value: '784'},
+            {name: 'styleTransferEnd', value: '795'},
+            {name: 'tilejsonTransferStart', value: '809'},
+            {name: 'tilejsonTransferEnd', value: '870'},
+            {name: 'spriteTransferStart', value: '810'},
+            {name: 'spriteTransferEnd', value: '900'},
+            {name: 'fontTransferStart', value: '1509.5'},
+            {name: 'fontTransferEnd', value: '1544.5'}
         ]);
         t.deepEqual(metrics.metadata, [
-            { name: 'devicePixelRatio', value: '1' },
-            { name: 'cpuCores', value: '8' },
+            {name: 'devicePixelRatio', value: '1'},
+            {name: 'cpuCores', value: '8'},
             {
-            name: 'userAgent',
-            value: 'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/15.2.1'
+                name: 'userAgent',
+                value: window.navigator.userAgent
             },
-            { name: 'windowWidth', value: '1024' },
-            { name: 'windowHeight', value: '768' },
-            { name: 'mapWidth', value: '100' },
-            { name: 'mapHeight', value: '50' },
-            { name: 'webglRenderer', value: 'webgl renderer' },
-            { name: 'webglVendor', value: 'webgl vendor' },
-            { name: 'sdkVersion', value: '2.12.0-dev' },
-            { name: 'sdkIdentifier', value: 'mapbox-gl-js' }
+            {name: 'windowWidth', value: '1024'},
+            {name: 'windowHeight', value: '768'},
+            {name: 'mapWidth', value: '100'},
+            {name: 'mapHeight', value: '50'},
+            {name: 'webglRenderer', value: 'webgl renderer'},
+            {name: 'webglVendor', value: 'webgl vendor'},
+            {name: 'sdkVersion', value: '2.12.0-dev'},
+            {name: 'sdkIdentifier', value: 'mapbox-gl-js'}
         ]);
         t.deepEqual(metrics.attributes, [
-            { name: 'style', value: 'mapbox:streets-v11' },
-            { name: 'terrain', value: 'false' },
-            { name: 'fog', value: 'false' }
+            {name: 'style', value: 'mapbox:streets-v11'},
+            {name: 'terrain', value: 'false'},
+            {name: 'fog', value: 'false'}
         ]);
         t.end();
     });

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -145,7 +145,7 @@ test('LivePerformance', (t) => {
             {name: 'sdkIdentifier', value: 'mapbox-gl-js'}
         ]);
         t.deepEqual(metrics.attributes, [
-            {name: 'style', value: 'mapbox:streets-v11'},
+            {name: 'style', value: 'mapbox://styles/mapbox/streets-v11'},
             {name: 'terrainEnabled', value: 'false'},
             {name: 'fogEnabled', value: 'false'}
         ]);

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -128,7 +128,6 @@ test('LivePerformance', (t) => {
         ]);
         t.deepEqual(metrics.metadata, [
             {name: 'devicePixelRatio', value: '1'},
-            {name: 'navigatorHardwareConcurrency', value: window.navigator.hardwareConcurrency.toString()},
             {
                 name: 'navigatorUserAgent',
                 value: window.navigator.userAgent

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -14,7 +14,46 @@ test('LivePerformance', (t) => {
 
     t.test('getLivePerformanceMetrics', (t) => {
         window.performance.getEntriesByType = (type) => {
-            if (type === 'resource') {
+            if (type === 'mark') {
+                return [
+                    {
+                        "name": "library-evaluate",
+                        "entryType": "mark",
+                        "startTime": 664.9000000357628,
+                        "duration": 0
+                    },
+                    {
+                        "name": "create",
+                        "entryType": "mark",
+                        "startTime": 716.6000000238419,
+                        "duration": 0
+                    },
+                    {
+                        "name": "frame",
+                        "entryType": "mark",
+                        "startTime": 741,
+                        "duration": 0
+                    },
+                    {
+                        "name": "render",
+                        "entryType": "mark",
+                        "startTime": 741.1999999880791,
+                        "duration": 0
+                    },
+                    {
+                        "name": "load",
+                        "entryType": "mark",
+                        "startTime": 2076.900000035763,
+                        "duration": 0
+                    },
+                    {
+                        "name": "fullLoad",
+                        "entryType": "mark",
+                        "startTime": 112120.10000002384,
+                        "duration": 0
+                    }
+                ]
+            } else if (type === 'resource') {
                 return [
                     {
                         "name": "https://api.mapbox.com/mapbox-gl-js/v2.10.0/mapbox-gl.css",
@@ -110,21 +149,31 @@ test('LivePerformance', (t) => {
             interactionRange: [Infinity, -Infinity],
             projection: 'mercator',
             vendor: 'webgl vendor',
-            renderer: 'webgl renderer'
+            renderer: 'webgl renderer',
+            zoom: 5
         });
         t.deepEqual(metrics.counters, [
-            {name: 'cssTransferStart', value: '25'},
-            {name: 'cssTransferEnd', value: '52'},
-            {name: 'javascriptTransferStart', value: '25'},
-            {name: 'javascriptTransferEnd', value: '417'},
-            {name: 'styleTransferStart', value: '784'},
-            {name: 'styleTransferEnd', value: '795'},
-            {name: 'tilejsonTransferStart', value: '809'},
-            {name: 'tilejsonTransferEnd', value: '870'},
-            {name: 'spriteTransferStart', value: '810'},
-            {name: 'spriteTransferEnd', value: '900'},
-            {name: 'fontTransferStart', value: '1509.5'},
-            {name: 'fontTransferEnd', value: '1544.5'}
+            {name: 'cssResolveRangeMin', value: '25'},
+            {name: 'cssResolveRangeMax', value: '52'},
+            {name: 'cssRequestCount', value: '1'},
+            {name: 'javascriptResolveRangeMin', value: '25'},
+            {name: 'javascriptResolveRangeMax', value: '417'},
+            {name: 'javascriptRequestCount', value: '1'},
+            {name: 'styleResolveRangeMin', value: '784'},
+            {name: 'styleResolveRangeMax', value: '795'},
+            {name: 'styleRequestCount', value: '1'},
+            {name: 'tilejsonResolveRangeMin', value: '809'},
+            {name: 'tilejsonResolveRangeMax', value: '870'},
+            {name: 'tilejsonRequestCount', value: '1'},
+            {name: 'spriteResolveRangeMin', value: '810'},
+            {name: 'spriteResolveRangeMax', value: '900'},
+            {name: 'spriteRequestCount', value: '2'},
+            {name: 'fontRangeResolveRangeMin', value: '1509.5'},
+            {name: 'fontRangeResolveRangeMax', value: '1544.5'},
+            {name: 'fontRangeRequestCount', value: '5'},
+            {name: 'create', value: '716.6000000238419'},
+            {name: 'load', value: '2076.900000035763'},
+            {name: 'fullLoad', value: '112120.10000002384'},
         ]);
         t.deepEqual(metrics.metadata, [
             {name: 'devicePixelRatio', value: '1'},
@@ -146,7 +195,8 @@ test('LivePerformance', (t) => {
         t.deepEqual(metrics.attributes, [
             {name: 'style', value: 'mapbox://styles/mapbox/streets-v11'},
             {name: 'terrainEnabled', value: 'false'},
-            {name: 'fogEnabled', value: 'false'}
+            {name: 'fogEnabled', value: 'false'},
+            {name: 'zoom', value: '5'}
         ]);
         t.end();
     });

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -127,7 +127,7 @@ test('LivePerformance', (t) => {
         ]);
         t.deepEqual(metrics.metadata, [
             {name: 'devicePixelRatio', value: '1'},
-            {name: 'cpuCores', value: '8'},
+            {name: 'cpuCores', value: window.navigator.hardwareConcurrency.toString()},
             {
                 name: 'userAgent',
                 value: window.navigator.userAgent

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -475,6 +475,43 @@ test("mapbox", (t) => {
         t.end();
     });
 
+    t.test('PerformanceEvent', (t) => {
+        let event;
+
+        t.beforeEach(() => {
+            window.useFakeXMLHttpRequest();
+            event = new mapbox.PerformanceEvent();
+        });
+
+        t.afterEach(() => {
+            window.restore();
+        });
+
+        t.test('mapbox.postPerformanceEvent', (t) => {
+            t.ok(mapbox.postPerformanceEvent);
+            t.end();
+        });
+
+        t.test('does not contains sku', (t) => {
+            event.postPerformanceEvent('token', {
+                width: 100,
+                height: 100,
+                interactionRange: [0, 0],
+                projection: 'mercator'
+            }, () => {});
+
+            const reqBody = window.server.requests[0].requestBody;
+            const performanceEvent = JSON.parse(reqBody.slice(1, reqBody.length - 1));
+
+            t.equals(performanceEvent.event, 'gljs.performance');
+            t.notOk(performanceEvent.skuId);
+            t.notOk(performanceEvent.skuToken);
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('TurnstileEvent', (t) => {
         const ms25Hours = (25 * 60 * 60 * 1000);
         let event;

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -43,6 +43,50 @@ test("mapbox", (t) => {
         t.end();
     });
 
+    t.test('.isMapboxHTTPStyleURL', (t) => {
+        t.ok(mapbox.isMapboxHTTPStyleURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11'));
+        t.ok(mapbox.isMapboxHTTPStyleURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11?'));
+        t.ok(mapbox.isMapboxHTTPStyleURL('https://api.mapbox.cn/styles/v1/mapbox/streets-v11'));
+        t.notOk(mapbox.isMapboxHTTPStyleURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite@2x.json'));
+        t.notOk(mapbox.isMapboxHTTPStyleURL('http://example.com/mapbox.com'));
+        t.end();
+    });
+
+    t.test('.isMapboxHTTPTileJSONURL', (t) => {
+        t.ok(mapbox.isMapboxHTTPTileJSONURL('https://api.mapbox.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json'));
+        t.ok(mapbox.isMapboxHTTPTileJSONURL('https://api.mapbox.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json?access_token=pk.eyJ1Ijoi'));
+        t.ok(mapbox.isMapboxHTTPTileJSONURL('https://api.mapbox.com/v4/mapbox.mapbox-streets-v8.json'));
+        t.ok(mapbox.isMapboxHTTPTileJSONURL('https://api.mapbox.cn/v4/mapbox.mapbox-streets-v8.json'));
+        t.ok(mapbox.isMapboxHTTPTileJSONURL('http://a.tiles.mapbox.cn/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json'));
+        t.notOk(mapbox.isMapboxHTTPTileJSONURL('http://example.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json'));
+        t.end();
+    });
+
+    t.test('.isMapboxHTTPSpriteURL', (t) => {
+        t.ok(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite@2x.json'));
+        t.ok(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite@2.5x.json'));
+        t.ok(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite@2x.json?access_token=pk.eyJ1Ijoi'));
+        t.ok(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.com/styles/v1/user/style/sprite.json'));
+        t.ok(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.com/styles/v1/user/style/sprite@2x.json'));
+        t.ok(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.cn/styles/v1/mapbox/streets-v11/sprite@2x.json'));
+        t.notOk(mapbox.isMapboxHTTPSpriteURL('http://example.com/mapbox.com/styles/v1/user/style/sprite@2x.json'));
+        t.notOk(mapbox.isMapboxHTTPSpriteURL('http://example.com/mapbox.com/sprite@2x.json'));
+        t.notOk(mapbox.isMapboxHTTPSpriteURL('http://example.com/mapbox.com/images@2x.json'));
+        t.notOk(mapbox.isMapboxHTTPSpriteURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11'));
+        t.end();
+    });
+
+    t.test('.isMapboxHTTPFontsURL', (t) => {
+        t.ok(mapbox.isMapboxHTTPFontsURL('https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Medium,Arial%20Unicode%20MS%20Regular/8192-8447.pbf'));
+        t.ok(mapbox.isMapboxHTTPFontsURL('https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Medium,Arial%20Unicode%20MS%20Regular/0-255.pbf'));
+        t.ok(mapbox.isMapboxHTTPFontsURL('https://api.mapbox.com/fonts/v1/mapbox/DIN%20Offc%20Pro%20Medium,Arial%20Unicode%20MS%20Regular/0-255.pbf?access_token=pk.eyJ1Ijoi'));
+        t.ok(mapbox.isMapboxHTTPFontsURL('https://api.mapbox.com/fonts/v1/mapbox/font1,font2/0-255.pbf'));
+        t.ok(mapbox.isMapboxHTTPFontsURL('https://api.mapbox.cn/fonts/v1/mapbox/font1,font2/0-255.pbf'));
+        t.notOk(mapbox.isMapboxHTTPFontsURL('https://example.com/file.pbf'));
+        t.notOk(mapbox.isMapboxHTTPFontsURL('https://api.mapbox.com/styles/v1/mapbox/streets-v11'));
+        t.end();
+    });
+
     t.test('RequestManager', (t) => {
         const manager = new mapbox.RequestManager();
 

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -503,7 +503,7 @@ test("mapbox", (t) => {
                 height: 100,
                 interactionRange: [0, 0],
                 projection: 'mercator'
-            }, () => {});
+            });
 
             const reqBody = window.server.requests[0].requestBody;
             const performanceEvent = JSON.parse(reqBody.slice(1, reqBody.length - 1));
@@ -521,7 +521,7 @@ test("mapbox", (t) => {
                 height: 100,
                 interactionRange: [0, 0],
                 projection: 'mercator'
-            }, () => {});
+            });
 
             const reqBody = window.server.requests[0].requestBody;
             const performanceEvent = JSON.parse(reqBody.slice(1, reqBody.length - 1));
@@ -539,7 +539,7 @@ test("mapbox", (t) => {
                 projection: 'mercator',
                 vendor: 'webgl vendor',
                 renderer: 'webgl renderer'
-            }, () => {});
+            });
 
             const reqBody = window.server.requests[0].requestBody;
             const performanceEvent = JSON.parse(reqBody.slice(1, reqBody.length - 1));

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -7,7 +7,7 @@ import {uuid} from '../../../src/util/util.js';
 import {SKU_ID} from '../../../src/util/sku_token.js';
 import {version} from '../../../package.json';
 import {equalWithPrecision} from '../../util/index.js';
-import assert from 'assert'
+import assert from 'assert';
 
 const mapboxTileURLs = [
     'https://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf',
@@ -509,7 +509,6 @@ test("mapbox", (t) => {
             t.notOk(performanceEvent.skuToken);
             t.end();
         });
-
 
         t.test('metrics', (t) => {
             event.postPerformanceEvent('token', {


### PR DESCRIPTION
This PR adds live (production build) performance counters recorded through telemetry to our events API. The server schema and addition is described in https://github.com/mapbox/event-schema/pull/242 for server side ingestion (which should be merged prior to merging this PR). These counters will serve to monitor performance on real environment, and allow us to support the resource bundling effort.

Here is an example of the counters, metadata and attributes that are being collected:

### attributes
```
{name: 'style', value: 'mapbox:streets-v11'}
{name: 'terrain', value: 'false'}
{name: 'fog', value: 'false'}
{name: 'projection', value: 'mercator'}
```

### counters
```
{name: 'javascriptTransferStart', value: '56.8999999910593'}
{name: 'javascriptTransferEnd', value: '83.8999999910593'}
{name: 'cssTransferStart', value: '57.8999999910593'}
{name: 'cssTransferEnd', value: '73.8999999910593'}
{name: 'styleTransferStart', value: {name: 'styleTransferEnd', value: '1168.0999999940395'}
{name: 'tilejsonTransferStart', value: '1419.5'}
{name: 'tilejsonTransferEnd', value: '1479.0999999940395'}
{name: 'spriteTransferStart', value: '1420.2999999970198'}
{name: 'spriteTransferEnd', value: '1498.0999999940395'}
{name: 'fontTransferStart', value: '1944.5'}
{name: 'fontTransferEnd', value: '1990.2999999970198'}
```

### metadata
```
{name: 'devicePixelRatio', value: '2'}
{name: 'connectionEffectiveType', value: '4g'}
{name: 'cpuCores', value: '8'}
{name: 'userAgent', value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Ap…KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36'}
{name: 'screenWidth', value: '2880'}
{name: 'screenHeight', value: '1800'}
{name: 'windowWidth', value: '1000'}
{name: 'windowHeight', value: '590'}
{name: 'mapWidth', value: '1000'}
{name: 'mapHeight', value: '590'}
{name: 'webglRenderer', value: 'ANGLE (Intel Inc., Intel(R) Iris(TM) Plus Graphics 655, OpenGL 4.1)'}
{name: 'webglVendor', value: 'Google Inc. (Intel {name: 'sdkVersion', value: '2.12.0-dev'}
{name: 'sdkIdentifier', value: 'mapbox-gl-js'}
```

Most of the context specific information is necessary to bucket performance traces in comparable groups. For example, we wouldn't want to compare viewport sizes that are widely different for rendering performance, but it is probably ok to do so for network and resource fetching performance comparisons.

Some of the attributes also provide us functionality usage information, such as terrain, fog and projection being used. Since these may use very different code paths in our codebase, it's important for us to bucket them separately when comparing and retrieving performance knowledge.

For now, this PR focuses on resource fetching information, for fonts, style, tilejson, sprites and code. Time to render content (TTRC) and rendering performance counters will be introduced separately.

### resource fetching range

Resource loading that are seen from chrome performance tab usually involves the timing including both the fetching and the processing of the received data:

<img width="577" alt="Screen Shot 2022-10-27 at 1 27 46 PM" src="https://user-images.githubusercontent.com/7061573/198395250-f147a6ff-956d-4533-9c9b-e635ab38cf0d.png">

in this PR the timing as referred to `spriteTransferStart` and `spriteTransferEnd` refers to the `networkTransfer` time mentioned above ranged from the earliest request for a resource category (css, javascript, sprites...) to the latest. For example, if two sprites network transfer duration were observed between the ranges `(15ms, 80ms)` and `(20ms, 100ms)`, we will return the range `(15ms, 100ms)`.

### interaction range

One addition to this PR is the introduction of interaction range timings

I have considered adding an interaction history to our metrics, so that we can differentiate between a map that has interactions (where loading is similar to the context of benchmap, where you just load a map without any interaction), and not (for example a more complex interaction of user zooming in, panning... before the becomes idle). An interaction timeline would could have a format like this:
```
[
  interactionType [ timingStart, timingEnd ],
  interactionType [ timingStart, timingEnd ],
  ...
]
```
which would give, for example:
```
[
  zooming, 10, 20,
  panning, 15, 30,
  zooming, 50, 60
  ...
]
```
But for now, something as simple as:
```
interactionStart: timingStart
interactionEnd: timingEnd
```
is sufficient for our uses. It is less granular and only tells us the start and end of an any interaction, but that's enough for us to bucket all maps that do not have interaction on first load prior to being idle so that we compare them together.

The main idea being that we don't want to compare map performance for maps that don't have similar initial interaction behaviors and adding a full history of interaction will not be useful in order to do that bucketing. For example, we'd like to know when a map does a lot of extra tile loads before becoming idle due to excessive panning from the user since performance may be fairly different from a map without it.

It's important to note that this interaction range may be rounded to the ms due to the use of `performance.now()`.

### opting-out

This PR adds a map constructor option to opt-out of performance collection.

### limitations

- There is currently no way of consistently knowing whether a resource was cached or not (Safari doesn't support [`decodedBodySize`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/decodedBodySize) and [`transferSize`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize)), this also limits information about network transfer sizes for cors resources
- There is no way to retrieve CPU vendor information, so only webgl vendor information is included
- Network speed information can only be retrieved through the [networkEffectiveType](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType) and may not always be included depending on support

### benchmark

- https://sites.mapbox.com/benchmap-js-results/runs/1060

<img width="930" alt="Screen Shot 2022-10-27 at 4 57 06 PM" src="https://user-images.githubusercontent.com/7061573/198418956-1d4f7a7d-0a8c-442a-a694-0a23c2d063d3.png">

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add live performance counters</changelog>`
