### PR TITLE
Minor struct array types cleanup

### DIFF
--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -148,7 +148,7 @@ for (const name in layoutAttributes) {
 }
 
 // Globe extension arrays
-createStructArrayType('fill_extrusion_ext', fillExtrusionAttributesExt, true);
+createStructArrayType('fill_extrusion_ext', fillExtrusionAttributesExt);
 
 // symbol layer specific arrays
 import {
@@ -248,7 +248,7 @@ createStructArrayLayoutType(createLayout([{
 createStructArrayType(`fill_extrusion_centroid`, centroidAttributes, true);
 
 // Globe extension arrays
-createStructArrayType('circle_globe_ext', circleGlobeAttributesExt, true);
+createStructArrayType('circle_globe_ext', circleGlobeAttributesExt);
 
 const layouts = Object.keys(layoutCache).map(k => layoutCache[k]);
 

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -987,39 +987,6 @@ class StructArrayLayout2f8 extends StructArray {
 StructArrayLayout2f8.prototype.bytesPerElement = 8;
 register(StructArrayLayout2f8, 'StructArrayLayout2f8');
 
-class FillExtrusionExtStruct extends Struct {
-    _structArray: FillExtrusionExtArray;
-    get a_pos_30(): number { return this._structArray.int16[this._pos2 + 0]; }
-    get a_pos_31(): number { return this._structArray.int16[this._pos2 + 1]; }
-    get a_pos_32(): number { return this._structArray.int16[this._pos2 + 2]; }
-    get a_pos_normal_30(): number { return this._structArray.int16[this._pos2 + 3]; }
-    get a_pos_normal_31(): number { return this._structArray.int16[this._pos2 + 4]; }
-    get a_pos_normal_32(): number { return this._structArray.int16[this._pos2 + 5]; }
-}
-
-FillExtrusionExtStruct.prototype.size = 12;
-
-export type FillExtrusionExt = FillExtrusionExtStruct;
-
-/**
- * @private
- */
-export class FillExtrusionExtArray extends StructArrayLayout6i12 {
-    /**
-     * Return the FillExtrusionExtStruct at the given location in the array.
-     * @param {number} index The index of the element.
-     * @private
-     */
-    get(index: number): FillExtrusionExtStruct {
-        assert(!this.isTransferred);
-        assert(index >= 0);
-        assert(index < this.length);
-        return new FillExtrusionExtStruct(this, index);
-    }
-}
-
-register(FillExtrusionExtArray, 'FillExtrusionExtArray');
-
 class CollisionBoxStruct extends Struct {
     _structArray: CollisionBoxArray;
     get projectedAnchorX(): number { return this._structArray.int16[this._pos2 + 0]; }
@@ -1221,67 +1188,15 @@ export class FeatureIndexArray extends StructArrayLayout1ul3ui12 {
 
 register(FeatureIndexArray, 'FeatureIndexArray');
 
-class FillExtrusionCentroidStruct extends Struct {
-    _structArray: FillExtrusionCentroidArray;
-    get a_centroid_pos0(): number { return this._structArray.uint16[this._pos2 + 0]; }
-    get a_centroid_pos1(): number { return this._structArray.uint16[this._pos2 + 1]; }
-}
-
-FillExtrusionCentroidStruct.prototype.size = 4;
-
-export type FillExtrusionCentroid = FillExtrusionCentroidStruct;
-
 /**
  * @private
  */
 export class FillExtrusionCentroidArray extends StructArrayLayout2ui4 {
-    /**
-     * Return the FillExtrusionCentroidStruct at the given location in the array.
-     * @param {number} index The index of the element.
-     * @private
-     */
-    get(index: number): FillExtrusionCentroidStruct {
-        assert(!this.isTransferred);
-        assert(index >= 0);
-        assert(index < this.length);
-        return new FillExtrusionCentroidStruct(this, index);
-    }
+    geta_centroid_pos0(index: number): number { return this.uint16[index * 2 + 0]; }
+    geta_centroid_pos1(index: number): number { return this.uint16[index * 2 + 1]; }
 }
 
 register(FillExtrusionCentroidArray, 'FillExtrusionCentroidArray');
-
-class CircleGlobeExtStruct extends Struct {
-    _structArray: CircleGlobeExtArray;
-    get a_pos_30(): number { return this._structArray.int16[this._pos2 + 0]; }
-    get a_pos_31(): number { return this._structArray.int16[this._pos2 + 1]; }
-    get a_pos_32(): number { return this._structArray.int16[this._pos2 + 2]; }
-    get a_pos_normal_30(): number { return this._structArray.int16[this._pos2 + 3]; }
-    get a_pos_normal_31(): number { return this._structArray.int16[this._pos2 + 4]; }
-    get a_pos_normal_32(): number { return this._structArray.int16[this._pos2 + 5]; }
-}
-
-CircleGlobeExtStruct.prototype.size = 12;
-
-export type CircleGlobeExt = CircleGlobeExtStruct;
-
-/**
- * @private
- */
-export class CircleGlobeExtArray extends StructArrayLayout6i12 {
-    /**
-     * Return the CircleGlobeExtStruct at the given location in the array.
-     * @param {number} index The index of the element.
-     * @private
-     */
-    get(index: number): CircleGlobeExtStruct {
-        assert(!this.isTransferred);
-        assert(index >= 0);
-        assert(index < this.length);
-        return new CircleGlobeExtStruct(this, index);
-    }
-}
-
-register(CircleGlobeExtArray, 'CircleGlobeExtArray');
 
 export {
     StructArrayLayout2i4,
@@ -1320,6 +1235,7 @@ export {
     StructArrayLayout4f16 as LineExtLayoutArray,
     StructArrayLayout10ui20 as PatternLayoutArray,
     StructArrayLayout8ui16 as DashLayoutArray,
+    StructArrayLayout6i12 as FillExtrusionExtArray,
     StructArrayLayout4i4ui4i24 as SymbolLayoutArray,
     StructArrayLayout3i3f20 as SymbolGlobeExtArray,
     StructArrayLayout4f16 as SymbolDynamicLayoutArray,
@@ -1335,5 +1251,6 @@ export {
     StructArrayLayout2ui4 as LineIndexArray,
     StructArrayLayout1ui2 as LineStripIndexArray,
     StructArrayLayout3f12 as SkyboxVertexArray,
-    StructArrayLayout4i8 as TileBoundsArray
+    StructArrayLayout4i8 as TileBoundsArray,
+    StructArrayLayout6i12 as CircleGlobeExtArray
 };

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -90,9 +90,8 @@ class FillExtrusionStyleLayer extends StyleLayer {
             // See FillExtrusionBucket#encodeCentroid(), centroid is inserted at vertexOffset + 1
             const centroidOffset = layoutVertexArrayOffset + 1;
             if (centroidOffset < centroidVertexArray.length) {
-                const centroidVertexObject = centroidVertexArray.get(centroidOffset);
-                centroid[0] = centroidVertexObject.a_centroid_pos0;
-                centroid[1] = centroidVertexObject.a_centroid_pos1;
+                centroid[0] = centroidVertexArray.geta_centroid_pos0(centroidOffset);
+                centroid[1] = centroidVertexArray.geta_centroid_pos1(centroidOffset);
             }
         }
 

--- a/src/util/struct_array.js.ejs
+++ b/src/util/struct_array.js.ejs
@@ -26,7 +26,10 @@ for (const member of members) {
 }
 
 // exceptions for which we generate accessors on the array rather than a separate struct for performance
-const useComponentGetters = StructArrayClass === 'GlyphOffsetArray' || StructArrayClass === 'SymbolLineVertexArray';
+const useComponentGetters =
+    StructArrayClass === 'GlyphOffsetArray' ||
+    StructArrayClass === 'SymbolLineVertexArray' ||
+    StructArrayClass === 'FillExtrusionCentroidArray';
 
 if (includeStructAccessors && !useComponentGetters) {
 -%>


### PR DESCRIPTION
There were some classes among array types that could be simplified — e.g. getters for `FillExtrusionExtArray` and `CircleGlobeExtArray` were unused, so were probably added by accident. Saves 150 bytes for the bundle.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

