### PR TITLE
Optimize and simplify symbol placement code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
   "parserOptions": {
     "sourceType": "module",
     "requireConfigFile": false,
+    "ecmaVersion": 2016,
     "babelOptions": {
       "presets": ["@babel/preset-flow"]
     }

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -1182,10 +1182,9 @@ register(GlyphOffsetArray, 'GlyphOffsetArray');
 /**
  * @private
  */
-export class SymbolLineVertexArray extends StructArrayLayout3i6 {
-    getx(index: number): number { return this.int16[index * 3 + 0]; }
-    gety(index: number): number { return this.int16[index * 3 + 1]; }
-    gettileUnitDistanceFromAnchor(index: number): number { return this.int16[index * 3 + 2]; }
+export class SymbolLineVertexArray extends StructArrayLayout2i4 {
+    getx(index: number): number { return this.int16[index * 2 + 0]; }
+    gety(index: number): number { return this.int16[index * 2 + 1]; }
 }
 
 register(SymbolLineVertexArray, 'SymbolLineVertexArray');

--- a/src/data/bucket/symbol_attributes.js
+++ b/src/data/bucket/symbol_attributes.js
@@ -135,6 +135,5 @@ export const glyphOffset: StructArrayLayout = createLayout([
 
 export const lineVertex: StructArrayLayout = createLayout([
     {type: 'Int16', name: 'x'},
-    {type: 'Int16', name: 'y'},
-    {type: 'Int16', name: 'tileUnitDistanceFromAnchor'}
+    {type: 'Int16', name: 'y'}
 ]);

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -923,32 +923,27 @@ class SymbolBucket implements Bucket {
         iconStartIndex: number, iconEndIndex: number,
         verticalIconStartIndex: number, verticalIconEndIndex: number): CollisionArrays {
 
+        // Only one box allowed per instance
         const collisionArrays = {};
-        for (let k = textStartIndex; k < textEndIndex; k++) {
-            const box: CollisionBox = (collisionBoxArray.get(k): any);
-            collisionArrays.textBox = {x1: box.x1, y1: box.y1, x2: box.x2, y2: box.y2, padding: box.padding, projectedAnchorX: box.projectedAnchorX, projectedAnchorY: box.projectedAnchorY, projectedAnchorZ: box.projectedAnchorZ, tileAnchorX: box.tileAnchorX, tileAnchorY: box.tileAnchorY};
-            collisionArrays.textFeatureIndex = box.featureIndex;
-            break; // Only one box allowed per instance
+        if (textStartIndex < textEndIndex) {
+            const {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY, featureIndex} = collisionBoxArray.get(textStartIndex);
+            collisionArrays.textBox = {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY};
+            collisionArrays.textFeatureIndex = featureIndex;
         }
-        for (let k = verticalTextStartIndex; k < verticalTextEndIndex; k++) {
-            const box: CollisionBox = (collisionBoxArray.get(k): any);
-            collisionArrays.verticalTextBox = {x1: box.x1, y1: box.y1, x2: box.x2, y2: box.y2, padding: box.padding, projectedAnchorX: box.projectedAnchorX, projectedAnchorY: box.projectedAnchorY, projectedAnchorZ: box.projectedAnchorZ, tileAnchorX: box.tileAnchorX, tileAnchorY: box.tileAnchorY};
-            collisionArrays.verticalTextFeatureIndex = box.featureIndex;
-            break; // Only one box allowed per instance
+        if (verticalTextStartIndex < verticalTextEndIndex) {
+            const {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY, featureIndex} = collisionBoxArray.get(verticalTextStartIndex);
+            collisionArrays.verticalTextBox = {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY};
+            collisionArrays.verticalTextFeatureIndex = featureIndex;
         }
-        for (let k = iconStartIndex; k < iconEndIndex; k++) {
-            // An icon can only have one box now, so this indexing is a bit vestigial...
-            const box: CollisionBox = (collisionBoxArray.get(k): any);
-            collisionArrays.iconBox = {x1: box.x1, y1: box.y1, x2: box.x2, y2: box.y2, padding: box.padding, projectedAnchorX: box.projectedAnchorX, projectedAnchorY: box.projectedAnchorY, projectedAnchorZ: box.projectedAnchorZ, tileAnchorX: box.tileAnchorX, tileAnchorY: box.tileAnchorY};
-            collisionArrays.iconFeatureIndex = box.featureIndex;
-            break; // Only one box allowed per instance
+        if (iconStartIndex < iconEndIndex) {
+            const {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY, featureIndex} = collisionBoxArray.get(iconStartIndex);
+            collisionArrays.iconBox = {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY};
+            collisionArrays.iconFeatureIndex = featureIndex;
         }
-        for (let k = verticalIconStartIndex; k < verticalIconEndIndex; k++) {
-            // An icon can only have one box now, so this indexing is a bit vestigial...
-            const box: CollisionBox = (collisionBoxArray.get(k): any);
-            collisionArrays.verticalIconBox = {x1: box.x1, y1: box.y1, x2: box.x2, y2: box.y2, padding: box.padding, projectedAnchorX: box.projectedAnchorX, projectedAnchorY: box.projectedAnchorY, projectedAnchorZ: box.projectedAnchorZ, tileAnchorX: box.tileAnchorX, tileAnchorY: box.tileAnchorY};
-            collisionArrays.verticalIconFeatureIndex = box.featureIndex;
-            break; // Only one box allowed per instance
+        if (verticalIconStartIndex < verticalIconEndIndex) {
+            const {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY, featureIndex} = collisionBoxArray.get(verticalIconStartIndex);
+            collisionArrays.verticalIconBox = {x1, y1, x2, y2, padding, projectedAnchorX, projectedAnchorY, projectedAnchorZ, tileAnchorX, tileAnchorY};
+            collisionArrays.verticalIconFeatureIndex = featureIndex;
         }
         return collisionArrays;
     }
@@ -1018,10 +1013,7 @@ class SymbolBucket implements Bucket {
             featureIndexes.push(symbolInstance.featureIndex);
         }
 
-        result.sort((aIndex, bIndex) => {
-            return (rotatedYs[aIndex] - rotatedYs[bIndex]) ||
-                   (featureIndexes[bIndex] - featureIndexes[aIndex]);
-        });
+        result.sort((aIndex, bIndex) => (rotatedYs[aIndex] - rotatedYs[bIndex]) || (featureIndexes[bIndex] - featureIndexes[aIndex]));
 
         return result;
     }
@@ -1061,33 +1053,23 @@ class SymbolBucket implements Bucket {
         this.featureSortOrder = [];
 
         for (const i of this.symbolInstanceIndexes) {
-            const symbolInstance = this.symbolInstances.get(i);
-            this.featureSortOrder.push(symbolInstance.featureIndex);
+            const symbol = this.symbolInstances.get(i);
+            this.featureSortOrder.push(symbol.featureIndex);
+            const {
+                rightJustifiedTextSymbolIndex: right, centerJustifiedTextSymbolIndex: center,
+                leftJustifiedTextSymbolIndex: left, verticalPlacedTextSymbolIndex: vertical,
+                placedIconSymbolIndex: icon, verticalPlacedIconSymbolIndex: iconVertical
+            } = symbol;
 
-            [
-                symbolInstance.rightJustifiedTextSymbolIndex,
-                symbolInstance.centerJustifiedTextSymbolIndex,
-                symbolInstance.leftJustifiedTextSymbolIndex
-            ].forEach((index, i, array) => {
-                // Only add a given index the first time it shows up,
-                // to avoid duplicate opacity entries when multiple justifications
-                // share the same glyphs.
-                if (index >= 0 && array.indexOf(index) === i) {
-                    this.addIndicesForPlacedSymbol(this.text, index);
-                }
-            });
+            // Only add a given index the first time it shows up, to avoid duplicate
+            // opacity entries when multiple justifications share the same glyphs.
+            if (right >= 0) this.addIndicesForPlacedSymbol(this.text, right);
+            if (center >= 0 && center !== right) this.addIndicesForPlacedSymbol(this.text, center);
+            if (left >= 0 && left !== center && left !== right) this.addIndicesForPlacedSymbol(this.text, left);
 
-            if (symbolInstance.verticalPlacedTextSymbolIndex >= 0) {
-                this.addIndicesForPlacedSymbol(this.text, symbolInstance.verticalPlacedTextSymbolIndex);
-            }
-
-            if (symbolInstance.placedIconSymbolIndex >= 0) {
-                this.addIndicesForPlacedSymbol(this.icon, symbolInstance.placedIconSymbolIndex);
-            }
-
-            if (symbolInstance.verticalPlacedIconSymbolIndex >= 0) {
-                this.addIndicesForPlacedSymbol(this.icon, symbolInstance.verticalPlacedIconSymbolIndex);
-            }
+            if (vertical >= 0) this.addIndicesForPlacedSymbol(this.text, vertical);
+            if (icon >= 0) this.addIndicesForPlacedSymbol(this.icon, icon);
+            if (iconVertical >= 0) this.addIndicesForPlacedSymbol(this.icon, iconVertical);
         }
 
         if (this.text.indexBuffer) this.text.indexBuffer.updateData(this.text.indexArray);

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -666,28 +666,11 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    addToLineVertexArray(anchor: Anchor, line: any): LineVertexRange {
+    addToLineVertexArray(anchor: Anchor, line: Array<Point>): LineVertexRange {
         const lineStartIndex = this.lineVertexArray.length;
-        const segment = anchor.segment;
-        if (segment !== undefined) {
-            let sumForwardLength = anchor.dist(line[segment + 1]);
-            let sumBackwardLength = anchor.dist(line[segment]);
-            const vertices = {};
-            for (let i = segment + 1; i < line.length; i++) {
-                vertices[i] = {x: line[i].x, y: line[i].y, tileUnitDistanceFromAnchor: sumForwardLength};
-                if (i < line.length - 1) {
-                    sumForwardLength += line[i + 1].dist(line[i]);
-                }
-            }
-            for (let i = segment || 0; i >= 0; i--) {
-                vertices[i] = {x: line[i].x, y: line[i].y, tileUnitDistanceFromAnchor: sumBackwardLength};
-                if (i > 0) {
-                    sumBackwardLength += line[i - 1].dist(line[i]);
-                }
-            }
-            for (let i = 0; i < line.length; i++) {
-                const vertex = vertices[i];
-                this.lineVertexArray.emplaceBack(vertex.x, vertex.y, vertex.tileUnitDistanceFromAnchor);
+        if (anchor.segment !== undefined) {
+            for (const {x, y} of line) {
+                this.lineVertexArray.emplaceBack(x, y);
             }
         }
         return {

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -716,14 +716,14 @@ class SymbolBucket implements Bucket {
             addVertex(layoutVertexArray, tileAnchor.x, tileAnchor.y, br.x, y + br.y, tex.x + tex.w, tex.y + tex.h, sizeVertex, isSDF, pixelOffsetBR.x, pixelOffsetBR.y, minFontScaleX, minFontScaleY);
 
             if (globe) {
-                const globeAnchor = globe.anchor;
-                const up = globe.up;
-                addGlobeVertex(globeExtVertexArray, globeAnchor.x, globeAnchor.y, globeAnchor.z, up[0], up[1], up[2]);
-                addGlobeVertex(globeExtVertexArray, globeAnchor.x, globeAnchor.y, globeAnchor.z, up[0], up[1], up[2]);
-                addGlobeVertex(globeExtVertexArray, globeAnchor.x, globeAnchor.y, globeAnchor.z, up[0], up[1], up[2]);
-                addGlobeVertex(globeExtVertexArray, globeAnchor.x, globeAnchor.y, globeAnchor.z, up[0], up[1], up[2]);
+                const {x, y, z} = globe.anchor;
+                const [ux, uy, uz] = globe.up;
+                addGlobeVertex(globeExtVertexArray, x, y, z, ux, uy, uz);
+                addGlobeVertex(globeExtVertexArray, x, y, z, ux, uy, uz);
+                addGlobeVertex(globeExtVertexArray, x, y, z, ux, uy, uz);
+                addGlobeVertex(globeExtVertexArray, x, y, z, ux, uy, uz);
 
-                addDynamicAttributes(arrays.dynamicLayoutVertexArray, globeAnchor.x, globeAnchor.y, globeAnchor.z, angle);
+                addDynamicAttributes(arrays.dynamicLayoutVertexArray, x, y, z, angle);
             } else {
                 addDynamicAttributes(arrays.dynamicLayoutVertexArray, tileAnchor.x, tileAnchor.y, tileAnchor.z, angle);
             }

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -850,14 +850,14 @@ class SymbolBucket implements Bucket {
                     instance.leftJustifiedTextSymbolIndex : instance.verticalPlacedTextSymbolIndex >= 0 ?
                         instance.verticalPlacedTextSymbolIndex : boxIndex;
 
-        const symbol: any = this.text.placedSymbolArray.get(symbolIndex);
+        const symbol = this.text.placedSymbolArray.get(symbolIndex);
         const featureSize = symbolSize.evaluateSizeForFeature(this.textSizeData, textSize, symbol) / ONE_EM;
 
         return this.tilePixelRatio * featureSize;
     }
 
     getSymbolInstanceIconSize(iconSize: any, zoom: number, iconIndex: number): number {
-        const symbol: any = this.icon.placedSymbolArray.get(iconIndex);
+        const symbol = this.icon.placedSymbolArray.get(iconIndex);
         const featureSize = symbolSize.evaluateSizeForFeature(this.iconSizeData, iconSize, symbol);
 
         return this.tilePixelRatio * featureSize;

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -194,7 +194,7 @@ function updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, var
             ];
 
             const projectedAnchor = symbolProjection.projectVector(reprojectedAnchor, pitchWithMap ? tileMatrix : labelPlaneMatrix);
-            const perspectiveRatio = symbolProjection.getPerspectiveRatio(transform.getCameraToCenterDistance(bucket.getProjection()), projectedAnchor.signedDistanceFromCamera);
+            const perspectiveRatio = symbolProjection.getPerspectiveRatio(transform.getCameraToCenterDistance(bucket.getProjection()), projectedAnchor[3]);
             let renderTextSize = symbolSize.evaluateSizeForFeature(bucket.textSizeData, size, symbol) * perspectiveRatio / ONE_EM;
             if (pitchWithMap) {
                 // Go from size in pixels to equivalent size in tile units
@@ -221,10 +221,10 @@ function updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, var
                     z + anchorElevation * upDir[2] * upVectorScale.metersToTile
                 ];
 
-                shiftedAnchor = symbolProjection.projectVector(reprojectedShiftedAnchor, labelPlaneMatrix).point;
+                shiftedAnchor = symbolProjection.projectVector(reprojectedShiftedAnchor, labelPlaneMatrix);
             } else {
                 const rotatedShift = rotateWithMap ? shift.rotate(-transform.angle) : shift;
-                shiftedAnchor = [projectedAnchor.point[0] + rotatedShift.x, projectedAnchor.point[1] + rotatedShift.y, 0];
+                shiftedAnchor = [projectedAnchor[0] + rotatedShift.x, projectedAnchor[1] + rotatedShift.y, 0];
             }
 
             const angle = (bucket.allowVerticalPlacement && symbol.placedOrientation === WritingMode.vertical) ? Math.PI / 2 : 0;

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -38,7 +38,6 @@ import {OverscaledTileID} from '../source/tile_id.js';
 import type {UniformValues} from './uniform_binding.js';
 import type {SymbolSDFUniformsType} from '../render/program/symbol_program.js';
 import type {CrossTileID, VariableOffset} from '../symbol/placement.js';
-import type {Vec3} from 'gl-matrix';
 
 export default drawSymbols;
 
@@ -124,7 +123,7 @@ function computeGlobeCameraUp(transform: Transform): [number, number, number] {
     return cameraUpVector;
 }
 
-function calculateVariableRenderShift(anchor, width, height, textOffset, textScale, renderTextSize): Point {
+function calculateVariableRenderShift({width, height, anchor, textOffset, textScale}, renderTextSize): Point {
     const {horizontalAlign, verticalAlign} = getAnchorAlignment(anchor);
     const shiftX = -(horizontalAlign - 0.5) * width;
     const shiftY = -(verticalAlign - 0.5) * height;
@@ -169,71 +168,72 @@ function updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, var
     const dynamicTextLayoutVertexArray = bucket.text.dynamicLayoutVertexArray;
     const dynamicIconLayoutVertexArray = bucket.icon.dynamicLayoutVertexArray;
     const placedTextShifts = {};
-    const tileMatrix = getSymbolTileProjectionMatrix(coord, bucket.getProjection(), transform);
+    const projection = bucket.getProjection();
+    const tileMatrix = getSymbolTileProjectionMatrix(coord, projection, transform);
     const elevation = transform.elevation;
-    const upVectorScale = bucket.getProjection().upVectorScale(coord.canonical, transform.center.lat, transform.worldSize);
+    const metersToTile = projection.upVectorScale(coord.canonical, transform.center.lat, transform.worldSize).metersToTile;
 
     dynamicTextLayoutVertexArray.clear();
     for (let s = 0; s < placedSymbols.length; s++) {
-        const symbol: any = placedSymbols.get(s);
+        const symbol = placedSymbols.get(s);
+        const {tileAnchorX, tileAnchorY, numGlyphs} = symbol;
         const skipOrientation = bucket.allowVerticalPlacement && !symbol.placedOrientation;
         const variableOffset = (!symbol.hidden && symbol.crossTileID && !skipOrientation) ? variableOffsets[symbol.crossTileID] : null;
 
         if (!variableOffset) {
             // These symbols are from a justification that is not being used, or a label that wasn't placed
             // so we don't need to do the extra math to figure out what incremental shift to apply.
-            symbolProjection.hideGlyphs(symbol.numGlyphs, dynamicTextLayoutVertexArray);
-        } else  {
-            const tileAnchor = new Point(symbol.tileAnchorX, symbol.tileAnchorY);
-            const upDir = bucket.getProjection().upVector(coord.canonical, tileAnchor.x, tileAnchor.y);
-            const anchorElevation = elevation ? elevation.getAtTileOffset(coord, tileAnchor.x, tileAnchor.y) : 0.0;
-            const reprojectedAnchor = [
-                symbol.projectedAnchorX + anchorElevation * upDir[0] * upVectorScale.metersToTile,
-                symbol.projectedAnchorY + anchorElevation * upDir[1] * upVectorScale.metersToTile,
-                symbol.projectedAnchorZ + anchorElevation * upDir[2] * upVectorScale.metersToTile
-            ];
+            symbolProjection.hideGlyphs(numGlyphs, dynamicTextLayoutVertexArray);
 
-            const projectedAnchor = symbolProjection.projectVector(reprojectedAnchor, pitchWithMap ? tileMatrix : labelPlaneMatrix);
-            const perspectiveRatio = symbolProjection.getPerspectiveRatio(transform.getCameraToCenterDistance(bucket.getProjection()), projectedAnchor[3]);
+        } else  {
+            let dx = 0, dy = 0, dz = 0;
+            if (elevation) {
+                const h = elevation ? elevation.getAtTileOffset(coord, tileAnchorX, tileAnchorY) : 0.0;
+                const [ux, uy, uz] = projection.upVector(coord.canonical, tileAnchorX, tileAnchorY);
+                dx = h * ux * metersToTile;
+                dy = h * uy * metersToTile;
+                dz = h * uz * metersToTile;
+            }
+            let anchor = [
+                symbol.projectedAnchorX + dx,
+                symbol.projectedAnchorY + dy,
+                symbol.projectedAnchorZ + dz
+            ];
+            anchor = symbolProjection.projectVector(anchor, pitchWithMap ? tileMatrix : labelPlaneMatrix);
+
+            const perspectiveRatio = symbolProjection.getPerspectiveRatio(transform.getCameraToCenterDistance(projection), anchor[3]);
             let renderTextSize = symbolSize.evaluateSizeForFeature(bucket.textSizeData, size, symbol) * perspectiveRatio / ONE_EM;
             if (pitchWithMap) {
                 // Go from size in pixels to equivalent size in tile units
                 renderTextSize *= bucket.tilePixelRatio / tileScale;
             }
 
-            const {width, height, anchor, textOffset, textScale} = variableOffset;
-
-            const shift = calculateVariableRenderShift(
-                anchor, width, height, textOffset, textScale, renderTextSize);
+            const shift = calculateVariableRenderShift(variableOffset, renderTextSize);
 
             // Usual case is that we take the projected anchor and add the pixel-based shift
             // calculated above. In the (somewhat weird) case of pitch-aligned text, we add an equivalent
             // tile-unit based shift to the anchor before projecting to the label plane.
-            let shiftedAnchor: Vec3;
-
             if (pitchWithMap) {
-                const shiftedTileAnchor = tileAnchor.add(shift);
-                const {x, y, z} = bucket.getProjection().projectTilePoint(shiftedTileAnchor.x, shiftedTileAnchor.y, coord.canonical);
+                const {x, y, z} = projection.projectTilePoint(tileAnchorX + shift.x, tileAnchorY + shift.y, coord.canonical);
+                anchor[0] = x + dx;
+                anchor[1] = y + dy;
+                anchor[2] = z + dz;
+                anchor = symbolProjection.projectVector(anchor, labelPlaneMatrix);
 
-                const reprojectedShiftedAnchor = [
-                    x + anchorElevation * upDir[0] * upVectorScale.metersToTile,
-                    y + anchorElevation * upDir[1] * upVectorScale.metersToTile,
-                    z + anchorElevation * upDir[2] * upVectorScale.metersToTile
-                ];
-
-                shiftedAnchor = symbolProjection.projectVector(reprojectedShiftedAnchor, labelPlaneMatrix);
             } else {
-                const rotatedShift = rotateWithMap ? shift.rotate(-transform.angle) : shift;
-                shiftedAnchor = [projectedAnchor[0] + rotatedShift.x, projectedAnchor[1] + rotatedShift.y, 0];
+                if (rotateWithMap) shift._rotate(-transform.angle);
+                anchor[0] += shift.x;
+                anchor[1] += shift.y;
+                anchor[2] = 0;
             }
 
             const angle = (bucket.allowVerticalPlacement && symbol.placedOrientation === WritingMode.vertical) ? Math.PI / 2 : 0;
-            for (let g = 0; g < symbol.numGlyphs; g++) {
-                addDynamicAttributes(dynamicTextLayoutVertexArray, shiftedAnchor[0], shiftedAnchor[1], shiftedAnchor[2], angle);
+            for (let g = 0; g < numGlyphs; g++) {
+                addDynamicAttributes(dynamicTextLayoutVertexArray, anchor[0], anchor[1], anchor[2], angle);
             }
             //Only offset horizontal text icons
             if (updateTextFitIcon && symbol.associatedIconIndex >= 0) {
-                placedTextShifts[symbol.associatedIconIndex] = {shiftedAnchor, angle};
+                placedTextShifts[symbol.associatedIconIndex] = {anchor, angle};
             }
         }
     }
@@ -243,16 +243,15 @@ function updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, var
         const placedIcons = bucket.icon.placedSymbolArray;
         for (let i = 0; i < placedIcons.length; i++) {
             const placedIcon = placedIcons.get(i);
-            if (placedIcon.hidden) {
-                symbolProjection.hideGlyphs(placedIcon.numGlyphs, dynamicIconLayoutVertexArray);
+            const {numGlyphs} = placedIcon;
+            const shift = placedTextShifts[i];
+
+            if (placedIcon.hidden || !shift) {
+                symbolProjection.hideGlyphs(numGlyphs, dynamicIconLayoutVertexArray);
             } else {
-                const shift = placedTextShifts[i];
-                if (!shift) {
-                    symbolProjection.hideGlyphs(placedIcon.numGlyphs, dynamicIconLayoutVertexArray);
-                } else {
-                    for (let g = 0; g < placedIcon.numGlyphs; g++) {
-                        addDynamicAttributes(dynamicIconLayoutVertexArray, shift.shiftedAnchor[0], shift.shiftedAnchor[1], shift.shiftedAnchor[2], shift.angle);
-                    }
+                const [x, y, z] = shift.anchor;
+                for (let g = 0; g < numGlyphs; g++) {
+                    addDynamicAttributes(dynamicIconLayoutVertexArray, x, y, z, shift.angle);
                 }
             }
         }

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -372,7 +372,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         if (alongLine) {
             const elevation = tr.elevation;
-            const getElevation = elevation ? elevation.getAtTileOffsetFunc(coord, tr.center.lat, tr.worldSize, bucket.getProjection()) : (_ => [0, 0, 0]);
+            const getElevation = elevation ? elevation.getAtTileOffsetFunc(coord, tr.center.lat, tr.worldSize, bucket.getProjection()) : null;
             const labelPlaneMatrixPlacement = symbolProjection.getLabelPlaneMatrixForPlacement(tileMatrix, tile.tileID.canonical, pitchWithMap, rotateWithMap, tr, bucket.getProjection(), s);
 
             symbolProjection.updateLineLabels(bucket, tileMatrix, painter, isText, labelPlaneMatrixPlacement, glCoordMatrix, pitchWithMap, keepUpright, getElevation, coord);

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -338,7 +338,8 @@ export class Placement {
                            symbolInstance: SymbolInstance, boxIndex: number, bucket: SymbolBucket,
                            orientation: number, iconBox: ?SingleCollisionBox, textSize: any, iconSize: any): ?{ shift: Point, placedGlyphBoxes: { box: Array<number>, offscreen: boolean, occluded: boolean } }  {
 
-        const textOffset = [symbolInstance.textOffset0, symbolInstance.textOffset1];
+        const {textOffset0, textOffset1, crossTileID} = symbolInstance;
+        const textOffset = [textOffset0, textOffset1];
         const shift = calculateVariableLayoutShift(anchor, width, height, textOffset, textScale);
 
         const placedGlyphBoxes = this.collisionIndex.placeCollisionBox(
@@ -358,13 +359,13 @@ export class Placement {
             // If this label was placed in the previous placement, record the anchor position
             // to allow us to animate the transition
             if (this.prevPlacement &&
-                this.prevPlacement.variableOffsets[symbolInstance.crossTileID] &&
-                this.prevPlacement.placements[symbolInstance.crossTileID] &&
-                this.prevPlacement.placements[symbolInstance.crossTileID].text) {
-                prevAnchor = this.prevPlacement.variableOffsets[symbolInstance.crossTileID].anchor;
+                this.prevPlacement.variableOffsets[crossTileID] &&
+                this.prevPlacement.placements[crossTileID] &&
+                this.prevPlacement.placements[crossTileID].text) {
+                prevAnchor = this.prevPlacement.variableOffsets[crossTileID].anchor;
             }
-            assert(symbolInstance.crossTileID !== 0);
-            this.variableOffsets[symbolInstance.crossTileID] = {
+            assert(crossTileID !== 0);
+            this.variableOffsets[crossTileID] = {
                 textOffset,
                 width,
                 height,
@@ -376,7 +377,7 @@ export class Placement {
 
             if (bucket.allowVerticalPlacement) {
                 this.markUsedOrientation(bucket, orientation, symbolInstance);
-                this.placedOrientations[symbolInstance.crossTileID] = orientation;
+                this.placedOrientations[crossTileID] = orientation;
             }
 
             return {shift, placedGlyphBoxes};
@@ -437,6 +438,8 @@ export class Placement {
         }
 
         const placeSymbol = (symbolInstance: SymbolInstance, boxIndex: number, collisionArrays: CollisionArrays) => {
+            const {crossTileID, numVerticalGlyphVertices} = symbolInstance;
+
             if (clippingData) {
                 // Setup globals
                 const globals = {
@@ -462,17 +465,17 @@ export class Placement {
                 const shouldClip = !filterFunc(globals, feature, canonicalTileId, new Point(symbolInstance.tileAnchorX, symbolInstance.tileAnchorY), this.transform.calculateDistanceTileData(clippingData.unwrappedTileID));
 
                 if (shouldClip) {
-                    this.placements[symbolInstance.crossTileID] = new JointPlacement(false, false, false, true);
-                    seenCrossTileIDs[symbolInstance.crossTileID] = true;
+                    this.placements[crossTileID] = new JointPlacement(false, false, false, true);
+                    seenCrossTileIDs[crossTileID] = true;
                     return;
                 }
             }
 
-            if (seenCrossTileIDs[symbolInstance.crossTileID]) return;
+            if (seenCrossTileIDs[crossTileID]) return;
             if (holdingForFade) {
                 // Mark all symbols from this tile as "not placed", but don't add to seenCrossTileIDs, because we don't
                 // know yet if we have a duplicate in a parent tile that _should_ be placed.
-                this.placements[symbolInstance.crossTileID] = new JointPlacement(false, false, false);
+                this.placements[crossTileID] = new JointPlacement(false, false, false);
                 return;
             }
             let placeText = false;
@@ -503,10 +506,9 @@ export class Placement {
 
             const updateBoxData = (box: SingleCollisionBox) => {
                 box.tileID = this.retainedQueryData[bucket.bucketInstanceId].tileID;
-                if (!this.transform.elevation && !box.elevation) return;
-                box.elevation = this.transform.elevation ? this.transform.elevation.getAtTileOffset(
-                    this.retainedQueryData[bucket.bucketInstanceId].tileID,
-                    box.tileAnchorX, box.tileAnchorY) : 0;
+                const elevation = this.transform.elevation;
+                if (!elevation && !box.elevation) return;
+                box.elevation = elevation ? elevation.getAtTileOffset(box.tileID, box.tileAnchorX, box.tileAnchorY) : 0;
             };
 
             const textBox = collisionArrays.textBox;
@@ -515,9 +517,9 @@ export class Placement {
                 const updatePreviousOrientationIfNotPlaced = (isPlaced) => {
                     let previousOrientation = WritingMode.horizontal;
                     if (bucket.allowVerticalPlacement && !isPlaced && this.prevPlacement) {
-                        const prevPlacedOrientation = this.prevPlacement.placedOrientations[symbolInstance.crossTileID];
+                        const prevPlacedOrientation = this.prevPlacement.placedOrientations[crossTileID];
                         if (prevPlacedOrientation) {
-                            this.placedOrientations[symbolInstance.crossTileID] = prevPlacedOrientation;
+                            this.placedOrientations[crossTileID] = prevPlacedOrientation;
                             previousOrientation = prevPlacedOrientation;
                             this.markUsedOrientation(bucket, previousOrientation, symbolInstance);
                         }
@@ -526,7 +528,7 @@ export class Placement {
                 };
 
                 const placeTextForPlacementModes = (placeHorizontalFn, placeVerticalFn) => {
-                    if (bucket.allowVerticalPlacement && symbolInstance.numVerticalGlyphVertices > 0 && collisionArrays.verticalTextBox) {
+                    if (bucket.allowVerticalPlacement && numVerticalGlyphVertices > 0 && collisionArrays.verticalTextBox) {
                         for (const placementMode of bucket.writingModes) {
                             if (placementMode === WritingMode.vertical) {
                                 placed = placeVerticalFn();
@@ -548,7 +550,7 @@ export class Placement {
                             new Point(0, 0), textAllowOverlap, textPixelRatio, posMatrix, collisionGroup.predicate);
                         if (placedFeature && placedFeature.box && placedFeature.box.length) {
                             this.markUsedOrientation(bucket, orientation, symbolInstance);
-                            this.placedOrientations[symbolInstance.crossTileID] = orientation;
+                            this.placedOrientations[crossTileID] = orientation;
                         }
                         return placedFeature;
                     };
@@ -559,7 +561,7 @@ export class Placement {
 
                     const placeVertical = () => {
                         const verticalTextBox = collisionArrays.verticalTextBox;
-                        if (bucket.allowVerticalPlacement && symbolInstance.numVerticalGlyphVertices > 0 && verticalTextBox) {
+                        if (bucket.allowVerticalPlacement && numVerticalGlyphVertices > 0 && verticalTextBox) {
                             updateBoxData(verticalTextBox);
                             return placeBox(verticalTextBox, WritingMode.vertical);
                         }
@@ -575,8 +577,8 @@ export class Placement {
                     // If this symbol was in the last placement, shift the previously used
                     // anchor to the front of the anchor list, only if the previous anchor
                     // is still in the anchor list
-                    if (this.prevPlacement && this.prevPlacement.variableOffsets[symbolInstance.crossTileID]) {
-                        const prevOffsets = this.prevPlacement.variableOffsets[symbolInstance.crossTileID];
+                    if (this.prevPlacement && this.prevPlacement.variableOffsets[crossTileID]) {
+                        const prevOffsets = this.prevPlacement.variableOffsets[crossTileID];
                         if (anchors.indexOf(prevOffsets.anchor) > 0) {
                             anchors = anchors.filter(anchor => anchor !== prevOffsets.anchor);
                             anchors.unshift(prevOffsets.anchor);
@@ -623,7 +625,7 @@ export class Placement {
                         const verticalTextBox = collisionArrays.verticalTextBox;
                         if (verticalTextBox) updateBoxData(verticalTextBox);
                         const wasPlaced = placed && placed.box && placed.box.length;
-                        if (bucket.allowVerticalPlacement && !wasPlaced && symbolInstance.numVerticalGlyphVertices > 0 && verticalTextBox) {
+                        if (bucket.allowVerticalPlacement && !wasPlaced && numVerticalGlyphVertices > 0 && verticalTextBox) {
                             return placeBoxForVariableAnchors(verticalTextBox, collisionArrays.verticalIconBox, WritingMode.vertical);
                         }
                         return {box: null, offscreen: null, occluded: null};
@@ -642,9 +644,9 @@ export class Placement {
                     // If we didn't get placed, we still need to copy our position from the last placement for
                     // fade animations
                     if (!placeText && this.prevPlacement) {
-                        const prevOffset = this.prevPlacement.variableOffsets[symbolInstance.crossTileID];
+                        const prevOffset = this.prevPlacement.variableOffsets[crossTileID];
                         if (prevOffset) {
-                            this.variableOffsets[symbolInstance.crossTileID] = prevOffset;
+                            this.variableOffsets[crossTileID] = prevOffset;
                             this.markUsedJustification(bucket, prevOffset.anchor, symbolInstance, prevOrientation);
                         }
                     }
@@ -722,7 +724,7 @@ export class Placement {
             }
 
             const iconWithoutText = textOptional ||
-                (symbolInstance.numHorizontalGlyphVertices === 0 && symbolInstance.numVerticalGlyphVertices === 0);
+                (symbolInstance.numHorizontalGlyphVertices === 0 && numVerticalGlyphVertices === 0);
             const textWithoutIcon = iconOptional || symbolInstance.numIconVertices === 0;
 
             // Combine the scales for icons and text.
@@ -772,15 +774,15 @@ export class Placement {
                 }
             }
 
-            assert(symbolInstance.crossTileID !== 0);
+            assert(crossTileID !== 0);
             assert(bucket.bucketInstanceId !== 0);
 
             const notGlobe = bucket.projection.name !== 'globe';
             alwaysShowText = alwaysShowText && (notGlobe || !textOccluded);
             alwaysShowIcon = alwaysShowIcon && (notGlobe || !iconOccluded);
 
-            this.placements[symbolInstance.crossTileID] = new JointPlacement(placeText || alwaysShowText, placeIcon || alwaysShowIcon, offscreen || bucket.justReloaded);
-            seenCrossTileIDs[symbolInstance.crossTileID] = true;
+            this.placements[crossTileID] = new JointPlacement(placeText || alwaysShowText, placeIcon || alwaysShowIcon, offscreen || bucket.justReloaded);
+            seenCrossTileIDs[crossTileID] = true;
         };
 
         if (zOrderByViewportY) {
@@ -808,56 +810,39 @@ export class Placement {
     }
 
     markUsedJustification(bucket: SymbolBucket, placedAnchor: TextAnchor, symbolInstance: SymbolInstance, orientation: number) {
-        const justifications = {
-            "left": symbolInstance.leftJustifiedTextSymbolIndex,
-            "center": symbolInstance.centerJustifiedTextSymbolIndex,
-            "right": symbolInstance.rightJustifiedTextSymbolIndex
-        };
+        const {
+            leftJustifiedTextSymbolIndex: left, centerJustifiedTextSymbolIndex: center,
+            rightJustifiedTextSymbolIndex: right, verticalPlacedTextSymbolIndex: vertical, crossTileID
+        } = symbolInstance;
 
-        let autoIndex;
-        if (orientation === WritingMode.vertical) {
-            autoIndex = symbolInstance.verticalPlacedTextSymbolIndex;
-        } else {
-            autoIndex = justifications[getAnchorJustification(placedAnchor)];
-        }
+        const justification = getAnchorJustification(placedAnchor);
+        const autoIndex =
+            orientation === WritingMode.vertical ? vertical :
+            justification === 'left' ? left :
+            justification === 'center' ? center :
+            justification === 'right' ? right : -1;
 
-        const indexes = [
-            symbolInstance.leftJustifiedTextSymbolIndex,
-            symbolInstance.centerJustifiedTextSymbolIndex,
-            symbolInstance.rightJustifiedTextSymbolIndex,
-            symbolInstance.verticalPlacedTextSymbolIndex
-        ];
-
-        for (const index of indexes) {
-            if (index >= 0) {
-                if (autoIndex >= 0 && index !== autoIndex) {
-                    // There are multiple justifications and this one isn't it: shift offscreen
-                    bucket.text.placedSymbolArray.get(index).crossTileID = 0;
-                } else {
-                    // Either this is the chosen justification or the justification is hardwired: use this one
-                    bucket.text.placedSymbolArray.get(index).crossTileID = symbolInstance.crossTileID;
-                }
-            }
-        }
+        // If there are multiple justifications and this one isn't it: shift offscreen
+        // If either this is the chosen justification or the justification is hardwired: use it
+        if (left >= 0) bucket.text.placedSymbolArray.get(left).crossTileID = autoIndex >= 0 && left !== autoIndex ? 0 : crossTileID;
+        if (center >= 0) bucket.text.placedSymbolArray.get(center).crossTileID = autoIndex >= 0 && center !== autoIndex ? 0 : crossTileID;
+        if (right >= 0) bucket.text.placedSymbolArray.get(right).crossTileID = autoIndex >= 0 && right !== autoIndex ? 0 : crossTileID;
+        if (vertical >= 0) bucket.text.placedSymbolArray.get(vertical).crossTileID = autoIndex >= 0 && vertical !== autoIndex ? 0 : crossTileID;
     }
 
     markUsedOrientation(bucket: SymbolBucket, orientation: number, symbolInstance: SymbolInstance) {
-        const horizontal = (orientation === WritingMode.horizontal || orientation === WritingMode.horizontalOnly) ? orientation : 0;
-        const vertical = orientation === WritingMode.vertical ? orientation : 0;
+        const horizontalOrientation = (orientation === WritingMode.horizontal || orientation === WritingMode.horizontalOnly) ? orientation : 0;
+        const verticalOrientation = orientation === WritingMode.vertical ? orientation : 0;
+        const {
+            leftJustifiedTextSymbolIndex: left, centerJustifiedTextSymbolIndex: center,
+            rightJustifiedTextSymbolIndex: right, verticalPlacedTextSymbolIndex: vertical
+        } = symbolInstance;
+        const array = bucket.text.placedSymbolArray;
 
-        const horizontalIndexes = [
-            symbolInstance.leftJustifiedTextSymbolIndex,
-            symbolInstance.centerJustifiedTextSymbolIndex,
-            symbolInstance.rightJustifiedTextSymbolIndex
-        ].filter(i => i !== -1);
-
-        for (const index of horizontalIndexes) {
-            bucket.text.placedSymbolArray.get(index).placedOrientation = horizontal;
-        }
-
-        if (symbolInstance.verticalPlacedTextSymbolIndex !== -1) {
-            bucket.text.placedSymbolArray.get(symbolInstance.verticalPlacedTextSymbolIndex).placedOrientation = vertical;
-        }
+        if (left >= 0) array.get(left).placedOrientation = horizontalOrientation;
+        if (center >= 0) array.get(center).placedOrientation = horizontalOrientation;
+        if (right >= 0) array.get(right).placedOrientation = horizontalOrientation;
+        if (vertical >= 0) array.get(vertical).placedOrientation = verticalOrientation;
     }
 
     commit(now: number): void {
@@ -974,7 +959,8 @@ export class Placement {
             const {
                 numHorizontalGlyphVertices,
                 numVerticalGlyphVertices,
-                crossTileID
+                crossTileID,
+                numIconVertices
             } = symbolInstance;
 
             const isDuplicate = seenCrossTileIDs[crossTileID];
@@ -991,9 +977,9 @@ export class Placement {
             seenCrossTileIDs[crossTileID] = true;
 
             const hasText = numHorizontalGlyphVertices > 0 || numVerticalGlyphVertices > 0;
-            const hasIcon = symbolInstance.numIconVertices > 0;
+            const hasIcon = numIconVertices > 0;
 
-            const placedOrientation = this.placedOrientations[symbolInstance.crossTileID];
+            const placedOrientation = this.placedOrientations[crossTileID];
             const horizontalHidden = placedOrientation === WritingMode.vertical;
             const verticalHidden = placedOrientation === WritingMode.horizontal || placedOrientation === WritingMode.horizontalOnly;
             if ((hasText || hasIcon) && !opacityState.isHidden()) visibleInstanceCount++;
@@ -1012,26 +998,24 @@ export class Placement {
                 // symbol instances appropriately so that symbols from buckets that have yet to be placed
                 // offset appropriately.
                 const symbolHidden = opacityState.text.isHidden();
-                [
-                    symbolInstance.rightJustifiedTextSymbolIndex,
-                    symbolInstance.centerJustifiedTextSymbolIndex,
-                    symbolInstance.leftJustifiedTextSymbolIndex
-                ].forEach(index => {
-                    if (index >= 0) {
-                        bucket.text.placedSymbolArray.get(index).hidden = symbolHidden || horizontalHidden ? 1 : 0;
-                    }
-                });
+                const {
+                    leftJustifiedTextSymbolIndex: left, centerJustifiedTextSymbolIndex: center,
+                    rightJustifiedTextSymbolIndex: right, verticalPlacedTextSymbolIndex: vertical
+                } = symbolInstance;
+                const array = bucket.text.placedSymbolArray;
+                const horizontalHiddenValue = symbolHidden || horizontalHidden ? 1 : 0;
 
-                if (symbolInstance.verticalPlacedTextSymbolIndex >= 0) {
-                    bucket.text.placedSymbolArray.get(symbolInstance.verticalPlacedTextSymbolIndex).hidden = symbolHidden || verticalHidden ? 1 : 0;
-                }
+                if (left >= 0) array.get(left).hidden = horizontalHiddenValue;
+                if (center >= 0) array.get(center).hidden = horizontalHiddenValue;
+                if (right >= 0) array.get(right).hidden = horizontalHiddenValue;
+                if (vertical >= 0) array.get(vertical).hidden = symbolHidden || verticalHidden ? 1 : 0;
 
-                const prevOffset = this.variableOffsets[symbolInstance.crossTileID];
+                const prevOffset = this.variableOffsets[crossTileID];
                 if (prevOffset) {
                     this.markUsedJustification(bucket, prevOffset.anchor, symbolInstance, placedOrientation);
                 }
 
-                const prevOrientation = this.placedOrientations[symbolInstance.crossTileID];
+                const prevOrientation = this.placedOrientations[crossTileID];
                 if (prevOrientation) {
                     this.markUsedJustification(bucket, 'left', symbolInstance, prevOrientation);
                     this.markUsedOrientation(bucket, prevOrientation, symbolInstance);
@@ -1040,19 +1024,20 @@ export class Placement {
 
             if (hasIcon) {
                 const packedOpacity = packOpacity(opacityState.icon);
+                const {placedIconSymbolIndex, verticalPlacedIconSymbolIndex} = symbolInstance;
+                const array = bucket.icon.placedSymbolArray;
+                const iconHidden = opacityState.icon.isHidden() ? 1 : 0;
 
-                if (symbolInstance.placedIconSymbolIndex >= 0) {
+                if (placedIconSymbolIndex >= 0) {
                     const horizontalOpacity = !horizontalHidden ? packedOpacity : PACKED_HIDDEN_OPACITY;
-                    addOpacities(bucket.icon, symbolInstance.numIconVertices, horizontalOpacity);
-                    bucket.icon.placedSymbolArray.get(symbolInstance.placedIconSymbolIndex).hidden =
-                        (opacityState.icon.isHidden(): any);
+                    addOpacities(bucket.icon, numIconVertices, horizontalOpacity);
+                    array.get(placedIconSymbolIndex).hidden = iconHidden;
                 }
 
-                if (symbolInstance.verticalPlacedIconSymbolIndex >= 0) {
+                if (verticalPlacedIconSymbolIndex >= 0) {
                     const verticalOpacity = !verticalHidden ? packedOpacity : PACKED_HIDDEN_OPACITY;
                     addOpacities(bucket.icon, symbolInstance.numVerticalIconVertices, verticalOpacity);
-                    bucket.icon.placedSymbolArray.get(symbolInstance.verticalPlacedIconSymbolIndex).hidden =
-                        (opacityState.icon.isHidden(): any);
+                    array.get(verticalPlacedIconSymbolIndex).hidden = iconHidden;
                 }
             }
 

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -429,7 +429,7 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
     const {lineStartIndex, glyphStartIndex, numGlyphs, segment, writingMode, flipState} = symbol;
     const lineEndIndex = lineStartIndex + symbol.lineLength;
 
-    const addGlyph = (glyph) => {
+    const addGlyph = (glyph: PlacedGlyph) => {
         if (globeExtVertexArray) {
             const [ux, uy, uz] = glyph.up;
             const offset = dynamicLayoutVertexArray.length;
@@ -467,7 +467,8 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
             // Since first and last glyph fit on the line, the rest of the glyphs can be placed too, but check to make sure
             const glyph = placeGlyphAlongLine(fontScale * glyphOffsetArray.getoffsetX(glyphIndex), lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, segment,
                 lineStartIndex, lineEndIndex, lineVertexArray, labelPlaneMatrix, projectionCache, getElevation, false, false, projection, tileID, pitchWithMap);
-            if (glyph) addGlyph(glyph);
+            if (!glyph) return {notEnoughRoom: true};
+            addGlyph(glyph);
         }
         addGlyph(firstAndLastGlyph.last);
     } else {

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -673,18 +673,15 @@ function placeGlyphAlongLine(
     };
 }
 
-const hiddenGlyphAttributes = new Float32Array([-Infinity, -Infinity, 0, -Infinity, -Infinity, 0, -Infinity, -Infinity, 0, -Infinity, -Infinity, 0, -Infinity, -Infinity, 0]);
-
 // Hide them by moving them offscreen. We still need to add them to the buffer
 // because the dynamic buffer is paired with a static buffer that doesn't get updated.
 function hideGlyphs(num: number, dynamicLayoutVertexArray: SymbolDynamicLayoutArray) {
-    for (let i = 0; i < num; i++) {
-        const offset = dynamicLayoutVertexArray.length;
-        dynamicLayoutVertexArray.resize(offset + 4);
-        // Since all hidden glyphs have the same attributes, we can build up the array faster with a single call to Float32Array.set
-        // for each set of four vertices, instead of calling addDynamicAttributes for each vertex.
-        dynamicLayoutVertexArray.float32.set(hiddenGlyphAttributes, offset * 4);
-    }
+    const offset = dynamicLayoutVertexArray.length;
+    const end = offset + 4 * num;
+    dynamicLayoutVertexArray.resize(end);
+    // Since all hidden glyphs have the same attributes, we can build up the array faster with a single call to
+    // Float32Array.fill for all vertices, instead of calling addDynamicAttributes for each vertex.
+    dynamicLayoutVertexArray.float32.fill(-Infinity, offset * 4, end * 4);
 }
 
 // For line label layout, we're not using z output and our w input is always 1

--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -67,13 +67,13 @@ const baselineOffset = 7;
 const INVALID_TEXT_OFFSET = Number.POSITIVE_INFINITY;
 const sqrt2 = Math.sqrt(2);
 
-export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, number]): [number, number] {
+export function evaluateVariableOffset(anchor: TextAnchor, [offsetX, offsetY]: [number, number]): [number, number] {
+    let x = 0, y = 0;
 
-    function fromRadialOffset(anchor: TextAnchor, radialOffset: number) {
-        let x = 0, y = 0;
-        if (radialOffset < 0) radialOffset = 0; // Ignore negative offset.
-        // solve for r where r^2 + r^2 = radialOffset^2
-        const hypotenuse = radialOffset / sqrt2;
+    if (offsetY === INVALID_TEXT_OFFSET) { // radial offset
+        if (offsetX < 0) offsetX = 0; // Ignore negative offset.
+        // solve for r where r^2 + r^2 = offsetX^2
+        const hypotenuse = offsetX / sqrt2;
         switch (anchor) {
         case 'top-right':
         case 'top-left':
@@ -84,10 +84,10 @@ export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, numb
             y = -hypotenuse + baselineOffset;
             break;
         case 'bottom':
-            y = -radialOffset + baselineOffset;
+            y = -offsetX + baselineOffset;
             break;
         case 'top':
-            y = radialOffset - baselineOffset;
+            y = offsetX - baselineOffset;
             break;
         }
 
@@ -101,18 +101,14 @@ export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, numb
             x = hypotenuse;
             break;
         case 'left':
-            x = radialOffset;
+            x = offsetX;
             break;
         case 'right':
-            x = -radialOffset;
+            x = -offsetX;
             break;
         }
 
-        return [x, y];
-    }
-
-    function fromTextOffset(anchor: TextAnchor, offsetX: number, offsetY: number) {
-        let x = 0, y = 0;
+    } else { // text offset
         // Use absolute offset values.
         offsetX = Math.abs(offsetX);
         offsetY = Math.abs(offsetY);
@@ -142,11 +138,9 @@ export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, numb
             x = offsetX;
             break;
         }
-
-        return [x, y];
     }
 
-    return (offset[1] !== INVALID_TEXT_OFFSET) ? fromTextOffset(anchor, offset[0], offset[1]) : fromRadialOffset(anchor, offset[0]);
+    return [x, y];
 }
 
 export function performSymbolLayout(bucket: SymbolBucket,

--- a/src/symbol/symbol_size.js
+++ b/src/symbol/symbol_size.js
@@ -80,7 +80,7 @@ function getSizeData(tileZoom: number, value: PropertyValue<number, PossiblyEval
 
 function evaluateSizeForFeature(sizeData: SizeData,
                                 {uSize, uSizeT}: InterpolatedSize,
-                                {lowerSize, upperSize}: { lowerSize: number, upperSize: number}): number {
+                                {lowerSize, upperSize}: {+lowerSize: number, +upperSize: number}): number {
     if (sizeData.kind === 'source') {
         return lowerSize / SIZE_PACK_FACTOR;
     } else if (sizeData.kind === 'composite') {


### PR DESCRIPTION
While I'm out of power and Internet, I'm going to be working offline on optimizing and simplifying symbol placement code, which is terrifyingly complex at the moment and in dire need of cleanup. Will try to do that in self-contained commits and push periodically when I'm back online.

## Results

Zooming around z14–16 on `streets-v11` SF with lots of roads in view, looking at profiler results, this PR seems to improve performance of placement along lines by ~40–50%.

**Before:**
<img width="630" alt="image" src="https://user-images.githubusercontent.com/25395/200855106-55c4e311-7833-4079-9dee-ad35f6df5ff0.png"> 

**After:**
<img width="634" alt="image" src="https://user-images.githubusercontent.com/25395/200854956-df2ccc6e-f8e4-4ec2-8c06-af855fa06f19.png">

Benchmarks don't show a convincing win, just tiny improvements close to statistical noise — I guess they don't hit label-dense areas enough, but it's still an improvement (most diagnostic metrics show a positive change, even if tiny):

- [rendering-2d](https://sites.mapbox.com/benchmap-js-results/runs/1150)
- [rendering-3d](https://sites.mapbox.com/benchmap-js-results/runs/1151)
- [loading](https://sites.mapbox.com/benchmap-js-results/runs/1152)
- [style-weighted-all](https://sites.mapbox.com/benchmap-js-results/runs/1153)

The PR also cuts down the bundle size a little (-314 bytes) and improves flow types in a few places around symbol code (replacing `any` with proper typing).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve performance of text and icon placement.</changelog>`
