### PR TITLE
Add dynamic raster tiles support

### DIFF
--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -145,15 +145,7 @@ class VectorTileSource extends Evented implements Source {
 
     reload() {
         this.cancelTileJSONRequest();
-
-        const clearTiles = () => {
-            const sourceCaches = this.map.style._getSourceCaches(this.id);
-            for (const sourceCache of sourceCaches) {
-                sourceCache.clearTiles();
-            }
-        };
-
-        this.load(clearTiles);
+        this.load(() => this.map.style._clearSource(this.id));
     }
 
     setSourceProperty(callback: Function) {

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -21,15 +21,13 @@ const mockDispatcher = wrapDispatcher({
 
 function createSource(options, {transformCallback, customAccessToken} = {}) {
     const source = new VectorTileSource('id', options, mockDispatcher, options.eventedParent);
-    const sourceCache = {clearTiles: () => {}};
 
     source.onAdd({
         transform: {showCollisionBoxes: false},
         _getMapId: () => 1,
         _requestManager: new RequestManager(transformCallback, customAccessToken),
-        _sourceCaches: [sourceCache],
         style: {
-            _getSourceCaches: () => [sourceCache]
+            _clearSource: () => {},
         }
     });
 
@@ -395,7 +393,7 @@ test('VectorTileSource', (t) => {
         const source = createSource({url: '/source.json'});
 
         const loadSpy = t.spy(source, 'load');
-        const clearTilesSpy = t.spy(source.map._sourceCaches[0], 'clearTiles');
+        const clearSourceSpy = t.spy(source.map.style, '_clearSource');
 
         const responseSpy = t.spy((xhr) =>
             xhr.respond(200, {"Content-Type": "application/json"}, JSON.stringify({...sourceFixture, maxzoom: 22})));
@@ -408,8 +406,8 @@ test('VectorTileSource', (t) => {
 
         t.ok(loadSpy.calledOnce);
         t.ok(responseSpy.calledOnce);
-        t.ok(clearTilesSpy.calledOnce);
-        t.ok(clearTilesSpy.calledAfter(responseSpy), 'Tiles should be cleared after TileJSON is loaded');
+        t.ok(clearSourceSpy.calledOnce);
+        t.ok(clearSourceSpy.calledAfter(responseSpy), 'Tiles should be cleared after TileJSON is loaded');
 
         t.end();
     });


### PR DESCRIPTION
This PR adds methods for changing a raster tile source dynamically (e.g. `setTiles`, `setUrl`). Same as in vector tiles in https://github.com/mapbox/mapbox-gl-js/pull/8048.

Closes https://github.com/mapbox/mapbox-gl-js/issues/11982

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>add methods for changing a raster tile source dynamically (e.g. setTiles, setUrl).</changelog>`
