### PR TITLE
Optimization: avoid generating data-driven `fill-outline-color` buffers if `fill-antialias` is `false`

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -415,6 +415,10 @@ export default class ProgramConfiguration {
 
         for (const property in layer.paint._values) {
             if (!filterProperties(property)) continue;
+
+            // optimization: ignore fill-outline-color if it matches fill-color or anti-alias is disabled
+            if ((property: any) === 'fill-outline-color' && ((layer.paint: any).get('fill-antialias') === false || (layer.paint._values: any)['fill-outline-color'] === (layer.paint._values: any)['fill-color'])) continue;
+
             const value = layer.paint.get(property);
             if (!(value instanceof PossiblyEvaluatedPropertyValue) || !supportsPropertyExpression(value.property.specification)) {
                 continue;

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -416,8 +416,8 @@ export default class ProgramConfiguration {
         for (const property in layer.paint._values) {
             if (!filterProperties(property)) continue;
 
-            // optimization: ignore fill-outline-color if it matches fill-color or anti-alias is disabled
-            if ((property: any) === 'fill-outline-color' && ((layer.paint: any).get('fill-antialias') === false || (layer.paint._values: any)['fill-outline-color'] === (layer.paint._values: any)['fill-color'])) continue;
+            // optimization: ignore fill-outline-color if antialias is disabled
+            if ((property: any) === 'fill-outline-color' && ((layer.paint: any).get('fill-antialias') === false)) continue;
 
             const value = layer.paint.get(property);
             if (!(value instanceof PossiblyEvaluatedPropertyValue) || !supportsPropertyExpression(value.property.specification)) {


### PR DESCRIPTION
A quick proof of concept to improve performance of styles that use data-driven `fill-color` in combination with `fill-antialias: false`: avoid generating `fill-outline-color` paint buffers since they would duplicate `fill-color` (with notable GPU memory footprint on heavy layers like `hillshade`) but are not used in practice. Let's see if this makes a difference in benchmarks.

## Launch Checklist

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve performance for fill layers with data-driven color and antialias: false</changelog>`
