### PR TITLE
Add `lines/slope-occlusion` query test to ignores

### DIFF
--- a/test/ignores.json
+++ b/test/ignores.json
@@ -1,7 +1,7 @@
 {
   "query-tests/regressions/mapbox-gl-js#4494": "https://github.com/mapbox/mapbox-gl-js/issues/2716",
   "query-tests/globe/circle/opposite-side-over-north-pole": "skip - needs baseline update",
-  "query-tests/terrain/draped/lines/slope-occlusion": "https://github.com/mapbox/mapbox-gl-js/issues/11726",
+  "query-tests/terrain/draped/lines/slope-occlusion": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11726",
   "render-tests/background-pattern/projected": "skip - patterns not working with projections",
   "render-tests/fill-pattern/projected": "https://github.com/mapbox/mapbox-gl-js/issues/11221",
   "render-tests/debug/tile": "skip - inconsistent text rendering with canvas on different platforms",

--- a/test/ignores.json
+++ b/test/ignores.json
@@ -1,6 +1,7 @@
 {
   "query-tests/regressions/mapbox-gl-js#4494": "https://github.com/mapbox/mapbox-gl-js/issues/2716",
   "query-tests/globe/circle/opposite-side-over-north-pole": "skip - needs baseline update",
+  "query-tests/terrain/draped/lines/slope-occlusion": "https://github.com/mapbox/mapbox-gl-js/issues/11726",
   "render-tests/background-pattern/projected": "skip - patterns not working with projections",
   "render-tests/fill-pattern/projected": "https://github.com/mapbox/mapbox-gl-js/issues/11221",
   "render-tests/debug/tile": "skip - inconsistent text rendering with canvas on different platforms",


### PR DESCRIPTION
This `slope-occlusion` flakiness is getting unbearable, especially when actively working on a PR — every other workflow run has this failure. Let's ignore it for now and figure out the root cause to unignore it later. Ref #11726 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

