### PR TITLE
Fix incorrect transition flag of properties

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4431,7 +4431,7 @@
     },
     "fill-pattern": {
       "type": "resolvedImage",
-      "transition": true,
+      "transition": false,
       "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
         "basic functionality": {
@@ -4575,7 +4575,7 @@
     },
     "fill-extrusion-pattern": {
       "type": "resolvedImage",
-      "transition": true,
+      "transition": false,
       "doc": "Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
         "basic functionality": {
@@ -4987,7 +4987,7 @@
       "value": "number",
       "doc": "Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "minimum": 0,
-      "transition": true,
+      "transition": false,
       "units": "line widths",
       "requires": [
         {
@@ -5016,7 +5016,7 @@
     },
     "line-pattern": {
       "type": "resolvedImage",
-      "transition": true,
+      "transition": false,
       "doc": "Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
         "basic functionality": {
@@ -6396,7 +6396,7 @@
     },
     "background-pattern": {
       "type": "resolvedImage",
-      "transition": true,
+      "transition": false,
       "doc": "Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
         "basic functionality": {


### PR DESCRIPTION
Seems like the specification is incorrect as we don't actually support transitioning of properties with image types.
There's no implementation for image transitioning and currently it just works like as a hard switch when another style is loaded with different image content, as illustrated below:

https://user-images.githubusercontent.com/2576246/201078211-a8d8b327-542f-47bc-b7b7-865f3c9412ea.mov



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix incorrect transition flag in *-pattern and line-dasharray properties</changelog>`
