### PR TITLE
Fix crash with multi-line labels along lines + RTL Text plugin

### DIFF
--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -437,7 +437,7 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
     const lineOffsetX = symbol.lineOffsetX * fontScale;
     const lineOffsetY = symbol.lineOffsetY * fontScale;
 
-    let placedGlyphs;
+    let placedGlyphs: Array<PlacedGlyph> = [];
     if (symbol.numGlyphs > 1) {
         const glyphEndIndex = symbol.glyphStartIndex + symbol.numGlyphs;
         const lineStartIndex = symbol.lineStartIndex;
@@ -465,10 +465,10 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
 
         placedGlyphs = [firstAndLastGlyph.first];
         for (let glyphIndex = symbol.glyphStartIndex + 1; glyphIndex < glyphEndIndex - 1; glyphIndex++) {
-            // Since first and last glyph fit on the line, we're sure that the rest of the glyphs can be placed
-            // $FlowFixMe
-            placedGlyphs.push(placeGlyphAlongLine(fontScale * glyphOffsetArray.getoffsetX(glyphIndex), lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, symbol.segment,
-                lineStartIndex, lineEndIndex, lineVertexArray, labelPlaneMatrix, projectionCache, getElevation, false, false, projection, tileID, pitchWithMap));
+            const glyph = placeGlyphAlongLine(fontScale * glyphOffsetArray.getoffsetX(glyphIndex), lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, symbol.segment,
+                lineStartIndex, lineEndIndex, lineVertexArray, labelPlaneMatrix, projectionCache, getElevation, false, false, projection, tileID, pitchWithMap);
+            if (!glyph) return {notEnoughRoom: true};
+            placedGlyphs.push(glyph);
         }
         placedGlyphs.push(firstAndLastGlyph.last);
     } else {
@@ -503,7 +503,7 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
     }
 
     if (globeExtVertexArray) {
-        for (const glyph: any of placedGlyphs) {
+        for (const glyph of placedGlyphs) {
             updateGlobeVertexNormal(globeExtVertexArray, dynamicLayoutVertexArray.length + 0, glyph.up[0], glyph.up[1], glyph.up[2]);
             updateGlobeVertexNormal(globeExtVertexArray, dynamicLayoutVertexArray.length + 1, glyph.up[0], glyph.up[1], glyph.up[2]);
             updateGlobeVertexNormal(globeExtVertexArray, dynamicLayoutVertexArray.length + 2, glyph.up[0], glyph.up[1], glyph.up[2]);
@@ -511,7 +511,7 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
             addDynamicAttributes(dynamicLayoutVertexArray, glyph.point[0], glyph.point[1], glyph.point[2], glyph.angle);
         }
     } else {
-        for (const glyph: any of placedGlyphs) {
+        for (const glyph of placedGlyphs) {
             addDynamicAttributes(dynamicLayoutVertexArray, glyph.point[0], glyph.point[1], glyph.point[2], glyph.angle);
         }
     }


### PR DESCRIPTION
A quick fix for the [Studio crash with multi-line labels along lines](https://mapbox.atlassian.net/browse/GLJS-210). Currently the placement code assumes that if the first and last glyphs can be placed, then those in the middle can too, but this assumption breaks with multi-line labels, which normally aren't supported at the moment, but work if you load the RTL plugin (which Studio loads by default). 

Note how this could have been caught earlier if we didn't use `any` when typing the code with Flow.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a bug where multi-line labels along lines combined with the RTL text plugin could crash the map.</changelog>`
