### PR TITLE
Add a basic page for debugging render tests

### DIFF
--- a/debug/render-test.html
+++ b/debug/render-test.html
@@ -24,7 +24,7 @@ fetch(`http://localhost:9966/test/integration/render-tests/${test}/style.json`).
         fadeDuration = 0,
         optimizeForTerrain = false,
         localIdeographFontFamily = false,
-        projection
+        projection, debug
     } = style.metadata.test;
 
     const container = document.getElementById('map');
@@ -45,6 +45,8 @@ fetch(`http://localhost:9966/test/integration/render-tests/${test}/style.json`).
         attributionControl: false
     });
     map.removeControl(map._logoControl);
+
+    if (debug) map.showTileBoundaries = true;
 });
 
 </script>

--- a/debug/render-test.html
+++ b/debug/render-test.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        #map { border: 1px solid #ccc; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+const test = 'text-writing-mode/line_label/mixed-multiline-horizontal-mode';
+
+fetch(`http://localhost:9966/test/integration/render-tests/${test}/style.json`).then(req => req.json()).then(style => {
+    const {
+        width, height,
+        fadeDuration = 0,
+        optimizeForTerrain = false,
+        localIdeographFontFamily = false,
+        projection
+    } = style.metadata.test;
+
+    const container = document.getElementById('map');
+    container.style.width = width + 'px';
+    container.style.height = height + 'px';
+
+    const transformRequest = url => ({url: url.replace('local://', 'http://localhost:9966/test/integration/')});
+
+    const map = window.map = new mapboxgl.Map({
+        container,
+        style,
+        transformRequest,
+        fadeDuration,
+        optimizeForTerrain,
+        localIdeographFontFamily,
+        projection,
+        interactive: false,
+        attributionControl: false
+    });
+    map.removeControl(map._logoControl);
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
I found myself creating temporary debug pages out of render tests very often, it's been a chore, so I made this simple debug page for quickly getting some render test running locally. It's not meant to reflect the render test environment 100%, just a starting point to quickly get something close to what the render test was intended to cover. We might want to expand this later (e.g. add support for `operations`).