### PR TITLE
Add 3D lighting mode to 2D layer shaders

### DIFF
--- a/src/shaders/_prelude_lighting.glsl
+++ b/src/shaders/_prelude_lighting.glsl
@@ -1,0 +1,16 @@
+#ifdef LIGHTING_3D_MODE
+
+uniform vec3 u_lighting_ambient_color;
+uniform vec3 u_lighting_directional_dir;        // Direction towards the light source
+uniform vec3 u_lighting_directional_color;
+
+vec3 apply_lighting(vec3 color) {
+    float NdotL = u_lighting_directional_dir.z;
+    return color * (u_lighting_ambient_color + u_lighting_directional_color * NdotL);
+}
+
+vec4 apply_lighting(vec4 color) {
+    return vec4(apply_lighting(color.rgb), color.a);
+}
+
+#endif

--- a/src/shaders/background.fragment.glsl
+++ b/src/shaders/background.fragment.glsl
@@ -1,9 +1,17 @@
 uniform vec4 u_color;
 uniform float u_opacity;
 
-void main() {
-    vec4 out_color = u_color;
+#ifdef LIGHTING_3D_MODE
+varying vec4 v_color;
+#endif
 
+void main() {
+    vec4 out_color;
+#ifdef LIGHTING_3D_MODE
+    out_color = v_color;
+#else
+    out_color = u_color;
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/background.vertex.glsl
+++ b/src/shaders/background.vertex.glsl
@@ -2,9 +2,17 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
+#ifdef LIGHTING_3D_MODE
+uniform vec4 u_color;
+varying vec4 v_color;
+#endif
+
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
+#ifdef LIGHTING_3D_MODE
+    v_color = apply_lighting(u_color);
+#endif
 #ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif

--- a/src/shaders/background_pattern.fragment.glsl
+++ b/src/shaders/background_pattern.fragment.glsl
@@ -12,6 +12,9 @@ void main() {
     vec2 pos = mix(u_pattern_tl / u_texsize, u_pattern_br / u_texsize, imagecoord);
     vec4 out_color = texture2D(u_image, pos);
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/circle.fragment.glsl
+++ b/src/shaders/circle.fragment.glsl
@@ -34,6 +34,9 @@ void main() {
 
     vec4 out_color = mix(color * opacity, stroke_color * stroke_opacity, color_t);
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -7,6 +7,9 @@ void main() {
 
     vec4 out_color = color;
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -11,6 +11,9 @@ void main() {
     float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
     vec4 out_color = outline_color;
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -25,6 +25,9 @@ void main() {
 
     vec4 out_color = texture2D(u_image, pos);
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -18,6 +18,9 @@ void main() {
     vec2 pos = mix(pattern_tl / u_texsize, pattern_br / u_texsize, imagecoord);
     vec4 out_color = texture2D(u_image, pos);
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/hillshade.fragment.glsl
+++ b/src/shaders/hillshade.fragment.glsl
@@ -44,6 +44,9 @@ void main() {
     vec4 shade_color = mix(u_shadow, u_highlight, shade) * sin(scaledSlope) * clamp(intensity * 2.0, 0.0, 1.0);
     gl_FragColor = accent_color * (1.0 - shade_color.a) + shade_color;
 
+#ifdef LIGHTING_3D_MODE
+    gl_FragColor = apply_lighting(gl_FragColor);
+#endif
 #ifdef FOG
     gl_FragColor = fog_dither(fog_apply_premultiplied(gl_FragColor, v_fog_pos));
 #endif

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -84,6 +84,9 @@ void main() {
     }
 #endif
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -49,6 +49,9 @@ void main() {
     vec2 pos = mix(pattern_tl * texel_size - texel_size, pattern_br * texel_size + texel_size, vec2(x, y));
     vec4 color = texture2D(u_image, pos);
 
+#ifdef LIGHTING_3D_MODE
+    color = apply_lighting(color);
+#endif
 #ifdef FOG
     color = fog_dither(fog_apply_premultiplied(color, v_fog_pos));
 #endif

--- a/src/shaders/raster.fragment.glsl
+++ b/src/shaders/raster.fragment.glsl
@@ -46,6 +46,9 @@ void main() {
 
     vec3 out_color = mix(u_high_vec, u_low_vec, rgb);
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
 #ifdef FOG
     out_color = fog_dither(fog_apply(out_color, v_fog_pos));
 #endif


### PR DESCRIPTION
This pull request adds a new simple lighting model to shaders of selected 2D layers. The new model is not complete and not intended to be used in gl-js. No performance changes/regressions expected as all changes are guarded by preprocessor defines.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
