### PR TITLE
Simplify and speed up render tests a bit

### DIFF
--- a/test/integration/lib/generate-fixture-json.js
+++ b/test/integration/lib/generate-fixture-json.js
@@ -24,12 +24,11 @@ export function generateFixtureJson(rootDirectory, suiteDirectory, outputDirecto
     }
 
     for (const fixturePath of allPaths) {
-        const testName = path.dirname(fixturePath);
         const fileName = path.basename(fixturePath);
         const extension = path.extname(fixturePath);
         try {
             if (extension === '.json') {
-                let json = parseJsonFromFile(fixturePath);
+                const json = parseJsonFromFile(fixturePath);
 
                 //Special case for style json which needs some preprocessing
                 if (fileName === 'style.json') {

--- a/test/integration/lib/generate-fixture-json.js
+++ b/test/integration/lib/generate-fixture-json.js
@@ -33,7 +33,8 @@ export function generateFixtureJson(rootDirectory, suiteDirectory, outputDirecto
 
                 //Special case for style json which needs some preprocessing
                 if (fileName === 'style.json') {
-                    json = processStyle(testName, json);
+                    // 7357 is testem's default port
+                    localizeURLs(json, 7357);
                 }
 
                 allFiles[fixturePath] = json;
@@ -84,22 +85,4 @@ export function getAllFixtureGlobs(rootDirectory, suiteDirectory) {
 
 function parseJsonFromFile(filePath) {
     return JSON.parse(fs.readFileSync(filePath, {encoding: 'utf8'}));
-}
-
-function processStyle(testName, style) {
-    const clone = JSON.parse(JSON.stringify(style));
-    // 7357 is testem's default port
-    localizeURLs(clone, 7357);
-
-    clone.metadata = clone.metadata || {};
-    clone.metadata.test = Object.assign({
-        testName,
-        width: 512,
-        height: 512,
-        pixelRatio: 1,
-        recycleMap: false,
-        allowed: 0.00015
-    }, clone.metadata.test);
-
-    return clone;
 }

--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -36,7 +36,6 @@ export default function (directory, implementation, options, run) {
                 width: 512,
                 height: 512,
                 pixelRatio: 1,
-                recycleMap: options.recycleMap || false,
                 allowed: 0.00015
             }, style.metadata.test);
 
@@ -188,7 +187,7 @@ export default function (directory, implementation, options, run) {
         const resultsShell = resultsTemplate({unsuccessful, tests, stats, shuffle: options.shuffle, seed: options.seed})
             .split('<!-- results go here -->');
 
-        const p = path.join(directory, options.recycleMap ? 'index-recycle-map.html' : 'index.html');
+        const p = path.join(directory, 'index.html');
         const out = fs.createWriteStream(p);
 
         const q = queue(1);

--- a/test/integration/lib/localize-urls.js
+++ b/test/integration/lib/localize-urls.js
@@ -19,6 +19,7 @@ export default function localizeURLs(style, port) {
                     localizeStyleURLs(op[1], port);
                     return;
                 }
+                if (op[1].startsWith('mapbox://')) return;
 
                 let styleJSON;
                 try {

--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -77,7 +77,7 @@ async function runTest(t) {
             width: 512,
             height: 512,
             pixelRatio: 1
-            ...(style.metadata && style.metadata.test);
+            ...(style.metadata && style.metadata.test)
         }
         const skipLayerDelete = style.metadata.skipLayerDelete;
 

--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -76,8 +76,8 @@ async function runTest(t) {
         options = {
             width: 512,
             height: 512,
-            pixelRatio: 1
-            ...(style.metadata && style.metadata.test)
+            pixelRatio: 1,
+            ...(style.metadata && style.metadata.test || {})
         }
         const skipLayerDelete = style.metadata.skipLayerDelete;
 

--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -73,7 +73,12 @@ async function runTest(t) {
             throw new Error(`Error occured while parsing expected.json: ${style.message}`);
         }
 
-        options = style.metadata.test;
+        options = {
+            width: 512,
+            height: 512,
+            pixelRatio: 1
+            ...(style.metadata && style.metadata.test);
+        }
         const skipLayerDelete = style.metadata.skipLayerDelete;
 
         window.devicePixelRatio = options.pixelRatio;

--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -77,8 +77,8 @@ async function runTest(t) {
             width: 512,
             height: 512,
             pixelRatio: 1,
-            ...(style.metadata && style.metadata.test || {})
-        }
+            ...((style.metadata && style.metadata.test) || {})
+        };
         const skipLayerDelete = style.metadata.skipLayerDelete;
 
         window.devicePixelRatio = options.pixelRatio;

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -50,12 +50,7 @@ tape.onFinish(() => {
 });
 
 for (const testName in fixtures) {
-    tape(testName, {timeout: 20000}, ensureTeardown);
-}
-
-function ensureTeardown(t) {
-    const testName = t.name;
-    const options = {timeout: 5000};
+    const options = {timeout: 20000};
     if (testName in ignores) {
         const ignoreType = ignores[testName];
         if (/^skip/.test(ignoreType)) {
@@ -64,9 +59,10 @@ function ensureTeardown(t) {
             options.todo = true;
         }
     }
+    tape(testName, options, runTest);
+}
 
-    t.test(testName, options, runTest);
-
+function ensureTeardown() {
     //Teardown all global resources
     //Cleanup WebGL context and map
     if (map) {
@@ -83,10 +79,11 @@ function ensureTeardown(t) {
 
     //Restore timers
     mapboxgl.restoreNow();
-    t.end();
 }
 
 async function runTest(t) {
+    t.teardown(ensureTeardown);
+
     let style, options;
     // This needs to be read from the `t` object because this function runs async in a closure.
     const currentTestName = t.name;
@@ -333,7 +330,7 @@ function drawImage(canvas, ctx, src, getImageData = true) {
 function createCanvas(id = 'fake-canvas') {
     const canvas = window.document.createElement('canvas');
     canvas.id = id;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', {willReadFrequently: true});
     return {canvas, ctx};
 }
 

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -27,6 +27,7 @@ const container = document.createElement('div');
 container.style.position = 'fixed';
 container.style.bottom = '10px';
 container.style.right = '10px';
+container.style.background = 'white';
 document.body.appendChild(container);
 
 // Container used to store all fake canvases added via addFakeCanvas operation
@@ -99,7 +100,14 @@ async function runTest(t) {
             throw new Error(`Error occured while parsing style.json: ${style.message}`);
         }
 
-        options = style.metadata.test;
+        options = {
+            width: 512,
+            height: 512,
+            pixelRatio: 1,
+            recycleMap: false,
+            allowed: 0.00015,
+            ...(style.metadata && style.metadata.test)
+        };
 
         // there may be multiple expected images, covering different platforms
         const expectedPaths = [];
@@ -255,7 +263,7 @@ async function runTest(t) {
             const pass = minDiff <= options.allowed;
             const testMetaData = {
                 name: currentTestName,
-                minDiff: minDiff.toFixed(5),
+                minDiff: Math.round(100000 * minDiff) / 100000,
                 status: t._todo ? 'todo' : pass ? 'passed' : 'failed'
             };
             t.ok(pass || t._todo, t.name);

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -105,7 +105,7 @@ async function runTest(t) {
             height: 512,
             pixelRatio: 1,
             allowed: 0.00015,
-            ...(style.metadata && style.metadata.test)
+            ...(style.metadata && style.metadata.test || {})
         };
 
         // there may be multiple expected images, covering different platforms

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -104,7 +104,6 @@ async function runTest(t) {
             width: 512,
             height: 512,
             pixelRatio: 1,
-            recycleMap: false,
             allowed: 0.00015,
             ...(style.metadata && style.metadata.test)
         };

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -105,7 +105,7 @@ async function runTest(t) {
             height: 512,
             pixelRatio: 1,
             allowed: 0.00015,
-            ...(style.metadata && style.metadata.test || {})
+            ...((style.metadata && style.metadata.test) || {})
         };
 
         // there may be multiple expected images, covering different platforms

--- a/test/util/html_generator.js
+++ b/test/util/html_generator.js
@@ -47,7 +47,7 @@ input { position: absolute; opacity: 0; z-index: -1;}
 input:checked + .tab-label { filter: brightness(90%); };
 input:checked + .tab-label::after { transform: rotate(90deg); }
 input:checked ~ .tab-content { max-height: 100vh; padding: 1em; border: 1px solid #eee; border-top: 0; border-radius: 5px; }
-iframe { pointer-events: none; }
+iframe { pointer-events: none; opacity: 0; }
 `;
 
 const stats = {

--- a/test/util/html_generator.js
+++ b/test/util/html_generator.js
@@ -119,13 +119,13 @@ export function setupHTML() {
 export function updateHTML(testData) {
     const status = testData.status;
     stats[status]++;
-
-    testData["color"] = colors[status];
-    testData["id"] = `${status}Test-${stats[status]}`;
     counterDom[status].innerHTML = stats[status];
 
     // skip adding passing tests to report in CI mode
     if (CI && status === 'passed') return;
+
+    testData["color"] = colors[status];
+    testData["id"] = `${status}Test-${stats[status]}`;
     const resultHTMLFrag = document.createRange().createContextualFragment(generateResultHTML({r: testData}));
     resultsContainer.appendChild(resultHTMLFrag);
 }


### PR DESCRIPTION
In this PR, I'm simplifying some of the code of our render test suite harness to make it simpler and also avoid some redundant work so that it would run faster — hopefully it should speed up the tests (which run the longest on CI, making them the weakest link) by at least 30-40s. Some of the changes:

- Avoid rasterizing and converting actual/expected/diff canvases to base64 for passing tests on CI (since those aren't used in output later).
- Use `willReadFrequently` Canvas2D option to make sure `getImageData` is fast.
- Simplify code that reads pixels from the WebGL context, avoiding manual flipping/unpremultiplying.
- Make the bundle containing test fixtures smaller by moving default values to the consumer code.
- Fix the "ENOENT File not found" error when launching tests that always bugged me.
- Cleaner teardown setup (newer `tape` has `t.teardown(callback)`).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
