### PR TITLE
Fix race condition when placing multiline line labels

### DIFF
--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -467,7 +467,11 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
             // Since first and last glyph fit on the line, the rest of the glyphs can be placed too, but check to make sure
             const glyph = placeGlyphAlongLine(fontScale * glyphOffsetArray.getoffsetX(glyphIndex), lineOffsetX, lineOffsetY, flip, anchorPoint, tileAnchorPoint, segment,
                 lineStartIndex, lineEndIndex, lineVertexArray, labelPlaneMatrix, projectionCache, getElevation, false, false, projection, tileID, pitchWithMap);
-            if (!glyph) return {notEnoughRoom: true};
+            if (!glyph) {
+                // undo previous glyphs of the symbol if it doesn't fit; it will be filled with hideGlyphs instead
+                dynamicLayoutVertexArray.length -= 4 * (glyphIndex - glyphStartIndex);
+                return {notEnoughRoom: true};
+            }
             addGlyph(glyph);
         }
         addGlyph(firstAndLastGlyph.last);


### PR DESCRIPTION
A quick follow-up to #12377. When a glyph in the middle of a multiline line label can't be placed, undo previously placed glyphs of the same label so that the total count always matches.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality (no idea how to test this, it requires a lot of wild zooming to trigger)
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
