### PR TITLE
Optimize image rasterization with `willReadFrequently` hints

### DIFF
--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -25,7 +25,8 @@ class RasterDEMTileWorkerSource {
         if (!this.offscreenCanvas || !this.offscreenCanvasContext) {
             // Dem tiles are typically 256x256
             this.offscreenCanvas = new OffscreenCanvas(imgBitmap.width, imgBitmap.height);
-            this.offscreenCanvasContext = this.offscreenCanvas.getContext('2d');
+            // $FlowIssue[extra-arg]: internal Flow types don't yet know about willReadFrequently
+            this.offscreenCanvasContext = this.offscreenCanvas.getContext('2d', {willReadFrequently: true});
         }
 
         this.offscreenCanvas.width = imgBitmap.width;

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -45,7 +45,7 @@ const exported = {
             canvas = window.document.createElement('canvas');
         }
 
-        const context = canvas.getContext('2d');
+        const context = canvas.getContext('2d', {willReadFrequently: true});
         if (!context) {
             throw new Error('failed to create canvas 2d context');
         }


### PR DESCRIPTION
When using `getImageData` (e.g. for DEM tiles), we reuse the same canvas object and then read it repeatedly for different images. Recent versions of Chrome started throwing this warning in the console:

> Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently

This PR adds `willReadFrequently`  hints in two places where it's needed to make sure that getting data out of loaded images is as fast as possible.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve performance of loading terrain data</changelog>`
