### PR TITLE
Add missing queryTerrainElevation to docs

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -749,6 +749,7 @@ class Camera extends Evented {
      *
      * In order to guarantee that the terrain data is loaded ensure that the geographical location is visible and wait for the `idle` event to occur.
      *
+     * @memberof Map#
      * @param {LngLatLike} lnglat The geographical location at which to query.
      * @param {ElevationQueryOptions} [options] Options object.
      * @param {boolean} [options.exaggerated=true] When `true` returns the terrain elevation with the value of `exaggeration` from the style already applied.

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -743,6 +743,8 @@ class Camera extends Evented {
         return {center: tr.center, zoom, bearing, pitch};
     }
 
+    /** @section {Querying features} */
+
     /**
      * Queries the currently loaded data for elevation at a geographical location. The elevation is returned in `meters` relative to mean sea-level.
      * Returns `null` if `terrain` is disabled or if terrain data for the location hasn't been loaded yet.
@@ -768,6 +770,11 @@ class Camera extends Evented {
         }
         return null;
     }
+
+    /** @section {Camera}
+     * @method
+     * @instance
+     * @memberof Map */
 
     /**
      * Calculate the center of these two points in the viewport and use


### PR DESCRIPTION
This PR adds a missing `@memberof Map#` to queryTerrainElevation, which seems to be the cause of it missing from the docs. I also had to surround it with `@section` metadata since everything else in this file is attached to the "Camera" section. I've marked it "Draft" state, pending an actual test of the docs.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
