### PR TITLE
Remove redundant network requests in render/query tests

### DIFF
--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -98,10 +98,13 @@ async function runTest(t) {
             skew: options.skew || [0, 0],
             fadeDuration: options.fadeDuration || 0,
             localIdeographFontFamily: options.localIdeographFontFamily || false,
-            crossSourceCollisions: typeof options.crossSourceCollisions === "undefined" ? true : options.crossSourceCollisions
+            crossSourceCollisions: typeof options.crossSourceCollisions === "undefined" ? true : options.crossSourceCollisions,
+            performanceMetricsCollection: false
         });
 
         map.repaint = true;
+        map._authenticate = () => {};
+
         await map.once('load');
         //3. Run the operations on the map
         await applyOperations(map, options);

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -149,6 +149,7 @@ async function runTest(t) {
             localIdeographFontFamily: options.localIdeographFontFamily || false,
             projection: options.projection,
             crossSourceCollisions: typeof options.crossSourceCollisions === "undefined" ? true : options.crossSourceCollisions,
+            performanceMetricsCollection: false,
             transformRequest: (url, resourceType) => {
                 // some tests have the port hardcoded to 2900
                 // this makes that backwards compatible
@@ -163,6 +164,7 @@ async function runTest(t) {
         });
 
         map.repaint = true;
+        map._authenticate = () => {};
 
         // override internal timing to enable precise wait operations
         window._renderTestNow = 0;


### PR DESCRIPTION
Disable map loads and performance telemetry network requests when running render and query tests. Currently they're done for every test, which floods the network on CI and possibly contributes to the tests being more flaky. The PR seems to improve test running time by 10–30s.