### PR TITLE
Store explicit projection instead of runtime projection in metrics

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3284,7 +3284,7 @@ class Map extends Camera {
                     visibilityHidden: this._visibilityHidden,
                     terrainEnabled: !!this.painter.style.getTerrain(),
                     fogEnabled: !!this.painter.style.getFog(),
-                    projection: this.painter.transform.projection,
+                    projection: this.getProjection().name,
                     zoom: this.transform.zoom,
                     renderer: this.painter.context.renderer,
                     vendor: this.painter.context.vendor

--- a/src/util/live_performance.js
+++ b/src/util/live_performance.js
@@ -2,7 +2,6 @@
 
 import window from './window.js';
 import {version as sdkVersion} from '../../package.json';
-import type Projection from '../geo/projection/projection.js';
 import {
     isMapboxHTTPStyleURL,
     isMapboxHTTPTileJSONURL,
@@ -23,7 +22,7 @@ export type LivePerformanceData = {
     height: number,
     terrainEnabled: boolean,
     fogEnabled: boolean,
-    projection: Projection,
+    projection: string,
     zoom: number,
     renderer: ?string,
     vendor: ?string
@@ -150,7 +149,7 @@ export function getLivePerformanceMetrics(data: LivePerformanceData): LivePerfor
     addMetric(metrics.attributes, "style", getStyle(resourceTimers));
     addMetric(metrics.attributes, "terrainEnabled", data.terrainEnabled ? "true" : "false");
     addMetric(metrics.attributes, "fogEnabled", data.fogEnabled ? "true" : "false");
-    addMetric(metrics.attributes, "projection", data.projection.name);
+    addMetric(metrics.attributes, "projection", data.projection);
     addMetric(metrics.attributes, "zoom", data.zoom);
 
     addMetric(metrics.metadata, "devicePixelRatio", devicePixelRatio);

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -642,7 +642,7 @@ export const postTurnstileEvent: (tileUrls: Array<string>, customAccessToken?: ?
 const mapLoadEvent_ = new MapLoadEvent();
 export const postMapLoadEvent: (number, string, ?string, EventCallback) => void = mapLoadEvent_.postMapLoadEvent.bind(mapLoadEvent_);
 
-const performanceEvent_ = new PerformanceEvent();
+export const performanceEvent_: PerformanceEvent = new PerformanceEvent();
 export const postPerformanceEvent: (?string, LivePerformanceData) => void = performanceEvent_.postPerformanceEvent.bind(performanceEvent_);
 
 const mapSessionAPI_ = new MapSessionAPI();

--- a/test/unit/util/live_performance.test.js
+++ b/test/unit/util/live_performance.test.js
@@ -196,6 +196,7 @@ test('LivePerformance', (t) => {
             {name: 'style', value: 'mapbox://styles/mapbox/streets-v11'},
             {name: 'terrainEnabled', value: 'false'},
             {name: 'fogEnabled', value: 'false'},
+            {name: 'projection', value: 'mercator'},
             {name: 'zoom', value: '5'}
         ]);
         t.end();

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -565,6 +565,7 @@ test("mapbox", (t) => {
             checkMetric(performanceEvent.metadata, 'webglVendor', 'webgl vendor');
             checkMetric(performanceEvent.metadata, 'webglRenderer', 'webgl renderer');
             checkMetric(performanceEvent.attributes, 'terrainEnabled', 'false');
+            checkMetric(performanceEvent.attributes, 'projection', 'mercator');
             checkMetric(performanceEvent.attributes, 'fogEnabled', 'false');
 
             t.end();


### PR DESCRIPTION
Small fix to live performance metrics: Store explicit projection instead of runtime projection in metrics.

We can always infer the runtime projection from a given zoom level and a given explicit projection, but not the other way around. For example, when seeing 'mercator' from the metrics, it's not possible to know if mercator is set as a consequence of a transition from globe or an explicit mercator projection. Storing the explicit projection allows for both: retrieve the runtime projection for a given zoom + know what the user wants as a global projection.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
