### PR TITLE
Remove function only added for IE11 compatibility

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3501,9 +3501,9 @@ class Map extends Camera {
         this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
 
-        removeNode(this._canvasContainer);
-        removeNode(this._controlContainer);
-        removeNode(this._missingCSSCanary);
+        this._canvasContainer.remove();
+        this._controlContainer.remove();
+        this._missingCSSCanary.remove();
 
         this._canvas = (undefined: any);
         this._canvasContainer = (undefined: any);
@@ -3754,12 +3754,6 @@ class Map extends Camera {
 }
 
 export default Map;
-
-function removeNode(node) {
-    if (node.parentNode) {
-        node.parentNode.removeChild(node);
-    }
-}
 
 /**
  * Interface for interactive controls added to the map. This is a


### PR DESCRIPTION
The removeNode helper function was introduced in #1905 for IE11 compatibility. As IE11 is no longer supported it can be removed and replaced with Node.remove() calls.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
