### PR TITLE
Add missing precision qualifiers to shader uniforms

### DIFF
--- a/src/shaders/_prelude_lighting.glsl
+++ b/src/shaders/_prelude_lighting.glsl
@@ -1,8 +1,8 @@
 #ifdef LIGHTING_3D_MODE
 
-uniform vec3 u_lighting_ambient_color;
-uniform vec3 u_lighting_directional_dir;        // Direction towards the light source
-uniform vec3 u_lighting_directional_color;
+uniform mediump vec3 u_lighting_ambient_color;
+uniform mediump vec3 u_lighting_directional_dir;        // Direction towards the light source
+uniform mediump vec3 u_lighting_directional_color;
 
 vec3 apply_lighting(vec3 color) {
     float NdotL = u_lighting_directional_dir.z;


### PR DESCRIPTION
This pull request adds missing precision qualifiers to shader uniforms declared in `_prelude.lighting.glsl`. These variables are not used in gl-js so the change affects only native rendering.

The fix has been validated on an android device where the shader compilation initially failed due missing precision qualifiers.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
