### PR TITLE
Refactor render tests

### DIFF
--- a/test/integration/lib/operation-handlers.js
+++ b/test/integration/lib/operation-handlers.js
@@ -160,7 +160,7 @@ export function applyOperations(map, options) {
 function updateCanvas(imagePath) {
     return new Promise((resolve) => {
         const canvas = window.document.getElementById('fake-canvas');
-        const ctx = canvas.getContext('2d');
+        const ctx = canvas.getContext('2d', {willReadFrequently: true});
         const image = new Image();
         image.src = imagePath.replace('./', '');
         image.onload = () => {

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -54,7 +54,7 @@ tape.onFinish(() => {
 });
 
 let osIgnore;
-let timeout = 20000;
+let timeout = 25000;
 
 if (process.env.CI) {
     // On CI, MacOS and Windows run on virtual machines.

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -203,7 +203,6 @@ async function renderMap(style, options) {
         }
     });
 
-    map.repaint = true;
     map._authenticate = () => {};
 
     // override internal timing to enable precise wait operations
@@ -300,11 +299,6 @@ function calculateDiff(map, {w, h}, actualImageData, expectedImages) {
 }
 
 async function runTest(t) {
-    const errors = [];
-    const onError = (error) => {
-        errors.push(error);
-    };
-
     t.teardown(ensureTeardown);
 
     // This needs to be read from the `t` object because this function runs async in a closure.
@@ -320,8 +314,6 @@ async function runTest(t) {
 
         //2. Initialize the Map
         map = await renderMap(style, options);
-        map.on('error', onError);
-
         const {w, h} = getViewportSize(map);
         const actualImageData = getActualImageData(map, {w, h}, options);
 
@@ -340,8 +332,7 @@ async function runTest(t) {
             name: currentTestName,
             minDiff: Math.round(100000 * minDiff) / 100000,
             status: t._todo ? 'todo' : pass ? 'passed' : 'failed',
-            style: pass ? 'ok' : map.getStyle(),
-            mapErrors: errors
+            style: map.getStyle(),
         };
 
         t.ok(pass || t._todo, t.name);
@@ -383,9 +374,6 @@ async function runTest(t) {
         t.error(e);
         updateHTML({name: t.name, status:'failed', jsonDiff: e.message});
     }
-
-    map.off('error', onError);
-    t.end();
 }
 
 function drawImage(canvas, ctx, src, getImageData = true) {

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -54,7 +54,7 @@ tape.onFinish(() => {
 });
 
 let osIgnore;
-let timeout = 25000;
+let timeout = 30000;
 
 if (process.env.CI) {
     // On CI, MacOS and Windows run on virtual machines.
@@ -230,7 +230,7 @@ async function renderMap(style, options) {
 
     //3. Run the operations on the map
     await applyOperations(map, options);
-    map.repaint = false;
+    await map.on('idle');
 
     return map;
 }

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -109,207 +109,247 @@ function ensureTeardown() {
     mapboxgl.restoreNow();
 }
 
+function parseStyle(currentFixture) {
+    const style = currentFixture.style;
+    if (!style) {
+        throw new Error('style.json is missing');
+    }
+
+    if (style.PARSE_ERROR) {
+        throw new Error(`Error occured while parsing style.json: ${style.message}`);
+    }
+
+    return style;
+}
+
+function parseOptions(currentFixture, style) {
+    const options = {
+        width: 512,
+        height: 512,
+        pixelRatio: 1,
+        allowed: 0.00015,
+        ...((style.metadata && style.metadata.test) || {})
+    };
+
+    return options;
+}
+
+async function setupLayout(options) {
+    window.devicePixelRatio = options.pixelRatio;
+    container.style.width = `${options.width}px`;
+    container.style.height = `${options.height}px`;
+
+    if (options.addFakeCanvas) {
+        const {canvas, ctx} = createCanvas(options.addFakeCanvas.id);
+        const src = options.addFakeCanvas.image.replace('./', '');
+        await drawImage(canvas, ctx, src, false);
+        fakeCanvasContainer.appendChild(canvas);
+    }
+}
+
+async function getExpectedImages(currentTestName) {
+    const currentFixture = fixtures[currentTestName];
+
+    // there may be multiple expected images, covering different platforms
+    const expectedPaths = [];
+    for (const prop in currentFixture) {
+        if (prop.indexOf('expected') > -1) {
+            let path = `${currentTestName}/${prop}.png`;
+            // regression tests with # in the name need to be sanitized
+            path = encodeURIComponent(path);
+            expectedPaths.push(path);
+        }
+    }
+
+    // if we have multiple expected images, we'll compare against each one and pick the one with
+    // the least amount of difference; this is useful for covering features that render differently
+    // depending on platform, i.e. heatmaps use half-float textures for improved rendering where supported
+    const expectedImages = await Promise.all(expectedPaths.map((path) => drawImage(expectedCanvas, expectedCtx, path)));
+
+    if (!process.env.UPDATE && expectedImages.length === 0) {
+        throw new Error('No expected*.png files found; did you mean to run tests with UPDATE=true?');
+    }
+
+    return expectedImages;
+}
+
+async function renderMap(style, options) {
+    mapboxgl.accessToken = 'pk.eyJ1IjoibWFwYm94LWdsLWpzIiwiYSI6ImNram9ybGI1ajExYjQyeGxlemppb2pwYjIifQ.LGy5UGNIsXUZdYMvfYRiAQ';
+    map = new mapboxgl.Map({
+        container,
+        style,
+        classes: options.classes,
+        interactive: false,
+        attributionControl: false,
+        preserveDrawingBuffer: true,
+        axonometric: options.axonometric || false,
+        skew: options.skew || [0, 0],
+        fadeDuration: options.fadeDuration || 0,
+        optimizeForTerrain: options.optimizeForTerrain || false,
+        localIdeographFontFamily: options.localIdeographFontFamily || false,
+        projection: options.projection,
+        crossSourceCollisions: typeof options.crossSourceCollisions === "undefined" ? true : options.crossSourceCollisions,
+        performanceMetricsCollection: false,
+        transformRequest: (url, resourceType) => {
+            // some tests have the port hardcoded to 2900
+            // this makes that backwards compatible
+            if (resourceType === 'Tile') {
+                const transformedUrl = new URL(url);
+                transformedUrl.port = '7357';
+                return {
+                    url: transformedUrl.toString()
+                };
+            }
+        }
+    });
+
+    map.repaint = true;
+    map._authenticate = () => {};
+
+    // override internal timing to enable precise wait operations
+    window._renderTestNow = 0;
+    mapboxgl.setNow(window._renderTestNow);
+
+    if (options.debug) map.showTileBoundaries = true;
+    if (options.showOverdrawInspector) map.showOverdrawInspector = true;
+    if (options.showTerrainWireframe) map.showTerrainWireframe = true;
+    if (options.showPadding) map.showPadding = true;
+    if (options.collisionDebug) map.showCollisionBoxes = true;
+    if (options.fadeDuration) map._isInitialLoad = false;
+
+    // Disable anisotropic filtering on render tests
+    map.painter.context.extTextureFilterAnisotropicForceOff = true;
+    // Disable globe antialiasing on render tests expect for antialiasing test
+    map.painter.context.extStandardDerivativesForceOff = !options.standardDerivatives;
+
+    await map.once('load');
+    // Disable vertex morphing by default
+    if (map.painter.terrain) {
+        map.painter.terrain.useVertexMorphing = false;
+    }
+
+    //3. Run the operations on the map
+    await applyOperations(map, options);
+    map.repaint = false;
+
+    return map;
+}
+
+function getViewportSize(map) {
+    const gl = map.painter.context.gl;
+    const viewport = gl.getParameter(gl.VIEWPORT);
+    const w = viewport[2];
+    const h = viewport[3];
+    return {w, h};
+}
+
+function getActualImageData(map, {w, h}, options) {
+    const gl = map.painter.context.gl;
+
+    // 1. get pixel data from test canvas as Uint8Array
+    if (options.output === "terrainDepth") {
+        const pixels = drawTerrainDepth(map, w, h);
+        if (!pixels) {
+            throw new Error('Failed to render terrain depth, make sure that terrain is enabled on the render test');
+        }
+        return Uint8ClampedArray.from(pixels);
+    }
+
+    actualCanvas.width = w;
+    actualCanvas.height = h;
+    actualCtx.drawImage(map.getCanvas(), 0, 0);
+    return actualCtx.getImageData(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight).data;
+}
+
+function getActualImageDataURL(actualImageData, map, {w, h}, options) {
+    if (options.output === "terrainDepth") {
+        actualCanvas.width = w;
+        actualCanvas.height = h;
+        const terrainDepthData = new ImageData(actualImageData, w, h);
+        actualCtx.putImageData(terrainDepthData, 0, 0);
+        return actualCanvas.toDataURL();
+    }
+
+    return map.getCanvas().toDataURL();
+}
+
+function calculateDiff(map, {w, h}, actualImageData, expectedImages) {
+    // 2. draw expected.png into a canvas and extract ImageData
+    let minDiffImage;
+    let minExpectedCanvas;
+    let minDiff = Infinity;
+
+    for (let i = 0; i < expectedImages.length; i++) {
+        // 3. set up Uint8ClampedArray to write diff into
+        const diffImage = new Uint8ClampedArray(w * h * 4);
+
+        // 4. Use pixelmatch to compare actual and expected images and write diff
+        // all inputs must be Uint8Array or Uint8ClampedArray
+        const currentDiff = pixelmatch(actualImageData, expectedImages[i].data, diffImage, w, h, {threshold: 0.1285}) / (w * h);
+
+        if (currentDiff < minDiff) {
+            minDiff = currentDiff;
+            minDiffImage = diffImage;
+            minExpectedCanvas = expectedCanvas;
+        }
+    }
+
+    return {minDiff, minDiffImage, minExpectedCanvas};
+}
+
 async function runTest(t) {
     t.teardown(ensureTeardown);
 
-    let style, options;
     // This needs to be read from the `t` object because this function runs async in a closure.
     const currentTestName = t.name;
     const writeFileBasePath = `test/integration/${currentTestName}`;
     const currentFixture = fixtures[currentTestName];
     try {
-        style = currentFixture.style;
-        if (!style) {
-            throw new Error('style.json is missing');
-        }
+        const expectedImages = await getExpectedImages(currentTestName);
 
-        if (style.PARSE_ERROR) {
-            throw new Error(`Error occured while parsing style.json: ${style.message}`);
-        }
-
-        options = {
-            width: 512,
-            height: 512,
-            pixelRatio: 1,
-            allowed: 0.00015,
-            ...((style.metadata && style.metadata.test) || {})
-        };
-
-        // there may be multiple expected images, covering different platforms
-        const expectedPaths = [];
-        for (const prop in currentFixture) {
-            if (prop.indexOf('expected') > -1) {
-                let path = `${currentTestName}/${prop}.png`;
-                // regression tests with # in the name need to be sanitized
-                path = encodeURIComponent(path);
-                expectedPaths.push(path);
-            }
-        }
-
-        const expectedImagePromises = Promise.all(expectedPaths.map((path) => drawImage(expectedCanvas, expectedCtx, path)));
-
-        window.devicePixelRatio = options.pixelRatio;
-
-        if (options.addFakeCanvas) {
-            const {canvas, ctx} = createCanvas(options.addFakeCanvas.id);
-            const src = options.addFakeCanvas.image.replace('./', '');
-            await drawImage(canvas, ctx, src, false);
-            fakeCanvasContainer.appendChild(canvas);
-        }
-
-        container.style.width = `${options.width}px`;
-        container.style.height = `${options.height}px`;
+        const style = parseStyle(currentFixture);
+        const options = parseOptions(currentFixture, style);
+        await setupLayout(options);
 
         //2. Initialize the Map
-        mapboxgl.accessToken = 'pk.eyJ1IjoibWFwYm94LWdsLWpzIiwiYSI6ImNram9ybGI1ajExYjQyeGxlemppb2pwYjIifQ.LGy5UGNIsXUZdYMvfYRiAQ';
-        map = new mapboxgl.Map({
-            container,
-            style,
-            classes: options.classes,
-            interactive: false,
-            attributionControl: false,
-            preserveDrawingBuffer: true,
-            axonometric: options.axonometric || false,
-            skew: options.skew || [0, 0],
-            fadeDuration: options.fadeDuration || 0,
-            optimizeForTerrain: options.optimizeForTerrain || false,
-            localIdeographFontFamily: options.localIdeographFontFamily || false,
-            projection: options.projection,
-            crossSourceCollisions: typeof options.crossSourceCollisions === "undefined" ? true : options.crossSourceCollisions,
-            performanceMetricsCollection: false,
-            transformRequest: (url, resourceType) => {
-                // some tests have the port hardcoded to 2900
-                // this makes that backwards compatible
-                if (resourceType === 'Tile') {
-                    const transformedUrl = new URL(url);
-                    transformedUrl.port = '7357';
-                    return {
-                        url: transformedUrl.toString()
-                    };
-                }
-            }
-        });
-
-        map.repaint = true;
-        map._authenticate = () => {};
-
-        // override internal timing to enable precise wait operations
-        window._renderTestNow = 0;
-        mapboxgl.setNow(window._renderTestNow);
-
-        if (options.debug) map.showTileBoundaries = true;
-        if (options.showOverdrawInspector) map.showOverdrawInspector = true;
-        if (options.showTerrainWireframe) map.showTerrainWireframe = true;
-        if (options.showPadding) map.showPadding = true;
-        if (options.collisionDebug) map.showCollisionBoxes = true;
-        if (options.fadeDuration) map._isInitialLoad = false;
-
-        // Disable anisotropic filtering on render tests
-        map.painter.context.extTextureFilterAnisotropicForceOff = true;
-        // Disable globe antialiasing on render tests expect for antialiasing test
-        map.painter.context.extStandardDerivativesForceOff = !options.standardDerivatives;
-
-        const gl = map.painter.context.gl;
-        await map.once('load');
-        // Disable vertex morphing by default
-        if (map.painter.terrain) {
-            map.painter.terrain.useVertexMorphing = false;
-        }
-
-        //3. Run the operations on the map
-        await applyOperations(map, options);
-        map.repaint = false;
-        const viewport = gl.getParameter(gl.VIEWPORT);
-        const w = viewport[2];
-        const h = viewport[3];
-        let actualImageData;
-
-        // 1. get pixel data from test canvas as Uint8Array
-        if (options.output === "terrainDepth") {
-            const pixels = drawTerrainDepth(map, w, h);
-            if (!pixels) {
-                throw new Error('Failed to render terrain depth, make sure that terrain is enabled on the render test');
-            }
-            actualImageData = Uint8ClampedArray.from(pixels);
-        } else {
-            actualCanvas.width = w;
-            actualCanvas.height = h;
-            actualCtx.drawImage(map.getCanvas(), 0, 0);
-            actualImageData = actualCtx.getImageData(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight).data;
-        }
-
-        // if we have multiple expected images, we'll compare against each one and pick the one with
-        // the least amount of difference; this is useful for covering features that render differently
-        // depending on platform, i.e. heatmaps use half-float textures for improved rendering where supported
-        const expectedImages = await expectedImagePromises;
-
-        if (!process.env.UPDATE && expectedImages.length === 0) {
-            throw new Error('No expected*.png files found; did you mean to run tests with UPDATE=true?');
-        }
-
-        let fileInfo;
-
-        const getActual = () => {
-            if (options.output === "terrainDepth") {
-                actualCanvas.width = w;
-                actualCanvas.height = h;
-                const terrainDepthData = new ImageData(actualImageData, w, h);
-                actualCtx.putImageData(terrainDepthData, 0, 0);
-                return actualCanvas.toDataURL();
-            }
-            return map.getCanvas().toDataURL();
-        };
+        map = await renderMap(style, options);
+        const {w, h} = getViewportSize(map);
+        const actualImageData = getActualImageData(map, {w, h}, options);
 
         if (process.env.UPDATE) {
-            fileInfo = [
-                {
-                    path: `${writeFileBasePath}/expected.png`,
-                    data: getActual().split(',')[1]
-                }
-            ];
-        } else {
-            // 2. draw expected.png into a canvas and extract ImageData
-            let minDiffImage;
-            let minExpectedCanvas;
-            let minDiff = Infinity;
+            browserWriteFile.postMessage([{
+                path: `${writeFileBasePath}/expected.png`,
+                data: getActualImageDataURL(actualImageData, map, {w, h}, options).split(',')[1]
+            }]);
 
-            for (let i = 0; i < expectedImages.length; i++) {
-                // 3. set up Uint8ClampedArray to write diff into
-                const diffImage = new Uint8ClampedArray(w * h * 4);
+            return;
+        }
 
-                // 4. Use pixelmatch to compare actual and expected images and write diff
-                // all inputs must be Uint8Array or Uint8ClampedArray
-                const currentDiff = pixelmatch(actualImageData, expectedImages[i].data, diffImage, w, h, {threshold: 0.1285}) / (w * h);
+        const {minDiff, minDiffImage, minExpectedCanvas} = calculateDiff(map, {w, h}, actualImageData, expectedImages);
+        const pass = minDiff <= options.allowed;
+        const testMetaData = {
+            name: currentTestName,
+            minDiff: Math.round(100000 * minDiff) / 100000,
+            status: t._todo ? 'todo' : pass ? 'passed' : 'failed'
+        };
 
-                if (currentDiff < minDiff) {
-                    minDiff = currentDiff;
-                    minDiffImage = diffImage;
-                    minExpectedCanvas = expectedCanvas;
-                }
-            }
+        t.ok(pass || t._todo, t.name);
 
-            const pass = minDiff <= options.allowed;
-            const testMetaData = {
-                name: currentTestName,
-                minDiff: Math.round(100000 * minDiff) / 100000,
-                status: t._todo ? 'todo' : pass ? 'passed' : 'failed'
-            };
-            t.ok(pass || t._todo, t.name);
+        // only display results locally, or on CI if it's failing
+        if (!process.env.CI || !pass) {
+            // 5. Convert diff Uint8Array to ImageData and write to canvas
+            // so we can get a base64 string to display the diff in the browser
+            diffCanvas.width = w;
+            diffCanvas.height = h;
+            const diffImageData = new ImageData(minDiffImage, w, h);
+            diffCtx.putImageData(diffImageData, 0, 0);
 
-            // only display results locally, or on CI if it's failing
-            if (!process.env.CI || !pass) {
-                // 5. Convert diff Uint8Array to ImageData and write to canvas
-                // so we can get a base64 string to display the diff in the browser
-                diffCanvas.width = w;
-                diffCanvas.height = h;
-                const diffImageData = new ImageData(minDiffImage, w, h);
-                diffCtx.putImageData(diffImageData, 0, 0);
+            const actual = getActualImageDataURL(actualImageData, map, {w, h}, options);
+            const imgDiff = diffCanvas.toDataURL();
 
-                const actual = getActual();
-                const imgDiff = diffCanvas.toDataURL();
-
-                // 6. use browserWriteFile to write actual and diff to disk (convert image back to base64)
-                fileInfo = process.env.CI ? null : [
+            // 6. use browserWriteFile to write actual and diff to disk (convert image back to base64)
+            if (!process.env.CI) {
+                browserWriteFile.postMessage([
                     {
                         path: `${writeFileBasePath}/actual.png`,
                         data: actual.split(',')[1]
@@ -318,19 +358,16 @@ async function runTest(t) {
                         path: `${writeFileBasePath}/diff.png`,
                         data: imgDiff.split(',')[1]
                     }
-                ];
-
-                // 7. pass image paths to testMetaData so the UI can load them from disk
-                testMetaData.actual = actual;
-                testMetaData.expected = minExpectedCanvas.toDataURL();
-                testMetaData.imgDiff = imgDiff;
+                ]);
             }
 
-            updateHTML(testMetaData);
+            // 7. pass image paths to testMetaData so the UI can render them
+            testMetaData.actual = actual;
+            testMetaData.expected = minExpectedCanvas.toDataURL();
+            testMetaData.imgDiff = imgDiff;
         }
 
-        if (!process.env.CI || process.env.UPDATE) browserWriteFile.postMessage(fileInfo);
-
+        updateHTML(testMetaData);
     } catch (e) {
         t.error(e);
         updateHTML({name: t.name, status:'failed', jsonDiff: e.message});

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -228,10 +228,11 @@ async function renderMap(style, options) {
         map.painter.terrain.useVertexMorphing = false;
     }
 
-    //3. Run the operations on the map
+    // 3. Run the operations on the map
     await applyOperations(map, options);
-    map.repaint = false;
-    await map.once('idle');
+
+    // 4. Wait until the map is idle
+    await new Promise(resolve => map._requestDomTask(resolve));
 
     return map;
 }

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -298,6 +298,11 @@ function calculateDiff(map, {w, h}, actualImageData, expectedImages) {
 }
 
 async function runTest(t) {
+    const errors = [];
+    const onError = (error) => {
+        errors.push(error);
+    };
+
     t.teardown(ensureTeardown);
 
     // This needs to be read from the `t` object because this function runs async in a closure.
@@ -313,6 +318,8 @@ async function runTest(t) {
 
         //2. Initialize the Map
         map = await renderMap(style, options);
+        map.on('error', onError);
+
         const {w, h} = getViewportSize(map);
         const actualImageData = getActualImageData(map, {w, h}, options);
 
@@ -330,7 +337,9 @@ async function runTest(t) {
         const testMetaData = {
             name: currentTestName,
             minDiff: Math.round(100000 * minDiff) / 100000,
-            status: t._todo ? 'todo' : pass ? 'passed' : 'failed'
+            status: t._todo ? 'todo' : pass ? 'passed' : 'failed',
+            style: pass ? 'ok' : map.getStyle(),
+            mapErrors: errors
         };
 
         t.ok(pass || t._todo, t.name);
@@ -373,6 +382,7 @@ async function runTest(t) {
         updateHTML({name: t.name, status:'failed', jsonDiff: e.message});
     }
 
+    map.off('error', onError);
     t.end();
 }
 

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -230,7 +230,8 @@ async function renderMap(style, options) {
 
     //3. Run the operations on the map
     await applyOperations(map, options);
-    await map.on('idle');
+    map.repaint = false;
+    await map.once('idle');
 
     return map;
 }

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -221,13 +221,13 @@ async function renderMap(style, options) {
     // Disable globe antialiasing on render tests expect for antialiasing test
     map.painter.context.extStandardDerivativesForceOff = !options.standardDerivatives;
 
+    map.repaint = true;
+    await map.once('load');
+
     // Disable vertex morphing by default
     if (map.painter.terrain) {
         map.painter.terrain.useVertexMorphing = false;
     }
-
-    map.repaint = true;
-    await map.once('load');
 
     // 3. Run the operations on the map
     await applyOperations(map, options);

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -221,16 +221,19 @@ async function renderMap(style, options) {
     // Disable globe antialiasing on render tests expect for antialiasing test
     map.painter.context.extStandardDerivativesForceOff = !options.standardDerivatives;
 
-    await map.once('load');
     // Disable vertex morphing by default
     if (map.painter.terrain) {
         map.painter.terrain.useVertexMorphing = false;
     }
 
+    map.repaint = true;
+    await map.once('load');
+
     // 3. Run the operations on the map
     await applyOperations(map, options);
 
     // 4. Wait until the map is idle
+    map.repaint = true;
     await new Promise(resolve => map._requestDomTask(resolve));
 
     return map;

--- a/test/integration/lib/server.js
+++ b/test/integration/lib/server.js
@@ -1,35 +1,52 @@
-import path from 'path';
 import fs from 'fs';
-import st from 'st';
+import path from 'path';
 import {createServer} from 'http';
+import {fileURLToPath} from 'url';
+import {createRequire} from 'module';
+import st from 'st';
 import localizeURLs from './localize-urls.js';
 
-import {fileURLToPath} from 'url';
+const require = createRequire(import.meta.url);
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
-import {createRequire} from 'module';
-const require = createRequire(import.meta.url);
+const integrationMount = st({
+    index: false,
+    path: path.join(__dirname, '..')
+});
+
+const mapboxGLStylesMount = st({
+    url: '/mapbox-gl-styles',
+    path: path.dirname(require.resolve('mapbox-gl-styles')),
+    passthrough: true,
+    index: false
+});
+
+const mapboxMVTFixturesMount = st({
+    url: '/mvt-fixtures',
+    path: path.dirname(require.resolve('@mapbox/mvt-fixtures')),
+    passthrough: true,
+    index: false
+});
+
+const port = 2900;
 
 export default function () {
-    const port = 2900;
-    const integrationMount = st({path: path.join(__dirname, '..')});
-    const mapboxGLStylesMount = st({path: path.dirname(require.resolve('mapbox-gl-styles')), url: 'mapbox-gl-styles'});
-    const mapboxMVTFixturesMount = st({path: path.dirname(require.resolve('@mapbox/mvt-fixtures')), url: 'mvt-fixtures'});
     const server = createServer((req, res) => {
+        // Write data to disk
         if (req.method === 'POST' && req.url === '/write-file') {
             let body = '';
             req.on('data', (data) => {
                 body += data;
             });
-            req.on('end', () => {
 
-                //Write data to disk
+            return req.on('end', () => {
                 const {filePath, data} = JSON.parse(body);
 
                 let encoding;
                 if (filePath.split('.')[1] !== 'json') {
                     encoding = 'base64';
                 }
+
                 fs.writeFile(path.join(process.cwd(), filePath), data, encoding, () => {
                     res.writeHead(200, {'Content-Type': 'text/html'});
                     res.end('ok');

--- a/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance-data-driven/early-dynamic-high-pitch/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance-data-driven/early-dynamic-high-pitch/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance-data-driven/early-dynamic-low-pitch/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance-data-driven/early-dynamic-low-pitch/style.json
@@ -5,8 +5,7 @@
         "collisionDebug": true,
         "height": 264,
         "width": 400,
-        "allowed": 0.0003,
-        "operations": [["wait"]]
+        "allowed": 0.0003
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance-data-driven/late-dynamic/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance-data-driven/late-dynamic/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance/high-pitch-far-hidden/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance/high-pitch-far-hidden/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance/low-pitch-far-visible/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/combined-pitch-distance/low-pitch-far-visible/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/distance-far-cull/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/distance-far-cull/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/distance-near-and-far-cull/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/distance-near-and-far-cull/style.json
@@ -5,8 +5,7 @@
         "collisionDebug": true,
         "height": 264,
         "width": 400,
-        "allowed": 0.0012,
-        "operations": [["wait"]]
+        "allowed": 0.0012
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/distance-near-cull/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/distance-near-cull/style.json
@@ -5,8 +5,7 @@
         "collisionDebug": true,
         "height": 264,
         "width": 400,
-        "allowed": 0.00062,
-        "operations": [["wait"]]
+        "allowed": 0.00062
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/distance-nofilter/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/distance-nofilter/style.json
@@ -5,8 +5,7 @@
         "collisionDebug": true,
         "height": 264,
         "width": 400,
-        "allowed": 0.0007,
-        "operations": [["wait"]]
+        "allowed": 0.0007
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/pitch-high-cull/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/pitch-high-cull/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/pitch-high-show/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/pitch-high-show/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/pitch-low-cull/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/pitch-low-cull/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/integration/render-tests/dynamic-filter/symbols/line/pitch-low-show/style.json
+++ b/test/integration/render-tests/dynamic-filter/symbols/line/pitch-low-show/style.json
@@ -4,8 +4,7 @@
       "test": {
         "collisionDebug": true,
         "height": 264,
-        "width": 400,
-        "operations": [["wait"]]
+        "width": 400
       }
     },
     "center": [-120.30344797631889, 38.11726797649675],

--- a/test/util/html_generator.js
+++ b/test/util/html_generator.js
@@ -25,6 +25,14 @@ const generateResultHTML = template(`
       <% if (r.jsonDiff) { %>
           <pre><%- r.jsonDiff.trim() %></pre>
       <% } %>
+      <% if (r.mapErrors.length !== 0) { %>
+          <ul>
+            <% r.mapErrors.forEach((error) => { %><li><pre><%- error.message %></pre></li><% }); %>
+          </ul>
+      <% } %>
+      <% if (r.status === 'failed') { %>
+          <pre><%- JSON.stringify(r.style, null, 2) %></pre>
+      <% } %>
     </div>
   </div>
 `);

--- a/test/util/html_generator.js
+++ b/test/util/html_generator.js
@@ -25,11 +25,6 @@ const generateResultHTML = template(`
       <% if (r.jsonDiff) { %>
           <pre><%- r.jsonDiff.trim() %></pre>
       <% } %>
-      <% if (r.mapErrors.length !== 0) { %>
-          <ul>
-            <% r.mapErrors.forEach((error) => { %><li><pre><%- error.message %></pre></li><% }); %>
-          </ul>
-      <% } %>
       <% if (r.status === 'failed') { %>
           <pre><%- JSON.stringify(r.style, null, 2) %></pre>
       <% } %>

--- a/test/util/html_generator.js
+++ b/test/util/html_generator.js
@@ -13,13 +13,13 @@ const generateResultHTML = template(`
     <label class="tab-label" style="background: <%- r.color %>" for="<%- r.id %>"><p class="status-container"><span class="status"><%- r.status %></span> - <%- r.name %> - diff: <%- r.minDiff %></p></label>
     <div class="tab-content">
       <% if (r.status !== 'errored') { %>
-          <img src="<%- r.actual %>">
+          <img title="actual" src="<%- r.actual %>">
       <% } %>
       <% if (r.expected) { %>
-          <img src="<%- r.expected %>">
+          <img title="expected" src="<%- r.expected %>">
       <% } %>
       <% if (r.imgDiff) { %>
-          <img src="<%- r.imgDiff %>">
+          <img title="diff" src="<%- r.imgDiff %>">
       <% } %>
       <% if (r.error) { %><p style="color: red"><strong>Error:</strong> <%- r.error.message %></p><% } %>
       <% if (r.jsonDiff) { %>


### PR DESCRIPTION
* Decomposes and slightly improves the `runTest` function in `test/integration/lib/render.js`
* Slightly improves `test/integration/lib/server.js`
* Increases render test timeout from the 20s to 30s

After multiple runs, I can't reproduce the flakiness for `dynamic-filter/symbols/line/`, but some tests still fail sometimes due to the timeout/missing tiles.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
