### PR TITLE
Add optional spec parameter to `validateMapboxApiSupported`

### DIFF
--- a/src/style-spec/validate_mapbox_api_supported.js
+++ b/src/style-spec/validate_mapbox_api_supported.js
@@ -167,7 +167,7 @@ function getRootErrors(style: Object, specKeys: Array<any>): Array<ValidationErr
  *   var validateMapboxApiSupported = require('mapbox-gl-style-spec/lib/validate_style_mapbox_api_supported.js');
  *   var errors = validateMapboxApiSupported(style);
  */
-export default function validateMapboxApiSupported(style: Object): ValidationErrors {
+export default function validateMapboxApiSupported(style: Object, styleSpec: Object = v8): ValidationErrors {
     let s = style;
     try {
         s = readStyle(s);
@@ -175,7 +175,7 @@ export default function validateMapboxApiSupported(style: Object): ValidationErr
         return [e];
     }
 
-    let errors = validateStyle(s, v8)
+    let errors = validateStyle(s, styleSpec)
         .concat(getRootErrors(s, Object.keys(v8.$root)));
 
     if (s.sources) {

--- a/test/unit/style-spec/validate_mapbox_api_supported.test.js
+++ b/test/unit/style-spec/validate_mapbox_api_supported.test.js
@@ -24,3 +24,13 @@ glob.sync(`${__dirname}/fixture/*.input.json`).forEach((file) => {
         t.end();
     });
 });
+
+const fixtures = glob.sync(`${__dirname}/fixture/*.input.json`);
+const style = JSON.parse(fs.readFileSync(fixtures[0]));
+import reference from '../../../src/style-spec/reference/latest.js';
+
+test('errors from validate do not contain line numbers', (t) => {
+    const result = validateMapboxApiSupported(style, reference);
+    t.equal(result[0].line, undefined);
+    t.end();
+});


### PR DESCRIPTION
Unblocks the ability to provide an alternate specification to `validateMapboxApiSupported`.
