### PR TITLE
Derive source type values from spec

### DIFF
--- a/src/style-spec/validate/validate_source.js
+++ b/src/style-spec/validate/validate_source.js
@@ -94,11 +94,21 @@ export default function validateSource(options: ValidationOptions): Array<Valida
         return validateEnum({
             key: `${key}.type`,
             value: value.type,
-            valueSpec: {values: ['vector', 'raster', 'raster-dem', 'geojson', 'video', 'image']},
+            valueSpec: {values: getSourceTypeValues(styleSpec)},
             style,
             styleSpec
         });
     }
+}
+
+function getSourceTypeValues(styleSpec) {
+    return styleSpec.source.reduce((memo, source) => {
+        const sourceType = styleSpec[source];
+        if (sourceType.type.type === 'enum') {
+            memo = memo.concat(Object.keys(sourceType.type.values));
+        }
+        return memo;
+    }, []);
 }
 
 function validatePromoteId({key, value}) {


### PR DESCRIPTION
## Launch Checklist

This too aids in using an alternate spec. Replace a fixed list from validate_source to validate against source types with one derived from `option.styleSpec`.