### PR TITLE
Update URLs in help messages for access token documentation

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -77,7 +77,7 @@ export class AJAXError extends Error {
     url: string;
     constructor(message: string, status: number, url: string) {
         if (status === 401 && isMapboxHTTPURL(url)) {
-            message += ': you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens-and-token-scopes';
+            message += ': you may have provided an invalid Mapbox access token. See https://docs.mapbox.com/api/overview/#access-tokens-and-token-scopes';
         }
         super(message);
         this.status = status;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -192,7 +192,7 @@ export class RequestManager {
     }
 
     _makeAPIURL(urlObject: UrlObject, accessToken: string | null | void): string {
-        const help = 'See https://www.mapbox.com/api-documentation/#access-tokens-and-token-scopes';
+        const help = 'See https://docs.mapbox.com/api/overview/#access-tokens-and-token-scopes';
         const apiUrlObject = parseUrl(config.API_URL);
         urlObject.protocol = apiUrlObject.protocol;
         urlObject.authority = apiUrlObject.authority;

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -82,7 +82,7 @@ test('ajax', (t) => {
         });
         getJSON({url:'api.mapbox.com'}, (error) => {
             t.equal(error.status, 401);
-            t.equal(error.message, "Unauthorized: you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens-and-token-scopes");
+            t.equal(error.message, "Unauthorized: you may have provided an invalid Mapbox access token. See https://docs.mapbox.com/api/overview/#access-tokens-and-token-scopes");
             t.end();
         });
         window.server.respond();


### PR DESCRIPTION
This pull request updates help messages, making URLs of the access token documentation up to date.

I have validated the syntax of the source code after the modification.
Many thanks.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
