### PR TITLE
Release `style-spec` v13.28.0-beta.1

### DIFF
--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 13.28.0-beta.1
+
+### Features ✨
+
+* Add optional spec parameter to `validateMapboxApiSupported` ([#12448](https://github.com/mapbox/mapbox-gl-js/pull/12448))
+* Derive source type values from spec ([#12449](https://github.com/mapbox/mapbox-gl-js/pull/12449))
+
+### Bug fixes 🐞
+
+* Fix incorrect transition flag in *-pattern and line-dasharray properties ([#12372](https://github.com/mapbox/mapbox-gl-js/pull/12372))
+
 ## 13.27.0
 
 ### Bug fixes 🐞

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "13.28.0-dev",
+  "version": "13.28.0-beta.1",
   "author": "Mapbox",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
This PR is for the `v13.28.0-beta.1` release of the `@mapbox/mapbox-gl-style-spec` package.