### PR TITLE
Fix line-border-color with line-trim-offset

### DIFF
--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -62,6 +62,7 @@ void main() {
     out_color = color;
 #endif
 
+    float trimmed = 1.0;
 #ifdef RENDER_LINE_TRIM_OFFSET
     // v_uv[2] and v_uv[3] are specifying the original clip range that the vertex is located in.
     highp float start = v_uv[2];
@@ -80,6 +81,7 @@ void main() {
     if (trim_end > trim_start) {
         if (line_progress <= trim_end && line_progress >= trim_start) {
             out_color = vec4(0, 0, 0, 0);
+            trimmed = 0.0;
         }
     }
 #endif
@@ -112,7 +114,7 @@ void main() {
             out_color.rgb *= (0.6  + 0.4 * smoothAlpha);
         }
 #else  // use user-provided border color
-        out_color.rgb = mix(u_border_color.rgb, out_color.rgb, smoothAlpha);
+        out_color.rgb = mix(u_border_color.rgb * u_border_color.a * trimmed, out_color.rgb, smoothAlpha);
 #endif // RENDER_LINE_BORDER_AUTO
     }
 #endif


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed line-border-color when used with line-trim-offset</changelog>`
