### PR TITLE
Reuse more work in render tests on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,6 @@ jobs:
       name: win/default
     working_directory: ~/mapbox-gl-js
     steps:
-      - run: Set-MpPreference -DisableRealtimeMonitoring $true
       - checkout
       - run: yarn --frozen-lockfile
       - run: yarn run build-dev
@@ -509,7 +508,6 @@ jobs:
     parallelism: 4
     working_directory: ~/mapbox-gl-js
     steps:
-      - run: Set-MpPreference -DisableRealtimeMonitoring $true
       - attach_workspace:
           at: ~/
       # The browser-tools orb doesn't work on Windows, so we install chrome manually.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,7 @@ jobs:
           key: v0-mac-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
            - ~/.cache/yarn
+      - run: yarn run build-dev
       - run:
           name: Creating test list
           command: |
@@ -499,7 +500,7 @@ jobs:
   test-render-windows-chrome-dev:
     executor:
       name: win/default
-    parallelism: 5
+    parallelism: 4
     working_directory: ~/mapbox-gl-js
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ jobs:
             - v0-linux-yarn-{{ .Branch }}-
             - v0-linux-yarn-
       - run: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
+      - run: yarn run build-dev
       - save_cache:
           key: v0-linux-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
@@ -242,7 +243,6 @@ jobs:
       - run: yarn run build-prod-min
       - run: yarn run build-prod
       - run: yarn run build-csp
-      - run: yarn run build-dev
       - run: yarn run build-css
       - run: yarn run build-style-spec
       - run: yarn run build-flow-types
@@ -389,7 +389,6 @@ jobs:
           at: ~/
       - browser-tools/install-browser-tools:
           chrome-version: 91.0.4472.164
-      - run: yarn run build-dev
       - run: yarn run build-token
       - run:
           name: Test Chrome
@@ -484,11 +483,14 @@ jobs:
     steps:
       - checkout
       - run: yarn --frozen-lockfile
-      # speed up persisting to workspace
-      - run: Remove-Item .git -Recurse -Force
-      - run: Remove-Item node_modules/flow-bin -Recurse -Force
-      - run: Remove-Item node_modules/tap -Recurse -Force
-      - run: Remove-Item node_modules/gl -Recurse -Force
+      - run: yarn run build-dev
+      - run:
+          name: Clean up workspace to persist faster
+          command: |
+            Remove-Item .git -Recurse -Force;
+            Remove-Item node_modules/flow-bin -Recurse -Force;
+            Remove-Item node_modules/tap -Recurse -Force;
+            Remove-Item node_modules/gl -Recurse -Force;
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,7 @@ jobs:
       name: win/default
     working_directory: ~/mapbox-gl-js
     steps:
+      - run: Set-MpPreference -DisableRealtimeMonitoring $true
       - checkout
       - run: yarn --frozen-lockfile
       - run: yarn run build-dev
@@ -494,7 +495,6 @@ jobs:
             Remove-Item node_modules/gl -Recurse -Force;
             Remove-Item node_modules/@mapbox/mvt-fixtures/real-world/osm-qa-* -Recurse -Force;
             Remove-Item node_modules/react-devtools-core -Recurse -Force;
-            Remove-Item node_modules/@babel -Recurse -Force;
             Remove-Item node_modules/@octokit -Recurse -Force;
             Remove-Item node_modules/puppeteer-core -Recurse -Force;
             Remove-Item node_modules/lodash -Recurse -Force;
@@ -509,6 +509,7 @@ jobs:
     parallelism: 4
     working_directory: ~/mapbox-gl-js
     steps:
+      - run: Set-MpPreference -DisableRealtimeMonitoring $true
       - attach_workspace:
           at: ~/
       # The browser-tools orb doesn't work on Windows, so we install chrome manually.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,6 +484,11 @@ jobs:
     steps:
       - checkout
       - run: yarn --frozen-lockfile
+      # speed up persisting to workspace
+      - run: Remove-Item .git -Recurse -Force
+      - run: Remove-Item node_modules/flow-bin -Recurse -Force
+      - run: Remove-Item node_modules/tap -Recurse -Force
+      - run: Remove-Item node_modules/gl -Recurse -Force
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,10 @@ jobs:
             Remove-Item node_modules/gl -Recurse -Force;
             Remove-Item node_modules/@mapbox/mvt-fixtures/real-world/osm-qa-* -Recurse -Force;
             Remove-Item node_modules/react-devtools-core -Recurse -Force;
+            Remove-Item node_modules/@babel -Recurse -Force;
             Remove-Item node_modules/@octokit -Recurse -Force;
+            Remove-Item node_modules/puppeteer-core -Recurse -Force;
+            Remove-Item node_modules/lodash -Recurse -Force;
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,9 @@ jobs:
             Remove-Item node_modules/flow-bin -Recurse -Force;
             Remove-Item node_modules/tap -Recurse -Force;
             Remove-Item node_modules/gl -Recurse -Force;
+            Remove-Item node_modules/@mapbox/mvt-fixtures/real-world/osm-qa-* -Recurse -Force;
+            Remove-Item node_modules/react-devtools-core -Recurse -Force;
+            Remove-Item node_modules/@octokit -Recurse -Force;
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - prepare-windows:
+          filters:
+            tags:
+              only: /.*/
       - test-render-windows-chrome-dev:
+          requires:
+            - prepare-windows
           filters:
             tags:
               only: /.*/
@@ -471,6 +477,17 @@ jobs:
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
 
+  prepare-windows:
+    executor:
+      name: win/default
+    working_directory: ~/mapbox-gl-js
+    steps:
+      - checkout
+      - run: yarn --frozen-lockfile
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - mapbox-gl-js
 
   test-render-windows-chrome-dev:
     executor:
@@ -478,7 +495,6 @@ jobs:
     parallelism: 5
     working_directory: ~/mapbox-gl-js
     steps:
-      - checkout
       - attach_workspace:
           at: ~/
       # The browser-tools orb doesn't work on Windows, so we install chrome manually.
@@ -488,14 +504,13 @@ jobs:
             $uri = "https://dl.google.com/chrome/install/latest/chrome_installer.exe";
             $path = "$PSScriptRoot\ChromeSetup.exe";
             Invoke-WebRequest -Uri $uri -OutFile $path;
-            Start-Process $path /install -NoNewWindow -Wait; 
+            Start-Process $path /install -NoNewWindow -Wait;
             Remove-Item $path;
 
             $chromeInstalled = (Get-Item (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe').'(Default)').VersionInfo;
             if ($chromeInstalled.FileName -eq $null) {
               Write-Host "Chrome failed to install";
             }
-      - run: yarn --frozen-lockfile
       - run:
           name: Creating test list
           command: |

--- a/test/integration/testem/testem.js
+++ b/test/integration/testem/testem.js
@@ -52,7 +52,7 @@ const testPage = `test/integration/testem_page_${
 
 const buildJob =
     process.env.BUILD === "production" ? "build-prod-min" :
-    process.env.BUILD === "csp" ? "build-csp" : "build-dev";
+    process.env.BUILD === "csp" ? "build-csp" : null;
 
 let beforeHookInvoked = false;
 let server;
@@ -183,7 +183,7 @@ function buildArtifactsCi() {
     //2. Build tape
     const tapePromise = buildTape();
     //3. Build test artifacts in parallel
-    const rollupPromise = runAll([`build-test-suite`, buildJob], {parallel: true});
+    const rollupPromise = runAll(['build-test-suite', buildJob].filter(Boolean), {parallel: true});
 
     return Promise.all([tapePromise, rollupPromise]);
 }


### PR DESCRIPTION
Experimented here, trying to make Windows builds faster by introducing a separate `prepare-windows` job so that the 5 subsequent parallel jobs don't have to do expensive but the same work: `checkout`, `yarn`, and `build-dev` (built-in to testem script). Tried to also do Chrome installation there but it's too big to persist between jobs cheaply.

As a result, CI doesn't necessarily run faster (depends on the current Circle load I guess), but hopefully it's more reliable since it does less redundant work, so there are more resources to run multiple workflows in parallel.

I'm not 100% sure whether it's a worthy tradeoff but making a draft PR for discussion.

One more tiny change here is that `build-dev` is now a part of `prepare` so that it's not done repeatedly in 3 dependent jobs further (two `-dev` render test jobs and `test-browser`).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

