### PR TITLE
Fix workflows for CI deploy jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ workflows:
               only: /.*/
       - check-bundle-size:
           requires:
-            - prepare
             - install-mbx-ci
             - build
           filters:
@@ -136,17 +135,7 @@ workflows:
       - deploy-benchmarks:
           requires:
             - install-mbx-ci
-            - lint
             - build
-            - test-flow
-            - test-unit
-            - test-render-linux-chrome-dev
-            - test-render-linux-chrome-prod
-            - test-render-linux-firefox-dev
-            - test-render-macos-chrome-dev
-            - test-render-windows-chrome-dev
-            - test-query
-            - test-expressions
           filters:
             tags:
               only: /v[0-9]+.[0-9]+.[0-9]+(-.+)?/
@@ -157,17 +146,7 @@ workflows:
       - deploy-release:
           requires:
             - install-mbx-ci
-            - lint
             - build
-            - test-flow
-            - test-unit
-            - test-render-linux-chrome-dev
-            - test-render-linux-chrome-prod
-            - test-render-linux-firefox-dev
-            - test-render-macos-chrome-dev
-            - test-render-windows-chrome-dev
-            - test-query
-            - test-expressions
           filters:
             tags:
               only: /v[0-9]+.[0-9]+.[0-9]+(-.+)?/


### PR DESCRIPTION
Currently, both `deploy-benchmarks` and `deploy-release` jobs depend on ALL the previous jobs being complete. This has two different problems.

First, the way workspaces persistence works in Circle is that it will apply persisted data from all upstream jobs sequentially when doing `attach_to_workspace`. From the [Workspaces docs](https://circleci.com/docs/workspaces/):
> When attaching a workspace the “layer” from each upstream job is applied in the order the upstream jobs appear in the workflow graph. When two jobs run concurrently, the order in which their layers are applied is undefined.

This means that when multiple jobs persist the same data, all of this data will be applied repeatedly — leading to the following error:
```
Error applying workspace layer for job e6826f13-37d7-4194-aa3b-f617e5c05f52: Concurrent upstream jobs persisted the same file(s)
```

This didn't trigger before #12462 because the Windows jobs didn't persist the workspace data and now does in `prepare-windows`, but we would discover this at some point anyway.

Second, it's preferable for the deploy jobs to run regardless whether the tests and checks pass:

- For benchmarks, we want to be able to compare between commits (and for weekly CLA runs to be successful) regardless whether the tests flaked or not. Ideally they would never flak, but that's the reality at the moment.
- For releases, the release branch is protected with a requirement for all tests to pass for anything that's merged to it, which means that we're guaranteed to have a green build when tagging the release in the branch. It may flake on the tag, but at this point we're confident that the release can proceed, so there's no need for flaky tests to stop the release.