### PR TITLE
Remove unnecessary attribute in terrain related rendering code.

### DIFF
--- a/src/shaders/ground_shadow.vertex.glsl
+++ b/src/shaders/ground_shadow.vertex.glsl
@@ -3,7 +3,6 @@ uniform mat4 u_light_matrix_0;
 uniform mat4 u_light_matrix_1;
 
 attribute vec2 a_pos;
-attribute vec2 a_texture_pos;
 
 varying vec4 v_pos_light_view_0;
 varying vec4 v_pos_light_view_1;

--- a/src/shaders/terrain_depth.vertex.glsl
+++ b/src/shaders/terrain_depth.vertex.glsl
@@ -1,11 +1,10 @@
 uniform mat4 u_matrix;
 attribute vec2 a_pos;
-attribute vec2 a_texture_pos;
 
 varying float v_depth;
 
 void main() {
-    float elevation = elevation(a_texture_pos);
+    float elevation = elevation(a_pos);
     gl_Position = u_matrix * vec4(a_pos, elevation, 1.0);
     v_depth = gl_Position.z / gl_Position.w;
 }

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -2,7 +2,6 @@ uniform mat4 u_matrix;
 uniform float u_skirt_height;
 
 attribute vec2 a_pos;
-attribute vec2 a_texture_pos;
 
 varying vec2 v_pos0;
 
@@ -22,13 +21,13 @@ const float skirtOffset = 24575.0;
 const float wireframeOffset = 0.00015;
 
 void main() {
-    v_pos0 = a_texture_pos / 8192.0;
     float skirt = float(a_pos.x >= skirtOffset);
-    float elevation = elevation(a_texture_pos) - skirt * u_skirt_height;
+    vec2 decodedPos = a_pos - vec2(skirt * skirtOffset, 0.0);
+    float elevation = elevation(decodedPos) - skirt * u_skirt_height;
 #ifdef TERRAIN_WIREFRAME
     elevation += wireframeOffset;
 #endif
-    vec2 decodedPos = a_pos - vec2(skirt * skirtOffset, 0.0);
+    v_pos0 = decodedPos / 8192.0;
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
 #ifdef FOG

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -4,8 +4,8 @@ import Point from '@mapbox/point-geometry';
 import SourceCache from '../source/source_cache.js';
 import {OverscaledTileID} from '../source/tile_id.js';
 import Tile from '../source/tile.js';
-import boundsAttributes from '../data/bounds_attributes.js';
-import {RasterBoundsArray, TriangleIndexArray, LineIndexArray} from '../data/array_types.js';
+import posAttributes from '../data/pos_attributes.js';
+import {TriangleIndexArray, LineIndexArray, PosArray} from '../data/array_types.js';
 import SegmentVector from '../data/segment.js';
 import Texture from '../render/texture.js';
 import Program from '../render/program.js';
@@ -249,7 +249,7 @@ export class Terrain extends Elevation {
         // edge vertices from neighboring tiles evaluate to the same 3D point.
         const [triangleGridArray, triangleGridIndices, skirtIndicesOffset] = createGrid(GRID_DIM + 1);
         const context = painter.context;
-        this.gridBuffer = context.createVertexBuffer(triangleGridArray, boundsAttributes.members);
+        this.gridBuffer = context.createVertexBuffer(triangleGridArray, posAttributes.members);
         this.gridIndexBuffer = context.createIndexBuffer(triangleGridIndices);
         this.gridSegments = SegmentVector.simpleSegment(0, 0, triangleGridArray.length, triangleGridIndices.length);
         this.gridNoSkirtSegments = SegmentVector.simpleSegment(0, 0, triangleGridArray.length, skirtIndicesOffset);
@@ -1489,8 +1489,8 @@ function sortByDistanceToCamera(tileIDs, painter) {
  * @param {number} count Count of rows and columns
  * @private
  */
-function createGrid(count: number): [RasterBoundsArray, TriangleIndexArray, number] {
-    const boundsArray = new RasterBoundsArray();
+function createGrid(count: number): [PosArray, TriangleIndexArray, number] {
+    const boundsArray = new PosArray();
     // Around the grid, add one more row/column padding for "skirt".
     const indexArray = new TriangleIndexArray();
     const size = count + 2;
@@ -1508,7 +1508,7 @@ function createGrid(count: number): [RasterBoundsArray, TriangleIndexArray, numb
             const offset = (x < 0 || x > gridBound || y < 0 || y > gridBound) ? skirtOffset : 0;
             const xi = clamp(Math.round(x), 0, EXTENT);
             const yi = clamp(Math.round(y), 0, EXTENT);
-            boundsArray.emplaceBack(xi + offset, yi, xi, yi);
+            boundsArray.emplaceBack(xi + offset, yi);
         }
     }
 


### PR DESCRIPTION
This PR gets rid of an unnecessary attribute in the terrain related shader code thereby slightly improving GPU memory footprint.

Although unrelated an unused attribute in `ground_shadow.vertex.glsl` has also been removed.

cc @karimnaaji @mpulkki-mapbox @aleksigron 


cc @mapbox/gl-native 
  
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve rendering performance of terrain slightly by reducing its GPU memory footprint.</changelog>`
