### PR TITLE
Fix #12450 

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -2067,13 +2067,7 @@ class Transform {
     // given a mercator meter value in order to eliminate the zoom/cameraToCenterDistance dependency.
     zoomFromMercatorZAdjusted(mercatorZ: number): number {
         assert(this.projection.name === 'globe');
-
-        const zoomFromMercatorZ = (zoom, mercatorZ) => {
-            assert(mercatorZ !== 0);
-            const worldSize = this.tileSize * Math.pow(2, zoom);
-            const d = this.getCameraToCenterDistance(this.projection, zoom, worldSize);
-            return this.scaleZoom(d / (mercatorZ * this.tileSize));
-        };
+        assert(mercatorZ !== 0);
 
         let zoomLow = 0;
         let zoomHigh = GLOBE_ZOOM_THRESHOLD_MAX;
@@ -2084,7 +2078,11 @@ class Transform {
 
         while (zoomHigh - zoomLow > epsilon && zoomHigh > zoomLow) {
             const zoomMid = zoomLow + (zoomHigh - zoomLow) * 0.5;
-            const newZoom = zoomFromMercatorZ(zoomMid, mercatorZ);
+
+            const worldSize = this.tileSize * Math.pow(2, zoomMid);
+            const d = this.getCameraToCenterDistance(this.projection, zoomMid, worldSize);
+            const newZoom = this.scaleZoom(d / (mercatorZ * this.tileSize));
+
             const diff = Math.abs(zoomMid - newZoom);
 
             if (diff < minZoomDiff) {

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -729,7 +729,7 @@ class Camera extends Evented {
         const meterPerECEF = earthRadius / GLOBE_RADIUS;
         const altitudeECEF = vec3.length(cameraPosition);
         const altitudeMeter = altitudeECEF * meterPerECEF - earthRadius;
-        const mercatorZ = mercatorZfromAltitude(altitudeMeter, 0);
+        const mercatorZ = mercatorZfromAltitude(Math.max(altitudeMeter, Number.EPSILON), 0);
 
         const zoom = Math.min(tr.zoomFromMercatorZAdjusted(mercatorZ), eOptions.maxZoom);
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -1730,14 +1730,17 @@ test('transform', (t) => {
         const transform = new Transform();
         transform.resize(500, 500);
         t.ok(transform.setProjection({name: 'globe'}));
-        transform.zoom = 0;
 
-        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e3, 0)), 3), 6);
-        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e6, 0)), 3), 5.874);
-        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(4e6, 0)), 3), 3.87);
-        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e7, 0)), 3), 2.054);
-        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(2e7, 0)), 3), 1.052);
-        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(5e7, 0)), 3), 0);
+        for (let zoom = 0; zoom < 6; ++zoom) {
+            transform.zoom = zoom;
+
+            t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e3, 0)), 3), 6);
+            t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e6, 0)), 3), 5.874);
+            t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(4e6, 0)), 3), 3.87);
+            t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e7, 0)), 3), 2.054);
+            t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(2e7, 0)), 3), 1.052);
+            t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(5e7, 0)), 3), 0);
+        }
 
         t.end();
     });

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -1726,6 +1726,22 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test("zoomFromMercatorZAdjusted", (t) => {
+        const transform = new Transform();
+        transform.resize(500, 500);
+        t.ok(transform.setProjection({name: 'globe'}));
+        transform.zoom = 0;
+
+        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e3, 0)), 3), 6);
+        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e6, 0)), 3), 5.874);
+        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(4e6, 0)), 3), 3.87);
+        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(1e7, 0)), 3), 2.054);
+        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(2e7, 0)), 3), 1.052);
+        t.equal(fixedNum(transform.zoomFromMercatorZAdjusted(mercatorZfromAltitude(5e7, 0)), 3), 0);
+
+        t.end();
+    });
+
     t.test("ZoomDeltaToMovement", (t) => {
         const transform = new Transform();
         transform.resize(100, 100);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -8,6 +8,7 @@ import {fixedLngLat, fixedNum, fixedVec3} from '../../util/fixed.js';
 import {equalWithPrecision} from '../../util/index.js';
 import MercatorCoordinate from '../../../src/geo/mercator_coordinate.js';
 import LngLat from '../../../src/geo/lng_lat.js';
+import LngLatBounds from '../../../src/geo/lng_lat_bounds.js';
 import {vec3, quat} from 'gl-matrix';
 
 test('camera', (t) => {
@@ -2302,6 +2303,21 @@ test('camera', (t) => {
                 top: 0,
                 bottom: 0
             });
+            t.end();
+        });
+
+        t.test('#12450', (t) => {
+            const camera = createCamera();
+
+            camera.setCenter([-115.6288447, 35.1509267]);
+            camera.setZoom(5);
+
+            const bounds = new LngLatBounds();
+            bounds.extend([-115.6288447, 35.1509267]);
+            camera.fitBounds(bounds, {padding: 75, duration: 0});
+
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), {lng: -115.6288, lat: 35.1509});
+            t.equal(camera.getZoom(), 20);
             t.end();
         });
 


### PR DESCRIPTION
Fix https://github.com/mapbox/mapbox-gl-js/issues/12450: Infinite loop in zoomFromMercatorZAdjusted.

- Prevent NaN by gating invalid values from the callee
- Prevent infinite loop by using a binary search instead of the previous method more prone to floating point comparison issues
- Add regression tests and new test for this function

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix potential infinite loop when calling fitBounds with globe projection</changelog>`
