### PR TITLE
Fix "undefined is not an object" in coalesceChanges

### DIFF
--- a/src/source/source_state.js
+++ b/src/source/source_state.js
@@ -131,7 +131,7 @@ class SourceFeatureState {
                 for (const feature in this.deletedStates[sourceLayer]) {
                     const deleteWholeFeatureState = this.deletedStates[sourceLayer][feature] === null;
                     if (deleteWholeFeatureState) this.state[sourceLayer][feature] = {};
-                    else {
+                    else if (this.state[sourceLayer][feature]) {
                         for (const key of Object.keys(this.deletedStates[sourceLayer][feature])) {
                             delete this.state[sourceLayer][feature][key];
                         }


### PR DESCRIPTION
This PR fixes #11784, by implementing the change suggested by @mourner. A/B tested against published npm package and local build. Bug did not occur in local build with these changes.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR (above)
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs (none)
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes "undefined is not an object" in coalesceChanges</changelog>`
