### PR TITLE
update license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,22 +2,22 @@ mapbox-gl-js v2.0
 
 Mapbox Web SDK
 
-Copyright (c) 2020, Mapbox
+Copyright © 2021 - 2023 Mapbox, Inc. All rights reserved.
 
-All rights reserved.
-
-Mapbox gl-js version 2.0 or higher (“Mapbox Web SDK”) must be used according to
-the Mapbox Terms of Service. This license allows developers with a current active
-Mapbox account to use and modify the Mapbox Web SDK. Developers may modify the
-Mapbox Web SDK code so long as the modifications do not change or interfere with
-marked portions of the code related to billing, accounting, and anonymized data
-collection. The Mapbox Web SDK only sends anonymized usage data, which Mapbox uses
-for fixing bugs and errors, accounting, and generating aggregated anonymized
-statistics. This license terminates automatically if a user no longer has an
-active Mapbox account.
-
-For the full license terms, please see the Mapbox Terms of Service at
-https://www.mapbox.com/legal/tos/.
+The software and files in this repository (collectively, "Software") are
+licensed under the Mapbox TOS for use only with the relevant Mapbox product(s)
+listed at www.mapbox.com/pricing. This license allows developers with a
+current active Mapbox account to use and modify the authorized portions of the
+Software as needed for use only with the relevant Mapbox product(s) through
+their Mapbox account in accordance with the Mapbox TOS.  This license
+terminates automatically if a developer no longer has a Mapbox account in good
+standing or breaches the Mapbox TOS. For the license terms, please see the
+Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox
+Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a
+SDK, modifications that change or interfere with marked portions of the code
+related to billing, accounting, or data collection are not authorized and the
+SDK sends limited de-identified location and usage data which is used in
+accordance with the Mapbox TOS. [Updated 2023-01]
 
 -------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ native SDKs. For code and issues specific to the native SDKs, see the
 
 ## License
 
-Copyright © 2021 Mapbox
+Mapbox Web SDK
 
-All rights reserved.
+Copyright © 2021 - 2023 Mapbox, Inc. All rights reserved.
 
-Mapbox GL JS version 2.0 or higher (“Mapbox Web SDK”) must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox Web SDK. Developers may modify the Mapbox Web SDK code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and anonymized data collection. The Mapbox Web SDK sends only anonymized usage data, which Mapbox uses for fixing bugs and errors, accounting, and generating aggregated anonymized statistics. This license terminates automatically if a user no longer has an active Mapbox account.
-
-For the full license terms, please see the [Mapbox Terms of Service](https://www.mapbox.com/legal/tos/).
+The software and files in this repository (collectively, “Software”) are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-01]


### PR DESCRIPTION
Updating license text in README and LICENSE to match latest version of the Mapbox TOS license.
