### PR TITLE
Fix `test-browser` failures by unpinning chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,8 +364,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - browser-tools/install-browser-tools:
-          chrome-version: 91.0.4472.164
+      - browser-tools/install-browser-tools
       - run: yarn run build-token
       - run:
           name: Test Chrome
@@ -510,3 +509,5 @@ jobs:
           path: test/integration/render-tests
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
+
+# VS Code Extension Version: 1.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@1.4.0
   browser-tools: circleci/browser-tools@1.4.0
-  win: circleci/windows@4.1.1
+  win: circleci/windows@5.0.0
 
 workflows:
   version: 2
@@ -509,5 +509,3 @@ jobs:
           path: test/integration/render-tests
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
-
-# VS Code Extension Version: 1.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@1.4.0
   browser-tools: circleci/browser-tools@1.4.0
-  win: circleci/windows@5.0.0
+  win: circleci/windows@4.1.1
 
 workflows:
   version: 2


### PR DESCRIPTION
Related to https://github.com/mapbox/mapbox-gl-js/pull/10887

Runs of `test-browser` started failing today on the install Chrome step with the following error:

```
Google Chrome is not currently installed; installing it
Preparing Chrome installation for Debian-based systems
https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_91.0.4472.164-1_amd64.deb:
2023-01-10 23:01:29 ERROR 404: Not Found.
/bin/bash: line 129: google-chrome-stable: command not found
Google Chrome v91.0.4472.164 (stable) failed to install.
```

The pinned version of Chrome is no longer available, tests pass after we remove it, defaulting to the latest version.

 - [X] briefly describe the changes in this PR
