### PR TITLE
Clear tiles with zoom dependent `line-width` layers from the terrain render cache

### DIFF
--- a/src/style/style_layer/line_style_layer.js
+++ b/src/style/style_layer/line_style_layer.js
@@ -70,6 +70,10 @@ class LineStyleLayer extends StyleLayer {
         return this._transitionablePaint._values['line-gradient'].value.expression;
     }
 
+    widthExpression(): StylePropertyExpression {
+        return this._transitionablePaint._values['line-width'].value.expression;
+    }
+
     recalculate(parameters: EvaluationParameters, availableImages: Array<string>) {
         super.recalculate(parameters, availableImages);
 

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -283,6 +283,9 @@ export class Terrain extends Elevation {
         style.on('neworder', this._checkRenderCacheEfficiency.bind(this));
         this._style = style;
         this._checkRenderCacheEfficiency();
+        this._style.map.on('moveend', () => {
+            this._clearTilesFromRenderCache();
+        });
     }
 
     /*
@@ -1073,8 +1076,6 @@ export class Terrain extends Elevation {
             }
             return;
         }
-
-        this._clearTilesFromRenderCache();
 
         const coords = this.proxyCoords;
         const dirty = this._tilesDirty;


### PR DESCRIPTION
GL JS is not considering a line width change as a prerequisite to clear off tiles from the terrain render cache. Because of that, while zooming between two zoom levels, GL JS is using a stale zoom in `getPixelsToTileUnitsMatrix` during the entire range [z..z+1].

This fix clears tiles with zoom-dependent `line-width` layers from the terrain render cache. One thing that bugs me is that most Mapbox core styles use a composite source with zoom-dependant line layers. So we are basically disabling the terrain render cache for the composite source in core styles here.

Closes #11956

## Benchmarks

After running benchmarks comparing the main branch with this PR, there is a regression in `frameTimeAverage` and `percentDroppedFrames`, see:

* `streets-v11` https://sites.mapbox.com/benchmap-js-results/runs/1266
* `streets-v12` https://sites.mapbox.com/benchmap-js-results/runs/1267

## Before

https://user-images.githubusercontent.com/533564/211821451-c2b160b3-8f2b-47eb-a3d1-7c9f79025791.mov

## After

https://user-images.githubusercontent.com/533564/211821488-1ad97314-0979-4f28-9642-358e00fb2de0.mov

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>fix blur on draped lines while zoom-in</changelog>`
