### PR TITLE
Location indicator hole shader changes for fill extrusion

### DIFF
--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -1,5 +1,10 @@
 varying vec4 v_color;
 
+// Note: 3x3 used instead of 2x2 to prevent a padding related bug in Metal
+// Could be changed after we update our cross-compiler toolchain
+uniform mat3 u_hole_centers;
+uniform vec2 u_hole_opacity_radius;
+
 #ifdef RENDER_SHADOWS
 varying highp vec4 v_pos_light_view_0;
 varying highp vec4 v_pos_light_view_1;
@@ -59,6 +64,17 @@ vec4 color;
 #ifdef FOG
     color = fog_dither(fog_apply_premultiplied(color, v_fog_pos));
 #endif
+
+#ifdef INDICATOR_HOLE
+    float holeMinOpacity = u_hole_opacity_radius.x;
+    float holeRadius = max(u_hole_opacity_radius.y, 0.0);
+    
+    float distA = distance(gl_FragCoord.xy, vec2(u_hole_centers[0][0], u_hole_centers[0][1]));
+    float distB = distance(gl_FragCoord.xy, vec2(u_hole_centers[1][0], u_hole_centers[1][1]));
+    color *= min(pow(distA / holeRadius, 2.0) + holeMinOpacity, 1.0);
+    color *= min(pow(distB / holeRadius, 2.0) + holeMinOpacity, 1.0);
+#endif
+
     gl_FragColor = color;
 
 #ifdef OVERDRAW_INSPECTOR


### PR DESCRIPTION
This PR includes shader changes to support the rendering of screen space "holes" on the fill extrusion layer, which is meant to help with the visibility of the location indicator and other features.

This feature is currently only used by gl-native, but could be added to gl-js where needed. See `endanke/indicator-hole` for a sample implementation. The changes also supports the rendering of more than one hole, which is needed in a use-case where several location indicators or the goal needs highlighting too. (Currently only two used, but can be extended later with a larger matrix.)

Illustration:

<img width="762" alt="Screenshot 2023-01-09 at 14 12 39" src="https://user-images.githubusercontent.com/2576246/212319927-d20eabf8-53a4-4b79-9890-596a8cabc0ee.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
