### PR TITLE
Backport video source fix for iOS into `v1.13.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🐞 Bug fixes
 
 * Fix incorrect billing when `customAccessToken` is provided along with non-Mapbox tiles ([#12520](https://github.com/mapbox/mapbox-gl-js/issues/12520))
+* Prevent video sources from entering fullscreen on iOS Safari ([#11067](https://github.com/mapbox/mapbox-gl-js/issues/11067))
 * Upgrade minimist to ^1.2.7 to avoid [CVE-2021-44906](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44906) ([#12442](https://github.com/mapbox/mapbox-gl-js/issues/12442)) (h/t @Spasfonx)
 
 ## 1.13.2

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -79,6 +79,9 @@ class VideoSource extends ImageSource {
                 this.video = video;
                 this.video.loop = true;
 
+                // Prevent the video from taking over the screen in iOS
+                this.video.setAttribute('playsinline', '');
+
                 // Start repainting when video starts playing. hasTransition() will then return
                 // true to trigger additional frames as long as the videos continues playing.
                 this.video.addEventListener('playing', () => {


### PR DESCRIPTION
Backporting video source fix for iOS into `v1.13.3` https://github.com/mapbox/mapbox-gl-js/pull/11067