### PR TITLE
Fix getVideo stub

### DIFF
--- a/test/ajax_stubs.js
+++ b/test/ajax_stubs.js
@@ -114,6 +114,7 @@ export const getVideo = function(urls, callback) {
                 if (err) return callback(err);
                 callback(null, {
                     readyState: 4, // HAVE_ENOUGH_DATA
+                    setAttribute() {},
                     addEventListener() {},
                     play() {},
                     width: png.width,


### PR DESCRIPTION
Fixes failing render test after backporting iOS video source fix https://github.com/mapbox/mapbox-gl-js/pull/12524