### PR TITLE
Remove deprecated webgl renderer info msg

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -121,7 +121,7 @@ class Context {
         this.extTextureFilterAnisotropicForceOff = false;
         this.extStandardDerivativesForceOff = false;
 
-        this.extDebugRendererInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        this.extDebugRendererInfo = gl.getParameter(gl.RENDERER);
         if (this.extDebugRendererInfo) {
             this.renderer = gl.getParameter(this.extDebugRendererInfo.UNMASKED_RENDERER_WEBGL);
             this.vendor = gl.getParameter(this.extDebugRendererInfo.UNMASKED_VENDOR_WEBGL);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 
## Description
Remove deprecated `WEBGL_debug_renderer_info` message that appears in Firefox