### PR TITLE
Increase render tests start delay for Safari

### DIFF
--- a/test/integration/testem/testem.js
+++ b/test/integration/testem/testem.js
@@ -190,7 +190,7 @@ module.exports = async function() {
                   activate
                   open location "<url>"
                  end tell
-                 delay 3000`,
+                 delay 10000`,
                 ],
             },
         },


### PR DESCRIPTION
Increases the render tests start delay from 3s to 10s for Safari.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
