### PR TITLE
[MAPS3D-691] line borders: respect lighting and fog

### DIFF
--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -86,13 +86,6 @@ void main() {
     }
 #endif
 
-#ifdef LIGHTING_3D_MODE
-    out_color = apply_lighting(out_color);
-#endif
-#ifdef FOG
-    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
-#endif
-
 #ifdef RENDER_LINE_ALPHA_DISCARD
     if (alpha < u_alpha_discard_threshold) {
         discard;
@@ -118,8 +111,16 @@ void main() {
 #endif // RENDER_LINE_BORDER_AUTO
     }
 #endif
-    gl_FragColor = out_color * (alpha * opacity);
 
+#ifdef LIGHTING_3D_MODE
+    out_color = apply_lighting(out_color);
+#endif
+
+#ifdef FOG
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
+#endif
+
+    gl_FragColor = out_color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

Before, (thick black borders ignore fog, notice the aliasing lines near horizon):
![image](https://user-images.githubusercontent.com/1542101/214596370-f74ceef9-ad3f-4ce1-8102-b2ce244635cd.png)

After, (line borders respect fog):
![image](https://user-images.githubusercontent.com/1542101/214596920-97da01c9-9446-4e2a-ab14-e0a34aefdfb5.png)

