### PR TITLE
Increase "allowed" value for `custom-layer-js/draped` render test

### DIFF
--- a/test/integration/render-tests/custom-layer-js/draped/style.json
+++ b/test/integration/render-tests/custom-layer-js/draped/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 1500,
       "height": 1000,
+      "allowed": 0.0012,
       "operations": [
         ["wait"],
         ["setStyle", {


### PR DESCRIPTION
Increases "allowed" value for `custom-layer-js/draped` render test introduced in https://github.com/mapbox/mapbox-gl-js/pull/12182

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
