### PR TITLE
Update CircleCI Orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 orbs:
-  aws-cli: circleci/aws-cli@1.4.0
-  browser-tools: circleci/browser-tools@1.4.0
+  aws-cli: circleci/aws-cli@3.1.4
+  browser-tools: circleci/browser-tools@1.4.1
   macos: circleci/macos@2.3.4
-  win: circleci/windows@4.1.1
+  win: circleci/windows@5.0.0
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   aws-cli: circleci/aws-cli@3.1.4
   browser-tools: circleci/browser-tools@1.4.1
   macos: circleci/macos@2.3.4
-  win: circleci/windows@5.0.0
+  win: circleci/windows@4.1.1
 
 workflows:
   version: 2


### PR DESCRIPTION
Updates CircleCI Orbs

* `circleci/aws-cli@3.1.4`
* `circleci/browser-tools@1.4.1`

Note `yarn` is broken in the new Windows Orb `circleci/windows@5.0.0`

```
yarn : The term 'yarn' is not recognized as the name of a cmdlet, function, script file, or operable program. Check 
the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ yarn --frozen-lockfile
+ ~~~~
    + CategoryInfo          : ObjectNotFound: (yarn:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
