### PR TITLE
Fix for android emulator about shader precision issue

### DIFF
--- a/src/shaders/background.vertex.glsl
+++ b/src/shaders/background.vertex.glsl
@@ -3,7 +3,7 @@ attribute vec2 a_pos;
 uniform mat4 u_matrix;
 
 #ifdef LIGHTING_3D_MODE
-uniform vec4 u_color;
+uniform mediump vec4 u_color;
 varying vec4 v_color;
 #endif
 


### PR DESCRIPTION
Android emulator was complaining about shader precision issues when running in x86_64 and API version v30.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
