### PR TITLE
Support referrerPolicy option for transformRequest function when using fetch

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -67,8 +67,9 @@ export type RequestParameters = {
     body?: string,
     type?: 'string' | 'json' | 'arrayBuffer',
     credentials?: 'same-origin' | 'include',
-    collectResourceTiming?: boolean
-};
+    collectResourceTiming?: boolean,
+    referrerPolicy?: ReferrerPolicyType
+}
 
 export type ResponseCallback<T> = (error: ?Error, data: ?T, cacheControl: ?string, expires: ?string) => void;
 
@@ -111,6 +112,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         credentials: requestParameters.credentials,
         headers: requestParameters.headers,
         referrer: getReferrer(),
+        referrerPolicy: requestParameters.referrerPolicy,
         signal: controller.signal
     });
     let complete = false;

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -43,6 +43,7 @@ if (typeof Object.freeze == 'function') {
  * @property {string} type Response body type to be returned `'string' | 'json' | 'arrayBuffer'`.
  * @property {string} credentials `'same-origin'|'include'` Use 'include' to send cookies with cross-origin requests.
  * @property {boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
+ * @property {string} referrerPolicy A string representing the request's referrerPolicy. For more information and possible values, see the [Referrer-Policy HTTP header page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy).
  * @example
  * // use transformRequest to modify requests that begin with `http://myHost`
  * const map = new Map({


### PR DESCRIPTION
Hi folks, 

we recently had to change the referrer policy on our website to `same-origin` for security reasons. As a result, we are not able to use Mapbox anymore -- the change of policy caused some Mapbox APIs return 403 Forbidden, as the API requires Referer header to be set on requests in order to identify clients, which isn't allowed by our new policy. (see more at https://docs.mapbox.com/accounts/guides/tokens/#requirements-and-limitations)

We cannot relax the referrer policy globally (e.g. to `strict-origin-when-cross-origin`), but we can relax it for the specific requests to Mapbox. The solution is to use [referrerPolicy option on fetch](https://javascript.info/fetch-api).

This PR adds support for overriding referrer policy by returning it from [transformRequest](https://docs.mapbox.com/mapbox-gl-js/api/map/) callback function on Map.

Note that this feature only works in browsers that support [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) interface.

Related issues:
https://github.com/mapbox/mapbox-gl-js/issues/10309
https://github.com/mapbox/mapbox-gl-js/issues/12568

I'd be happy to add some tests but it seems that the underlying testing environment (sinon) doesn't support fetch/Request and the tests use XMLHttpRequest, which doesn't support referrer policy overrides. I tested this manually in the sandbox and also on our website by modifying `mapbox-gl-js` source code in installed node_modules and it works as intended. 

## Launch Checklist
* [x]  briefly describe the changes in this PR
* [x]  manually test the debug page
* [x]  add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Support referrerPolicy option for transformRequest function when using fetch</changelog>`