### PR TITLE
Fix `LngLatBounds.extend()` with literal LngLat object

### DIFF
--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -104,7 +104,7 @@ class LngLatBounds {
                 const lngLatObj = ((obj: any): LngLatLike);
                 return this.extend(LngLat.convert(lngLatObj));
             }
-        } else if (typeof obj === 'object' && obj !== null && obj.hasOwnProperty("lat") && obj.hasOwnProperty("lon")) {
+        } else if (typeof obj === 'object' && obj !== null && obj.hasOwnProperty("lat") && (obj.hasOwnProperty("lon") || obj.hasOwnProperty("lng"))) {
             return this.extend(LngLat.convert(obj));
         } else {
             return this;

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -114,6 +114,20 @@ test('LngLatBounds', (t) => {
         t.end();
     });
 
+    t.test('#extend with literal object LngLat', (t) => {
+        const bounds1 = new LngLatBounds([0, 0], [10, 10]);
+        const bounds2 = {lng: -10, lat: -10};
+
+        bounds1.extend(bounds2);
+
+        t.equal(bounds1.getSouth(), -10);
+        t.equal(bounds1.getWest(), -10);
+        t.equal(bounds1.getNorth(), 10);
+        t.equal(bounds1.getEast(), 10);
+
+        t.end();
+    });
+
     t.test('#extend with null', (t) => {
         const bounds = new LngLatBounds([0, 0], [10, 10]);
 


### PR DESCRIPTION
Add support for extending `LngLatBounds` with literal LngLat object in `{lng: number, lat: number}` format.

Closes https://github.com/mapbox/mapbox-gl-js/issues/12604

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix LngLatBounds.extend() with literal LngLat object.</changelog>`
