### PR TITLE
Add arrow character codes on the verticalizedCharacterMap

### DIFF
--- a/src/util/verticalize_punctuation.js
+++ b/src/util/verticalize_punctuation.js
@@ -85,7 +85,9 @@ export const verticalizedCharacterMap = {
     '｠': '︶',
     '｡': '︒',
     '｢': '﹁',
-    '｣': '﹂'
+    '｣': '﹂',
+    '←': '↑',
+    '→': '↓'
 };
 
 export default function verticalizePunctuation(input: string, skipContextChecking: boolean): string {


### PR DESCRIPTION
## Launch Checklist

I know that CJK fonts are complex to render. During testing, I found that the arrow special character and CJK font representation were ugly. 
This PR describes that is to add arrow special character to the `verticalizedCharacterMap` object.

I had test named [Display line that crosses 180th meridian](https://docs.mapbox.com/mapbox-gl-js/example/line-across-180th-meridian/)

(Ps. I'm awesome about the great mapbox library 👍 )
 

before | after
--|--
<img width="376" alt="image" src="https://user-images.githubusercontent.com/42694076/223629927-a22f07a7-a88e-4a76-9b8e-56447bedded7.png">|<img width="406" alt="image" src="https://user-images.githubusercontent.com/42694076/223630079-2d7e78cf-c986-4467-aee7-7f229d22069f.png">


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add arrow characters to the map of verticalized character</changelog>`
