### PR TITLE
Fix watcher not reloading fixtures when running render tests locally

### DIFF
--- a/test/integration/lib/generate-fixture-json.js
+++ b/test/integration/lib/generate-fixture-json.js
@@ -79,7 +79,7 @@ export function generateFixtureJson(rootDirectory, suiteDirectory, outputDirecto
 
 export function getAllFixtureGlobs(rootDirectory, suiteDirectory) {
     const basePath = path.join(rootDirectory, suiteDirectory);
-    const jsonPaths = path.join(basePath, '/**/[!actual]*.json');
+    const jsonPaths = path.join(basePath, '/**/*.json');
     const imagePaths = path.join(basePath, '/**/*.png');
 
     return [jsonPaths, imagePaths];

--- a/test/integration/lib/middlewares.cjs
+++ b/test/integration/lib/middlewares.cjs
@@ -3,9 +3,13 @@ const fs = require('fs');
 const path = require('path');
 const serveStatic = require('serve-static');
 
-const options = {
+const defaultOptions = {
     index: false,
     fallthrough: false,
+};
+
+const ciOptions = {
+    ...defaultOptions,
     // Explicitly indicate that revalidation is not required because the content never changes.
     maxAge: '1h',
     immutable: true,
@@ -15,7 +19,9 @@ const options = {
     lastModified: false,
 };
 
-const injectMiddlewares = (app) => {
+function injectMiddlewares(app, {ci = false}) {
+    const options = ci ? ciOptions : defaultOptions;
+
     app.use('/mvt-fixtures', serveStatic(path.dirname(require.resolve('@mapbox/mvt-fixtures')), options));
     app.use('/mapbox-gl-styles', serveStatic(path.dirname(require.resolve('mapbox-gl-styles')), options));
 
@@ -43,6 +49,6 @@ const injectMiddlewares = (app) => {
             });
         });
     });
-};
+}
 
 module.exports = {injectMiddlewares};

--- a/test/integration/lib/middlewares.cjs
+++ b/test/integration/lib/middlewares.cjs
@@ -19,8 +19,8 @@ const ciOptions = {
     lastModified: false,
 };
 
-function injectMiddlewares(app, {ci = false}) {
-    const options = ci ? ciOptions : defaultOptions;
+function injectMiddlewares(app, config = {ci: false}) {
+    const options = config.ci ? ciOptions : defaultOptions;
 
     app.use('/mvt-fixtures', serveStatic(path.dirname(require.resolve('@mapbox/mvt-fixtures')), options));
     app.use('/mapbox-gl-styles', serveStatic(path.dirname(require.resolve('mapbox-gl-styles')), options));

--- a/test/integration/testem/testem.js
+++ b/test/integration/testem/testem.js
@@ -167,7 +167,7 @@ module.exports = async function() {
     await (ci ? buildArtifactsCi() : buildArtifactsDev());
 
     const testemConfig = {
-        middleware: [injectMiddlewares],
+        middleware: [(app) => injectMiddlewares(app, {ci})],
         "test_page": testPage,
         "query_params": getQueryParams(),
     };

--- a/test/integration/testem/testem.js
+++ b/test/integration/testem/testem.js
@@ -89,7 +89,7 @@ function buildArtifactsDev() {
     return buildTape().then(() => {
         // A promise that resolves on the first build of fixtures.json
         return new Promise((resolve, reject) => {
-            fixtureWatcher = chokidar.watch(getAllFixtureGlobs(rootFixturePath, suitePath), {ignored: (path) => path.includes('actual.png') || path.includes('actual.json') || path.includes('diff.png')});
+            fixtureWatcher = chokidar.watch(getAllFixtureGlobs(rootFixturePath, suitePath), {ignored: /diff.png|actual.png|actual.json/});
             let needsRebuild = false;
             fixtureWatcher.on('ready', () => {
                 generateFixtureJson(rootFixturePath, suitePath, outputPath, suitePath === 'render-tests');


### PR DESCRIPTION
* Fix fixtures glob
* Disable static server cache if not in CI

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
