### PR TITLE
Re-add Safari render test job in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,14 +493,9 @@ jobs:
   test-render-mac-safari-dev:
     <<: *mac-defaults
     resource_class: macos.m1.large.gen1
-    parallelism: 3
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Creating test list
-          command: |
-            circleci tests glob "test/integration/render-tests/**/*.json" | circleci tests split --split-by=timings > tests-to-run.txt
       - run: yarn run test-render-safari
       - store_test_results:
           path: test/integration/render-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,7 @@ jobs:
 
   test-render-mac-safari-dev:
     <<: *mac-defaults
+    resource_class: macos.m1.large.gen1
     parallelism: 3
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,7 +492,6 @@ jobs:
 
   test-render-mac-safari-dev:
     <<: *mac-defaults
-    resource_class: macos.m1.large.gen1
     parallelism: 3
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ linux-defaults: &linux-defaults
 mac-defaults: &mac-defaults
   macos:
     # https://circleci.com/docs/using-macos/#supported-xcode-versions
-    xcode: 14.2.0 # macOS 12.6 (Monterey)
+    xcode: 14.3.0 # macOS 13.2 (Ventura)
   environment:
     HOMEBREW_NO_AUTO_UPDATE: 1
   working_directory: ~/mapbox-gl-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,13 +149,19 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-render-mac-chrome-webgl2-dev:
+          requires:
+            - prepare-mac
+          filters:
+            tags:
+              only: /.*/
       - test-render-mac-safari-dev:
           requires:
             - prepare-mac
           filters:
             tags:
               only: /.*/
-      - test-render-mac-chrome-webgl2-dev:
+      - test-render-mac-safari-webgl2-dev:
           requires:
             - prepare-mac
           filters:
@@ -490,18 +496,6 @@ jobs:
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
 
-  test-render-mac-safari-dev:
-    <<: *mac-defaults
-    resource_class: macos.m1.large.gen1
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: yarn run test-render-safari
-      - store_test_results:
-          path: test/integration/render-tests
-      - store_artifacts:
-          path: "test/integration/render-tests/index.html"
-
   test-render-mac-chrome-webgl2-dev:
     <<: *mac-defaults
     parallelism: 3
@@ -514,6 +508,30 @@ jobs:
           command: |
             circleci tests glob "test/integration/render-tests/**/*.json" | circleci tests split --split-by=timings > tests-to-run.txt
       - run: USE_WEBGL2=true yarn run test-render
+      - store_test_results:
+          path: test/integration/render-tests
+      - store_artifacts:
+          path: "test/integration/render-tests/index.html"
+
+  test-render-mac-safari-dev:
+    <<: *mac-defaults
+    resource_class: macos.m1.large.gen1
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: yarn run test-render-safari
+      - store_test_results:
+          path: test/integration/render-tests
+      - store_artifacts:
+          path: "test/integration/render-tests/index.html"
+
+  test-render-mac-safari-webgl2-dev:
+    <<: *mac-defaults
+    resource_class: macos.m1.large.gen1
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: USE_WEBGL2=true yarn run test-render-safari
       - store_test_results:
           path: test/integration/render-tests
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,7 @@ linux-defaults: &linux-defaults
   working_directory: ~/mapbox-gl-js
 
 mac-defaults: &mac-defaults
+  resource_class: macos.x86.medium.gen2
   macos:
     # https://circleci.com/docs/using-macos/#supported-xcode-versions
     xcode: 14.3.0 # macOS 13.2 (Ventura)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-render-mac-safari-dev:
+          requires:
+            - prepare-mac
+          filters:
+            tags:
+              only: /.*/
       - test-render-mac-chrome-webgl2-dev:
           requires:
             - prepare-mac
@@ -175,6 +181,8 @@ mac-defaults: &mac-defaults
   macos:
     # https://circleci.com/docs/using-macos/#supported-xcode-versions
     xcode: 14.2.0 # macOS 12.6 (Monterey)
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: 1
   working_directory: ~/mapbox-gl-js
 
 windows-defaults: &windows-defaults
@@ -477,6 +485,23 @@ jobs:
           command: |
             circleci tests glob "test/integration/render-tests/**/*.json" | circleci tests split --split-by=timings > tests-to-run.txt
       - run: yarn run test-render
+      - store_test_results:
+          path: test/integration/render-tests
+      - store_artifacts:
+          path: "test/integration/render-tests/index.html"
+
+  test-render-mac-safari-dev:
+    <<: *mac-defaults
+    resource_class: macos.m1.large.gen1
+    parallelism: 3
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Creating test list
+          command: |
+            circleci tests glob "test/integration/render-tests/**/*.json" | circleci tests split --split-by=timings > tests-to-run.txt
+      - run: yarn run test-render-safari
       - store_test_results:
           path: test/integration/render-tests
       - store_artifacts:

--- a/test/integration/render-tests/fog/space-color/style.json
+++ b/test/integration/render-tests/fog/space-color/style.json
@@ -2,6 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
+      "allowed": 0.00024,
       "width": 512,
       "height": 256,
       "allowed": 0.00027

--- a/test/integration/render-tests/fog/star-intensity/style.json
+++ b/test/integration/render-tests/fog/star-intensity/style.json
@@ -2,6 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
+      "allowed": 0.0004,
       "width": 512,
       "height": 256,
       "allowed": 0.00032

--- a/test/integration/render-tests/terrain/background-clear-optimization/style.json
+++ b/test/integration/render-tests/terrain/background-clear-optimization/style.json
@@ -2,6 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
+      "allowed": 0.00033,
       "height": 256,
       "width": 256,
       "operations": [


### PR DESCRIPTION
Disabling homebrew updates helped to eliminate the Safari timeouts, so re-adding them. At first, I tried to run Safari render tests on Apple Silicon in CircleCI, but it seems to work on the Intel chip with disabled homebrew updates for 6 consecutive runs.

- Re-add Safari render test job in the CI with disabled homebrew updates
- Increase the allowed value for 3 render tests

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
