### PR TITLE
Disable panning inertia if `prefers-reduced-motion` is enabled

### DIFF
--- a/src/ui/handler_inertia.js
+++ b/src/ui/handler_inertia.js
@@ -70,6 +70,10 @@ export default class HandlerInertia {
     }
 
     _onMoveEnd(panInertiaOptions?: DragPanOptions): ?(EasingOptions & {easeId?: string}) {
+        if (browser.prefersReducedMotion) {
+            return;
+        }
+
         this._drainInertiaBuffer();
         if (this._inertiaBuffer.length < 2) {
             return;


### PR DESCRIPTION
This PR removes panning inertia if [prefers reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is enabled. The fix doesn't affect the `essential` option behavior in `AnimationOptions`.

https://user-images.githubusercontent.com/533564/228240276-6af5dff4-a773-4de3-91f5-8be1714f0191.mov

See also https://github.com/mapbox/mapbox-gl-js/pull/8494 and https://github.com/mapbox/mapbox-gl-js/pull/8883

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Disable panning inertia if "prefers-reduced-motion" is enabled</changelog>`
