### PR TITLE
Revert FoV getter in `Transform`

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -395,6 +395,10 @@ class Transform {
         return this.width / this.height;
     }
 
+    get fov(): number {
+        return this._fov / Math.PI * 180;
+    }
+
     get fovX(): number {
         return this._fov;
     }


### PR DESCRIPTION
This is a fix for the regression introduced in https://github.com/mapbox/mapbox-gl-js/pull/12138. It appears that the `threebox-plugin` [depends on the internal Transform API](https://github.com/jscastro76/threebox/blob/417220468b2b099396f5d8591fa5ab9632c7d078/src/Threebox.js#L590), and removing the FoV getter causes the issue in https://github.com/mapbox/mapbox-gl-js/issues/12632

Closes https://github.com/mapbox/mapbox-gl-js/issues/12632

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix the regression with object selection misalignment</changelog>`
