### PR TITLE
Including spaces between Magnitude and Unit in Scale Control Formatting

### DIFF
--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -105,7 +105,7 @@ class ScaleControl {
             // Intl.NumberFormat doesn't support nautical-mile as a unit,
             // so we are hardcoding `nm` as a unit symbol for all locales
             if (unit === 'nautical-mile') {
-                this._container.innerHTML = `${distance}&nbsp;nm`;
+                this._container.innerHTML = `${distance}nm`;
                 return;
             }
 

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -105,12 +105,12 @@ class ScaleControl {
             // Intl.NumberFormat doesn't support nautical-mile as a unit,
             // so we are hardcoding `nm` as a unit symbol for all locales
             if (unit === 'nautical-mile') {
-                this._container.innerHTML = `${distance}nm`;
+                this._container.innerHTML = `${distance}&nbsp;nm`;
                 return;
             }
 
             // $FlowFixMe — flow v0.142.0 doesn't support optional `locales` argument and `unit` style option
-            this._container.innerHTML = new Intl.NumberFormat(this._language, {style: 'unit', unitDisplay: 'narrow', unit}).format(distance);
+            this._container.innerHTML = new Intl.NumberFormat(this._language, {style: 'unit', unitDisplay: 'short', unit}).format(distance);
         });
     }
 


### PR DESCRIPTION
Tackling Scale Control Formatting Consistency Issue #12620. Decided that including spaces between magnitude and unit in the Scale Control for all units would be the best practice, this will also ensure consistency between the legacySetScale (includes spaces) function and _setScale (currently does not include spaces). 
 
Before: 
<img width="228" alt="Screenshot 2023-04-07 at 6 37 15 PM" src="https://user-images.githubusercontent.com/21328194/230697713-d646d8df-bd6b-4fae-a245-a6df5124573e.png">

After:
<img width="221" alt="Screenshot 2023-04-07 at 6 38 08 PM" src="https://user-images.githubusercontent.com/21328194/230697719-0c894041-ecc4-4b78-b639-a03733239d4a.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Adding Spaces between Magnitude and Unit in the Scale Control for all units</changelog>`

