### PR TITLE
Forbid class fields to fix transpilation errors with Vite/ESBuild

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,9 @@
     "no-duplicate-imports": "off",
     "import/no-duplicates": "error",
 
+    // prevent issues with esbuild/vite https://github.com/mapbox/mapbox-gl-js/issues/12656
+    "no-restricted-syntax": ["error", "ClassProperty[value]"],
+
     // ensure compatibility with Node's native ESM
     "import/extensions": ["error", {
       "js": "always",

--- a/src/style/style_layer/line_style_layer.js
+++ b/src/style/style_layer/line_style_layer.js
@@ -22,7 +22,7 @@ import type {TilespaceQueryGeometry} from '../query_geometry.js';
 import type {IVectorTileFeature} from '@mapbox/vector-tile';
 
 class LineFloorwidthProperty extends DataDrivenProperty<number> {
-    useIntegerZoom = true;
+    useIntegerZoom: ?boolean;
 
     possiblyEvaluate(value, parameters) {
         parameters = new EvaluationParameters(Math.floor(parameters.zoom), {

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -69,7 +69,7 @@ test('util', (t) => {
                 this.name = 'Tom';
             }
 
-            ontimer = () => {
+            ontimer() {
                 t.equal(this.name, 'Tom');
                 t.end();
             }

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -76,6 +76,7 @@ test('util', (t) => {
         }
 
         const my = new MyClass();
+        // $FlowFixMe[method-unbinding]
         setTimeout(my.ontimer, 0);
     });
 


### PR DESCRIPTION
Closes #12656, an issue where v2.14 broke building GL JS in some setups involving ESBuild / Vite. The issue was accidentally introduced in #12588 by adding a class field in one place in the source code. In some project setups, this class field introduced a helper method (`__publicField`), which obviously broke our dynamic main thread / worker bundling setup, where helper functions aren't included in the worker code.

The helper function in turn only appears because of subtle inconsistencies between TypeScript class fields and later developed ECMAScript class fields, defined by the [`useDefineForClassFields` option](https://www.typescriptlang.org/tsconfig#useDefineForClassFields). This option is [turned on by default in Vite](https://vitejs.dev/guide/features.html#usedefineforclassfields), so when GL JS is a part of a bundle with Vite (or ESBuild with this option set), and the target is anything below `es2022`, it produces a broken bundle.

For now, I'm introducing an ESLint rule to make sure we don't accidentally introduce class fields in our source code, but in the future, we'll need to think of a way to deal with similar problems related to bundling and new syntax.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix transpilation issues with some setups involving Vite or ESBuild</changelog>`
