### PR TITLE
Improve performance of symbol layers with identical or no text

### DIFF
--- a/debug/symbols-generated.html
+++ b/debug/symbols-generated.html
@@ -57,8 +57,6 @@ map.on('styleimagemissing', ({id}) => {
     ctx.fill();
     ctx.stroke();
 
-    console.log(id);
-
     map.addImage(id, ctx.getImageData(0, 0, size, size), {pixelRatio: 2});
 });
 

--- a/debug/symbols-generated.html
+++ b/debug/symbols-generated.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+
+const map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/satellite-v9',
+    center: [-79.197693, 43.832545],
+    zoom: 15
+});
+
+const canvas = document.createElement('canvas');
+const ctx = canvas.getContext('2d', {willReadFrequently: true});
+
+map.on('styleimagemissing', ({id}) => {
+    const [shape, fill, stroke] = id.split('-');
+    const size = 32;
+
+    ctx.canvas.width = size;
+    ctx.canvas.height = size;
+
+    ctx.fillStyle = fill;
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 4;
+
+    if (shape === 'circle') {
+        ctx.arc(16, 16, 14, 0, Math.PI * 2);
+
+    } else if (shape === 'triangle') {
+        ctx.moveTo(2, 2);
+        ctx.lineTo(30, 2);
+        ctx.lineTo(16, 30);
+
+    } else if (shape === 'square') {
+        ctx.moveTo(4, 4);
+        ctx.lineTo(28, 4);
+        ctx.lineTo(28, 28);
+        ctx.lineTo(4, 28);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+
+    console.log(id);
+
+    map.addImage(id, ctx.getImageData(0, 0, size, size), {pixelRatio: 2});
+});
+
+map.on('load', () => {
+    map.addSource('trees', {
+        'type': 'vector',
+        'url': 'mapbox://william-davis.b5m4mb3c'
+    });
+    map.addLayer({
+        'id': 'trees',
+        'source': 'trees',
+        'source-layer': 'trees',
+        'type': 'symbol',
+        'layout': {
+            // 'icon-image': ['concat', 'square-rgb(0,', ['*', ['round', ['get', 'd_height']], 5], ',0)-green'],
+            'icon-image': ['case', ['<', ['get', 'd_height'], 10], 'circle-red-white', 'triangle-blue-yellow'],
+            'icon-allow-overlap': true,
+            'icon-ignore-placement': true
+        }
+    });
+});
+
+</script>
+</body>
+</html>

--- a/flow-typed/kdbush.js
+++ b/flow-typed/kdbush.js
@@ -1,0 +1,8 @@
+// @flow strict
+declare module 'kdbush' {
+    declare export default class KDBush<T> {
+        points: Array<T>;
+        constructor(points: Array<T>, getX: (T) => number, getY: (T) => number, nodeSize?: number, arrayType?: Class<$ArrayBufferView>): KDBush<T>;
+        range(minX: number, minY: number, maxX: number, maxY: number): Array<number>;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "geojson-vt": "^3.2.1",
     "gl-matrix": "^3.4.3",
     "grid-index": "^1.1.0",
+    "kdbush": "^3.0.0",
     "murmurhash-js": "^1.0.0",
     "pbf": "^3.2.1",
     "potpack": "^2.0.0",

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -14,7 +14,6 @@ import {isMapAuthenticated} from '../util/mapbox.js';
 import posAttributes from '../data/pos_attributes.js';
 import boundsAttributes from '../data/bounds_attributes.js';
 import ProgramConfiguration from '../data/program_configuration.js';
-import CrossTileSymbolIndex from '../symbol/cross_tile_symbol_index.js';
 import shaders from '../shaders/shaders.js';
 import Program from './program.js';
 import {programUniforms} from './program/program_uniforms.js';
@@ -147,7 +146,6 @@ class Painter {
     id: string;
     _showOverdrawInspector: boolean;
     cache: {[_: string]: Program<*> };
-    crossTileSymbolIndex: CrossTileSymbolIndex;
     symbolFadeChange: number;
     gpuTimers: GPUTimers;
     deferredRenderGpuTimeQueries: Array<any>;
@@ -176,8 +174,6 @@ class Painter {
         // This is implemented using the WebGL depth buffer.
         this.numSublayers = SourceCache.maxUnderzooming + SourceCache.maxOverzooming + 1;
         this.depthEpsilon = 1 / Math.pow(2, 16);
-
-        this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
         this.deferredRenderGpuTimeQueries = [];
         this.gpuTimers = {};

--- a/src/symbol/cross_tile_symbol_index.js
+++ b/src/symbol/cross_tile_symbol_index.js
@@ -44,7 +44,9 @@ class TileLayerIndex {
             const {x, y} = this.getScaledCoordinates(symbolInstance, tileID);
             coords.push({x, y, key, crossTileID});
         }
-        this.index = new KDBush(coords, p => p.x, p => p.y, 64, Int32Array);
+        // create a spatial index for deduplicating symbol instances;
+        // use a low nodeSize because we're optimizing for search performance, not indexing
+        this.index = new KDBush(coords, p => p.x, p => p.y, 16, Int32Array);
     }
 
     // Converts the coordinates of the input symbol instance into coordinates that be can compared

--- a/src/symbol/cross_tile_symbol_index.js
+++ b/src/symbol/cross_tile_symbol_index.js
@@ -32,7 +32,7 @@ const roundingFactor = 512 / EXTENT / 2;
 class TileLayerIndex {
     tileID: OverscaledTileID;
     bucketInstanceId: number;
-    index: KDBush;
+    index: KDBush<{x: number, y: number, key: number, crossTileID: number}>;
 
     constructor(tileID: OverscaledTileID, symbolInstances: SymbolInstanceArray, bucketInstanceId: number) {
         this.tileID = tileID;

--- a/test/unit/symbol/cross_tile_symbol_index.js
+++ b/test/unit/symbol/cross_tile_symbol_index.js
@@ -146,7 +146,7 @@ test('CrossTileSymbolIndex.addLayer', (t) => {
         t.equal(mainInstances[1].crossTileID, 2);
 
         const layerIndex = index.layerIndexes[styleLayer.id];
-        t.deepEqual(Object.keys(layerIndex.usedCrossTileIDs[6]), [1, 2]);
+        t.deepEqual([...layerIndex.usedCrossTileIDs[6]], [1, 2]);
 
         // copies parent ids without duplicate ids in this tile
         index.addLayer(styleLayer, [childTile], 0, {name: 'mercator'});
@@ -155,8 +155,8 @@ test('CrossTileSymbolIndex.addLayer', (t) => {
         t.equal(childInstances[2].crossTileID, 3); // C' gets new ID
 
         // Updates per-zoom usedCrossTileIDs
-        t.deepEqual(Object.keys(layerIndex.usedCrossTileIDs[6]), []);
-        t.deepEqual(Object.keys(layerIndex.usedCrossTileIDs[7]), [1, 2, 3]);
+        t.deepEqual([...layerIndex.usedCrossTileIDs[6]], []);
+        t.deepEqual([...layerIndex.usedCrossTileIDs[7]], [1, 2, 3]);
 
         t.end();
     });
@@ -184,7 +184,7 @@ test('CrossTileSymbolIndex.addLayer', (t) => {
         t.equal(firstInstances[1].crossTileID, 2);
 
         const layerIndex = index.layerIndexes[styleLayer.id];
-        t.deepEqual(Object.keys(layerIndex.usedCrossTileIDs[6]), [1, 2]);
+        t.deepEqual([...layerIndex.usedCrossTileIDs[6]], [1, 2]);
 
         // uses same ids when tile gets updated
         index.addLayer(styleLayer, [secondTile], 0, {name: 'mercator'});
@@ -192,7 +192,7 @@ test('CrossTileSymbolIndex.addLayer', (t) => {
         t.equal(secondInstances[1].crossTileID, 2); // B' copies from B
         t.equal(secondInstances[2].crossTileID, 3); // C' gets new ID
 
-        t.deepEqual(Object.keys(layerIndex.usedCrossTileIDs[6]), [1, 2, 3]);
+        t.deepEqual([...layerIndex.usedCrossTileIDs[6]], [1, 2, 3]);
 
         t.end();
     });


### PR DESCRIPTION
Closes #7973. There was an accidental quadratic behavior in `CrossTileSymbolIndex` (responsible for deduplicating symbols across tiles) when a map had a ton of symbols with the same text (or no text, just an icon).

This PR changes the logic so that instead of indexing symbol instances by key (which is a numeric hash of its text), we make a KDBush index and search for duplicate symbols spatially. KDBush is already included as a dependency of Supercluster, so it doesn't increase the bundle size, and it's pretty fast, so the approach should work well for both the "lots of identical icons" (added in the `debug/symbols-generated.html` debug page) and "lots of different text labels" (e.g. Streets) cases.

In theory, this should also improve memory footprint for Streets because we avoid creating thousands of small arrays and a big object with key to array mapping — KDBush is much more memory-efficient. We should run a benchmark before merging to make sure it doesn't accidentally regress anything.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port — @alexshalamov this affects Native too because it has the same logic.
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Improve performance of symbol layers with identical or no text</changelog>`
