### PR TITLE
Fix inconsistency removeFeatureState docs #12612

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2836,7 +2836,6 @@ class Map extends Camera {
         return this._update();
     }
 
-
     /**
      * Gets the `state` of a feature.
      * A feature's `state` is a set of user-defined key-value pairs that are assigned to a feature at runtime.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2794,10 +2794,10 @@ class Map extends Camera {
      *
      * @param {Object} feature Identifier of where to remove state. It can be a source, a feature, or a specific key of feature.
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
+     * @param {number | string} [feature.id] (optional) Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional) For vector tile sources, `sourceLayer` is required.
-     * @param {string} key (optional) The key in the feature state to reset.
+     * @param {string} [key] (optional) The key in the feature state to reset.
      *
      * @example
      * // Reset the entire state object for all features
@@ -2830,11 +2830,12 @@ class Map extends Camera {
      *     }, 'hover');
      * });
      *
-    */
+     */
     removeFeatureState(feature: { source: string; sourceLayer?: string; id?: string | number; }, key?: string): this {
         this.style.removeFeatureState(feature, key);
         return this._update();
     }
+
 
     /**
      * Gets the `state` of a feature.


### PR DESCRIPTION
This PR addresses the issue of inconsistent parameter descriptions in the removeFeatureState documentation. The original lines have been replaced with new lines to provide clearer and more accurate descriptions of the optional parameters.

Changes made:
- Removed original lines with inconsistent parameter descriptions
- Added new lines with updated and consistent parameter descriptions

Here is the updated code snippet:

```js
    * @param {number | string} [feature.id] (optional) Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
    * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
    * @param {string} [feature.sourceLayer] (optional) For vector tile sources, `sourceLayer` is required.
    * @param {string} [key] (optional) The key in the feature state to reset.
```

Closes https://github.com/mapbox/mapbox-gl-js/issues/12612