### PR TITLE
clarify layer requirements in clustered source methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features ✨ and improvements 🏁
 
+* Clarify layer requirements in documentation examples related to clustered source methods ([#12680](https://github.com/mapbox/mapbox-gl-js/pull/12680))
+
 * Support `referrerPolicy` option for the `transformRequest` function when using fetch ([#12590](https://github.com/mapbox/mapbox-gl-js/pull/12590)) (h/t [robertcepa](https://github.com/robertcepa))
 
 ## Bug fixes 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Features ✨ and improvements 🏁
 
-* Clarify layer requirements in documentation examples related to clustered source methods ([#12680](https://github.com/mapbox/mapbox-gl-js/pull/12680))
-
 * Support `referrerPolicy` option for the `transformRequest` function when using fetch ([#12590](https://github.com/mapbox/mapbox-gl-js/pull/12590)) (h/t [robertcepa](https://github.com/robertcepa))
 
 ## Bug fixes 🐞

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -196,6 +196,7 @@ class GeoJSONSource extends Evented implements Source {
      * @example
      * // Assuming the map has a layer named 'clusters' and a source 'earthquakes'
      * // The following creates a camera animation on cluster feature click
+     * // the clicked layer should be filtered to only include clusters, e.g. `filter: ['has', 'point_count']`
      * map.on('click', 'clusters', (e) => {
      *     const features = map.queryRenderedFeatures(e.point, {
      *         layers: ['clusters']
@@ -230,6 +231,7 @@ class GeoJSONSource extends Evented implements Source {
      * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example
      * // Retrieve cluster children on click
+     * // the clicked layer should be filtered to only include clusters, e.g. `filter: ['has', 'point_count']`
      * map.on('click', 'clusters', (e) => {
      *     const features = map.queryRenderedFeatures(e.point, {
      *         layers: ['clusters']
@@ -260,6 +262,7 @@ class GeoJSONSource extends Evented implements Source {
      * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example
      * // Retrieve cluster leaves on click
+     * // the clicked layer should be filtered to only include clusters, e.g. `filter: ['has', 'point_count']`
      * map.on('click', 'clusters', (e) => {
      *     const features = map.queryRenderedFeatures(e.point, {
      *         layers: ['clusters']


### PR DESCRIPTION
Based on docs user feedback, this PR clarifies some of the sample code related to clustered source methods (`getClusterExpansionZoom`, `getClusterChildren`, & `getClusterLeaves`), adding a reminder that the layer being clicked must have been filtered to only include clusters.

The text from the original docs feedback:

> getClusterLeaves - I wasted days figuring out this error `No cluster with the specified id` even though I was sure the cluster id was correct. In the end I discovered that the layer must have clusters ONLY, in other words it must have this option `filter: ['has', 'point_count']`. This should be explicitly documented here.

 - [*] briefly describe the changes in this PR

changelog: `<changelog>Clarify layer requirements in documentation examples related to clustered source methods</changelog>`
