### PR TITLE
Add `respectPrefersReducedMotion` map option

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -90,8 +90,7 @@ export type CameraOptions = {
     bearing?: number,
     pitch?: number,
     around?: LngLatLike,
-    padding?: PaddingOptions,
-    offset?: PointLike
+    padding?: PaddingOptions
 };
 
 export type FullCameraOptions = {
@@ -192,6 +191,7 @@ class Camera extends Evented {
     _easeStart: number;
     _easeOptions: {duration: number, easing: (_: number) => number};
     _easeId: string | void;
+    _respectPrefersReducedMotion: boolean;
 
     _onEaseFrame: ?(_: number) => Transform | void;
     _onEaseEnd: ?(easeId?: string) => void;
@@ -202,12 +202,13 @@ class Camera extends Evented {
 
     +_preloadTiles: (transform: Transform | Array<Transform>, callback?: Callback<any>) => any;
 
-    constructor(transform: Transform, options: {bearingSnap: number}) {
+    constructor(transform: Transform, options: {bearingSnap: number, respectPrefersReducedMotion: ?boolean}) {
         super();
         this._moving = false;
         this._zooming = false;
         this.transform = transform;
         this._bearingSnap = options.bearingSnap;
+        this._respectPrefersReducedMotion = options.respectPrefersReducedMotion !== false;
 
         bindAll(['_renderFrameCallback'], this);
 
@@ -1255,7 +1256,7 @@ class Camera extends Evented {
             easing: defaultEasing
         }, options);
 
-        if (options.animate === false || (!options.essential && browser.prefersReducedMotion)) options.duration = 0;
+        if (options.animate === false || this._prefersReducedMotion(options)) options.duration = 0;
 
         const tr = this.transform,
             startZoom = this.getZoom(),
@@ -1499,7 +1500,7 @@ class Camera extends Evented {
      */
     flyTo(options: EasingOptions, eventData?: Object): this {
         // Fall through to jumpTo if user has set prefers-reduced-motion
-        if (!options.essential && browser.prefersReducedMotion) {
+        if (this._prefersReducedMotion(options)) {
             const coercedOptions = pick(options, ['center', 'zoom', 'bearing', 'pitch', 'around']);
             return this.jumpTo(coercedOptions, eventData);
         }
@@ -1757,6 +1758,12 @@ class Camera extends Evented {
         center.lng +=
             delta > 180 ? -360 :
             delta < -180 ? 360 : 0;
+    }
+
+    _prefersReducedMotion(options: ?AnimationOptions): boolean {
+        const essential = options && options.essential;
+        const prefersReducedMotion = this._respectPrefersReducedMotion && browser.prefersReducedMotion;
+        return prefersReducedMotion && !essential;
     }
 
     // emulates frame function for some transform

--- a/src/ui/handler_inertia.js
+++ b/src/ui/handler_inertia.js
@@ -70,7 +70,7 @@ export default class HandlerInertia {
     }
 
     _onMoveEnd(panInertiaOptions?: DragPanOptions): ?(EasingOptions & {easeId?: string}) {
-        if (browser.prefersReducedMotion) {
+        if (this._map._prefersReducedMotion()) {
             return;
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -183,6 +183,7 @@ const defaultOptions = {
     transformRequest: null,
     accessToken: null,
     fadeDuration: 300,
+    respectPrefersReducedMotion: true,
     crossSourceCollisions: true
 };
 
@@ -288,6 +289,7 @@ const defaultOptions = {
  *   Expected to return a {@link RequestParameters} object with a `url` property and optionally `headers` and `credentials` properties.
  * @param {boolean} [options.collectResourceTiming=false] If `true`, Resource Timing API information will be collected for requests made by GeoJSON and Vector Tile web workers (this information is normally inaccessible from the main Javascript thread). Information will be returned in a `resourceTiming` property of relevant `data` events.
  * @param {number} [options.fadeDuration=300] Controls the duration of the fade-in/fade-out animation for label collisions, in milliseconds. This setting affects all symbol layers. This setting does not affect the duration of runtime styling transitions or raster tile cross-fading.
+ * @param {boolean} [options.respectPrefersReducedMotion=true] If set to `true`, the map will respect the user's `prefers-reduced-motion` browser setting and apply a reduced motion mode, minimizing animations and transitions. When set to `false`, the map will always ignore the `prefers-reduced-motion` settings, regardless of the user's preference, making all animations essential.
  * @param {boolean} [options.crossSourceCollisions=true] If `true`, symbols from multiple sources can collide with each other during collision detection. If `false`, collision detection is run separately for the symbols in each source.
  * @param {string} [options.accessToken=null] If specified, map will use this [token](https://docs.mapbox.com/help/glossary/access-token/) instead of the one defined in `mapboxgl.accessToken`.
  * @param {Object} [options.locale=null] A patch to apply to the default localization table for UI strings such as control tooltips. The `locale` object maps namespaced UI string IDs to translated strings in the target language;

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -26,7 +26,7 @@ test('camera', (t) => {
         const transform = new Transform(0, 20, 0, 85, options.renderWorldCopies, options.projection);
         transform.resize(512, 512);
 
-        const camera = attachSimulateFrame(new Camera(transform, {}))
+        const camera = attachSimulateFrame(new Camera(transform, options))
             .jumpTo(options);
 
         camera._update = () => {};
@@ -970,6 +970,42 @@ test('camera', (t) => {
                 camera.simulateFrame();
 
                 camera.easeTo({center: [100, 0], zoom: 3.2, bearing: 90, duration: 200, essential: true});
+
+                setTimeout(() => {
+                    stubNow.callsFake(() => 200);
+                    camera.simulateFrame();
+                }, 0);
+            }, 0);
+        });
+
+        t.test('animation occurs when prefers-reduced-motion: reduce is set but overridden by respectPrefersReducedMotion: false', (t) => {
+            const camera = createCamera({respectPrefersReducedMotion: false});
+
+            const stubPrefersReducedMotion = t.stub(browser, 'prefersReducedMotion');
+            const stubNow = t.stub(browser, 'now');
+
+            stubPrefersReducedMotion.get(() => true);
+
+            // camera transition expected to take in this range when prefersReducedMotion is set and essential: true,
+            // when a duration of 200 is requested
+            const min = 100;
+            const max = 300;
+
+            let startTime;
+            camera
+                .on('movestart', () => { startTime = browser.now(); })
+                .on('moveend', () => {
+                    const endTime = browser.now();
+                    const timeDiff = endTime - startTime;
+                    t.ok(timeDiff >= min && timeDiff < max, `Camera transition time exceeded expected range( [${min},${max}) ) :${timeDiff}`);
+                    t.end();
+                });
+
+            setTimeout(() => {
+                stubNow.callsFake(() => 0);
+                camera.simulateFrame();
+
+                camera.easeTo({center: [100, 0], zoom: 3.2, bearing: 90, duration: 200});
 
                 setTimeout(() => {
                     stubNow.callsFake(() => 200);


### PR DESCRIPTION
Adds `respectPrefersReducedMotion` map option (`true` by default). If set to `true`, the map will respect the user's `prefers-reduced-motion` browser setting and apply a reduced motion mode, minimizing animations and transitions if it is set to `reduce`. When set to `false`, the map will always ignore the `prefers-reduced-motion` settings, regardless of the user's preference, making all animations essential.

https://user-images.githubusercontent.com/533564/235982697-4bcc7e49-7111-4c64-8c57-25f0cb23faf3.mov

See also #849, #8883, and #12631

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add "respectPrefersReducedMotion" map option</changelog>`
