### PR TITLE
Add the `isPointOnSurface` method

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1363,7 +1363,7 @@ class Transform {
      */
     isPointOnSurface(p: Point): boolean {
         if (p.y < 0 || p.y > this.height || p.x < 0 || p.x > this.width) return false;
-        if (this.elevation) return !this.isPointAboveHorizon(p);
+        if (this.elevation || this.zoom >= GLOBE_ZOOM_THRESHOLD_MAX) return !this.isPointAboveHorizon(p);
         const coord = this.pointCoordinate(p);
         return coord.y >= 0 && coord.y <= 1;
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1355,6 +1355,21 @@ class Transform {
     }
 
     /**
+     * Determines if the given point is located on a visible map surface.
+     *
+     * @param {Point} p
+     * @returns {boolean}
+     * @private
+     */
+    isPointOnSurface(p: Point): boolean {
+        if (p.y < 0 || p.y > this.height || p.x < 0 || p.x > this.width) return false;
+        if (this.elevation) return !this.isPointAboveHorizon(p);
+        const coord = this.pointCoordinate(p);
+        console.log(coord);
+        return coord.y >= 0 && coord.y <= 1;
+    }
+
+    /**
      * Given a coordinate, return the screen point that corresponds to it
      * @param {Coordinate} coord
      * @param {boolean} sampleTerrainIn3D in 3D mode (terrain enabled), sample elevation for the point.

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1365,7 +1365,6 @@ class Transform {
         if (p.y < 0 || p.y > this.height || p.x < 0 || p.x > this.width) return false;
         if (this.elevation) return !this.isPointAboveHorizon(p);
         const coord = this.pointCoordinate(p);
-        console.log(coord);
         return coord.y >= 0 && coord.y <= 1;
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1834,7 +1834,7 @@ class Map extends Camera {
      */
     isPointOnSurface(point: PointLike): boolean {
         const {name} = this.transform.projection;
-        if (name !== 'globe' || name !== 'mercator') {
+        if (name !== 'globe' && name !== 'mercator') {
             warnOnce(`${name} projection does not support isPointOnSurface, this API may behave unexpectedly.`);
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1833,7 +1833,7 @@ class Map extends Camera {
      * const pointOnSurface = map.isPointOnSurface([100, 200]);
      */
     isPointOnSurface(point: PointLike): boolean {
-        return !this.transform.isPointAboveHorizon(Point.convert(point));
+        return this.transform.isPointOnSurface(Point.convert(point));
     }
 
     /** @section {Working with styles} */

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1824,6 +1824,18 @@ class Map extends Camera {
         return this.style.querySourceFeatures(sourceId, parameters);
     }
 
+    /**
+     * Determines if the given point is located on a visible map surface.
+     *
+     * @param {PointLike} point - The point to be checked, specified as an array of two numbers representing the x and y coordinates, or as a {@link https://docs.mapbox.com/mapbox-gl-js/api/geography/#point|Point} object.
+     * @returns {boolean} Returns `true` if the point is on the visible map surface, otherwise returns `false`.
+     * @example
+     * const pointOnSurface = map.isPointOnSurface([100, 200]);
+     */
+    isPointOnSurface(point: PointLike): boolean {
+        return !this.transform.isPointAboveHorizon(Point.convert(point));
+    }
+
     /** @section {Working with styles} */
 
     /**

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1833,6 +1833,10 @@ class Map extends Camera {
      * const pointOnSurface = map.isPointOnSurface([100, 200]);
      */
     isPointOnSurface(point: PointLike): boolean {
+        if (this.transform.projection.name !== 'globe' || this.transform.projection.name !== 'mercator') {
+            warnOnce(`${this.transform.projection.name} projection do not support isPointOnSurface API, this API may behave unexpectedly.`);
+        }
+
         return this.transform.isPointOnSurface(Point.convert(point));
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1833,8 +1833,9 @@ class Map extends Camera {
      * const pointOnSurface = map.isPointOnSurface([100, 200]);
      */
     isPointOnSurface(point: PointLike): boolean {
-        if (this.transform.projection.name !== 'globe' || this.transform.projection.name !== 'mercator') {
-            warnOnce(`${this.transform.projection.name} projection do not support isPointOnSurface API, this API may behave unexpectedly.`);
+        const {name} = this.transform.projection;
+        if (name !== 'globe' || name !== 'mercator') {
+            warnOnce(`${name} projection does not support isPointOnSurface, this API may behave unexpectedly.`);
         }
 
         return this.transform.isPointOnSurface(Point.convert(point));

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -4044,6 +4044,59 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.only('#isPointOnSurface', (t) => {
+
+        t.test('Mercator', (t) => {
+            const map = createMap(t, {
+                zoom: 0,
+                projection: 'mercator'
+            });
+
+            t.ok(map.isPointOnSurface([100, 100]), 'center of the map');
+            t.notOk(map.isPointOnSurface([-100, -100]), 'top left outside of the map');
+            t.notOk(map.isPointOnSurface([300, 300]), 'bottom right outside of the map');
+
+            // With pitch
+            map.setPitch(90);
+            t.ok(map.isPointOnSurface([100, 100]), 'center of the map');
+            t.notOk(map.isPointOnSurface([100, 99]), 'above the horizon');
+
+            t.end();
+        });
+
+        t.test('Globe', (t) => {
+            const map = createMap(t, {
+                zoom: 0,
+                projection: 'globe'
+            });
+
+            // On the Globe
+            t.ok(map.isPointOnSurface([45, 45]));
+            t.ok(map.isPointOnSurface([135, 45]));
+            t.ok(map.isPointOnSurface([135, 135]));
+            t.ok(map.isPointOnSurface([45, 135]));
+
+            // Off the Globe
+            t.notOk(map.isPointOnSurface([25, 25]));
+            t.notOk(map.isPointOnSurface([175, 25]));
+            t.notOk(map.isPointOnSurface([175, 175]));
+            t.notOk(map.isPointOnSurface([25, 175]));
+
+            // North pole
+            map.setCenter([0, 90]);
+            t.ok(map.isPointOnSurface([100, 100]));
+
+            // North pole with pitch
+            map.setPitch(90);
+            t.ok(map.isPointOnSurface([100, 100]));
+            t.notOk(map.isPointOnSurface([100, 99]));
+
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.end();
 });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -4102,6 +4102,15 @@ test('Map', (t) => {
                 t.equal(map.isPointOnSurface([100, 100]), true, 'center of the map');
                 t.equal(map.isPointOnSurface([100, 85]), false, 'above the horizon');
 
+                map.setZoom(5);
+                map.setCenter([0, 0]);
+                t.equal(map.isPointOnSurface([100, 100]), true, 'on the globe on zoom 5');
+                t.equal(map.isPointOnSurface([100, 85]), false, 'above the horizon on zoom 5');
+
+                map.setZoom(6);
+                t.equal(map.isPointOnSurface([100, 100]), true, 'on the globe on zoom 6');
+                t.equal(map.isPointOnSurface([100, 85]), false, 'above the horizon on zoom 6');
+
                 t.end();
             });
         });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -4044,7 +4044,20 @@ test('Map', (t) => {
         t.end();
     });
 
-    t.only('#isPointOnSurface', (t) => {
+    t.test('#isPointOnSurface', (t) => {
+
+        t.test('Off the map', (t) => {
+            const map = createMap(t);
+
+            t.equal(map.isPointOnSurface([100, 100]), true, 'center of the map');
+            t.equal(map.isPointOnSurface([0, 0]), true, 'top left of the map');
+            t.equal(map.isPointOnSurface([200, 200]), true, 'bottom right of the map');
+
+            t.equal(map.isPointOnSurface([-100, -100]), false, 'top left outside of the map');
+            t.equal(map.isPointOnSurface([300, 300]), false, 'bottom right outside of the map');
+
+            t.end();
+        });
 
         t.test('Mercator', (t) => {
             const map = createMap(t, {
@@ -4052,14 +4065,11 @@ test('Map', (t) => {
                 projection: 'mercator'
             });
 
-            t.ok(map.isPointOnSurface([100, 100]), 'center of the map');
-            t.notOk(map.isPointOnSurface([-100, -100]), 'top left outside of the map');
-            t.notOk(map.isPointOnSurface([300, 300]), 'bottom right outside of the map');
+            t.equal(map.isPointOnSurface([100, 100]), true, 'center of the map');
 
-            // With pitch
             map.setPitch(90);
-            t.ok(map.isPointOnSurface([100, 100]), 'center of the map');
-            t.notOk(map.isPointOnSurface([100, 99]), 'above the horizon');
+            t.equal(map.isPointOnSurface([100, 100]), true, 'center of the map');
+            t.equal(map.isPointOnSurface([100, 85]), false, 'above the horizon');
 
             t.end();
         });
@@ -4070,28 +4080,30 @@ test('Map', (t) => {
                 projection: 'globe'
             });
 
-            // On the Globe
-            t.ok(map.isPointOnSurface([45, 45]));
-            t.ok(map.isPointOnSurface([135, 45]));
-            t.ok(map.isPointOnSurface([135, 135]));
-            t.ok(map.isPointOnSurface([45, 135]));
+            map.on('load', () => {
+                // On the Globe
+                t.equal(map.isPointOnSurface([45, 45]), true, 'top left on the globe');
+                t.equal(map.isPointOnSurface([135, 45]), true, 'top right on the globe');
+                t.equal(map.isPointOnSurface([135, 135]), true, 'bottom right on the globe');
+                t.equal(map.isPointOnSurface([45, 135]), true, 'bottom left on the globe');
 
-            // Off the Globe
-            t.notOk(map.isPointOnSurface([25, 25]));
-            t.notOk(map.isPointOnSurface([175, 25]));
-            t.notOk(map.isPointOnSurface([175, 175]));
-            t.notOk(map.isPointOnSurface([25, 175]));
+                // Off the Globe
+                t.equal(map.isPointOnSurface([25, 25]), false, 'top left off the globe');
+                t.equal(map.isPointOnSurface([175, 25]), false, 'top right off the globe');
+                t.equal(map.isPointOnSurface([175, 175]), false, 'bottom right off the globe');
+                t.equal(map.isPointOnSurface([25, 175]), false, 'bottom left off the globe');
 
-            // North pole
-            map.setCenter([0, 90]);
-            t.ok(map.isPointOnSurface([100, 100]));
+                // North pole
+                map.setCenter([0, 90]);
+                t.equal(map.isPointOnSurface([100, 100]), true, 'center of the map');
 
-            // North pole with pitch
-            map.setPitch(90);
-            t.ok(map.isPointOnSurface([100, 100]));
-            t.notOk(map.isPointOnSurface([100, 99]));
+                // North pole with pitch
+                map.setPitch(90);
+                t.equal(map.isPointOnSurface([100, 100]), true, 'center of the map');
+                t.equal(map.isPointOnSurface([100, 85]), false, 'above the horizon');
 
-            t.end();
+                t.end();
+            });
         });
 
         t.end();


### PR DESCRIPTION
Adds the `isPointOnSurface` map method to determine if the given point is located on a visible map surface.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add the "isPointOnSurface" map method to determine if the given point is located on a visible map surface.</changelog>`
