### PR TITLE
Use WebGL2 in render tests by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-render-linux-firefox-dev:
+      - test-render-linux-chrome-webgl1-dev:
           requires:
             - prepare-linux
           filters:
@@ -139,6 +139,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-render-linux-firefox-dev:
+          requires:
+            - prepare-linux
+          filters:
+            tags:
+              only: /.*/
       - prepare-mac:
           filters:
             tags:
@@ -149,7 +155,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-render-mac-chrome-webgl2-dev:
+      - test-render-mac-chrome-webgl1-dev:
           requires:
             - prepare-mac
           filters:
@@ -161,7 +167,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-render-mac-safari-webgl2-dev:
+      - test-render-mac-safari-webgl1-dev:
           requires:
             - prepare-mac
           filters:
@@ -423,6 +429,21 @@ jobs:
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
 
+  test-render-linux-chrome-webgl1-dev:
+    <<: *linux-defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - browser-tools/install-chrome
+      - run:
+          name: Running tests in parallel
+          command: |
+            USE_WEBGL2=false yarn run test-render
+      - store_test_results:
+          path: test/integration/render-tests
+      - store_artifacts:
+          path: "test/integration/render-tests/index.html"
+
   test-render-linux-chrome-prod:
     <<: *linux-defaults
     steps:
@@ -497,7 +518,7 @@ jobs:
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
 
-  test-render-mac-chrome-webgl2-dev:
+  test-render-mac-chrome-webgl1-dev:
     <<: *mac-defaults
     parallelism: 3
     steps:
@@ -508,7 +529,7 @@ jobs:
           name: Creating test list
           command: |
             circleci tests glob "test/integration/render-tests/**/*.json" | circleci tests split --split-by=timings > tests-to-run.txt
-      - run: USE_WEBGL2=true yarn run test-render
+      - run: USE_WEBGL2=false yarn run test-render
       - store_test_results:
           path: test/integration/render-tests
       - store_artifacts:
@@ -526,13 +547,13 @@ jobs:
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
 
-  test-render-mac-safari-webgl2-dev:
+  test-render-mac-safari-webgl1-dev:
     <<: *mac-defaults
     resource_class: macos.m1.large.gen1
     steps:
       - attach_workspace:
           at: ~/
-      - run: USE_WEBGL2=true yarn run test-render-safari
+      - run: USE_WEBGL2=false yarn run test-render-safari
       - store_test_results:
           path: test/integration/render-tests
       - store_artifacts:

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -59,6 +59,8 @@ tape.onFinish(() => {
 let ignoreList;
 let timeout = 30000;
 
+const useWebGL2 = process.env.USE_WEBGL2 ? process.env.USE_WEBGL2 !== 'false' : true;
+
 if (process.env.CI) {
     const ua = navigator.userAgent;
     const browser = ua.includes('Firefox') ? 'firefox' :
@@ -129,13 +131,12 @@ function parseStyle(currentFixture) {
     return style;
 }
 
-function parseOptions(currentFixture, style, useWebGL2) {
+function parseOptions(currentFixture, style) {
     const options = {
         width: 512,
         height: 512,
         pixelRatio: 1,
         allowed: 0.00015,
-        useWebGL2,
         ...((style.metadata && style.metadata.test) || {})
     };
 
@@ -192,7 +193,7 @@ async function renderMap(style, options) {
         attributionControl: false,
         preserveDrawingBuffer: true,
         axonometric: options.axonometric || false,
-        useWebGL2: options.useWebGL2 || false,
+        useWebGL2,
         skew: options.skew || [0, 0],
         fadeDuration: options.fadeDuration || 0,
         optimizeForTerrain: options.optimizeForTerrain || false,
@@ -323,7 +324,7 @@ async function runTest(t) {
         const expectedImages = await getExpectedImages(currentTestName, currentFixture);
 
         const style = parseStyle(currentFixture);
-        const options = parseOptions(currentFixture, style, process.env.USE_WEBGL2 && process.env.USE_WEBGL2 === 'true');
+        const options = parseOptions(currentFixture, style);
         const {actualImageData, w, h} = await getActualImage(style, options);
 
         if (process.env.UPDATE) {


### PR DESCRIPTION
Switches render tests to use WebGL2 by default. Adds WebGL1 render tests for:

* Chrome on Linux
* Chrome on macOS
* Safari on macOS

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
