### PR TITLE
Introduce padding for popup

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -587,10 +587,10 @@ export default class Popup extends Evented {
         const width = container.offsetWidth;
         const height = container.offsetHeight;
 
-        const isTop = pos.y + bottomY - this.options.padding.top < height;
+        const isTop = pos.y + bottomY < height + this.options.padding.top;
         const isBottom = pos.y > map.transform.height - height - this.options.padding.bottom;
         const isLeft = pos.x < width / 2 + this.options.padding.left;
-        const isRight = pos.x  > map.transform.width - width / 2 - this.options.padding.right;
+        const isRight = pos.x > map.transform.width - width / 2 - this.options.padding.right;
 
         if (isTop) {
             if (isLeft) return 'top-left';
@@ -696,14 +696,14 @@ function normalizeOffset(offset: Offset = new Point(0, 0), anchor: Anchor = 'bot
         // input specifies a radius from which to calculate offsets at all positions
         const cornerOffset = Math.round(Math.sqrt(0.5 * Math.pow(offset, 2)));
         switch (anchor) {
-            case 'top': return new Point(0, offset);
-            case 'top-left': return new Point(cornerOffset, cornerOffset);
-            case 'top-right': return new Point(-cornerOffset, cornerOffset);
-            case 'bottom': return new Point(0, -offset);
-            case 'bottom-left': return new Point(cornerOffset, -cornerOffset);
-            case 'bottom-right': return new Point(-cornerOffset, -cornerOffset);
-            case 'left': return new Point(offset, 0);
-            case 'right': return new Point(-offset, 0);
+        case 'top': return new Point(0, offset);
+        case 'top-left': return new Point(cornerOffset, cornerOffset);
+        case 'top-right': return new Point(-cornerOffset, cornerOffset);
+        case 'bottom': return new Point(0, -offset);
+        case 'bottom-left': return new Point(cornerOffset, -cornerOffset);
+        case 'bottom-right': return new Point(-cornerOffset, -cornerOffset);
+        case 'left': return new Point(offset, 0);
+        case 'right': return new Point(-offset, 0);
         }
         return new Point(0, 0);
     }

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -479,6 +479,27 @@ test('Popup', (t) => {
         const point = args[1];
         const transform = args[2];
 
+        test('Popup respects padding and changes anchor accordingly', (t) => {
+            const map = createMap(t);
+            const padding = {top: 10, bottom: 10, left: 10, right: 10};
+            const popup = new Popup({padding})
+                .setText('Test')
+                .setLngLat([0, 0])
+                .addTo(map);
+            map._domRenderTaskQueue.run();
+
+            Object.defineProperty(popup.getElement(), 'offsetWidth', {value: 5});
+            Object.defineProperty(popup.getElement(), 'offsetHeight', {value: 5});
+
+            t.stub(map, 'project').returns(point);
+            t.stub(map.transform, 'locationPoint3D').returns(point);
+            popup.setLngLat([0, 0]);
+            map._domRenderTaskQueue.run();
+
+            t.ok(popup.getElement().classList.contains(`mapboxgl-popup-anchor-${anchor}`));
+            t.end();
+        });
+
         test(`Popup automatically anchors to ${anchor}`, (t) => {
             const map = createMap(t);
             const popup = new Popup()


### PR DESCRIPTION
Hey, In my app there are HTML elements overlayed on top of map container - `Popup` of course does not respect them and hides below them.
In this PR I introduced optional padding for `Popup` class so popup anchor is not calculated only based on map container dimensions but also takes given padding into consideration.

Before:

https://github.com/mapbox/mapbox-gl-js/assets/34219675/020d8de5-4794-4d66-a707-a75e024cf822

After: 


https://github.com/mapbox/mapbox-gl-js/assets/34219675/3b29bf9e-8347-408b-9744-6ae1a78e8137

@mapbox

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Introduce padding to Popup</changelog>`
