### PR TITLE
Update map to use fullscreenchange event when available

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -366,6 +366,7 @@ class Map extends Camera {
     _refreshExpiredTiles: boolean;
     _hash: Hash;
     _delegatedListeners: any;
+    _fullscreenchangeEvent: "fullscreenchange" | "webkitfullscreenchange";
     _isInitialLoad: boolean;
     _shouldCheckAccess: boolean;
     _fadeDuration: number;
@@ -565,20 +566,18 @@ class Map extends Camera {
         this.on('zoom', () => this._update(true));
 
         if (typeof window !== 'undefined') {
+            this._fullscreenchangeEvent = 'onfullscreenchange' in window.document ?
+                    'fullscreenchange' :
+                    'webkitfullscreenchange';
+
             // $FlowFixMe[method-unbinding]
             window.addEventListener('online', this._onWindowOnline, false);
             // $FlowFixMe[method-unbinding]
             window.addEventListener('resize', this._onWindowResize, false);
             // $FlowFixMe[method-unbinding]
             window.addEventListener('orientationchange', this._onWindowResize, false);
-
-            const fullscreenchange = 'onfullscreenchange' in window.document ?
-                'fullscreenchange' :
-                'webkitfullscreenchange';
-
             // $FlowFixMe[method-unbinding]
-            window.addEventListener(fullscreenchange, this._onWindowResize, false);
-
+            window.addEventListener(this._fullscreenchangeEvent, this._onWindowResize, false);
             // $FlowFixMe[method-unbinding]
             window.addEventListener('visibilitychange', this._onVisibilityChange, false);
         }
@@ -3545,7 +3544,7 @@ class Map extends Camera {
             // $FlowFixMe[method-unbinding]
             window.removeEventListener('orientationchange', this._onWindowResize, false);
             // $FlowFixMe[method-unbinding]
-            window.removeEventListener('webkitfullscreenchange', this._onWindowResize, false);
+            window.removeEventListener(this._fullscreenchangeEvent, this._onWindowResize, false);
             // $FlowFixMe[method-unbinding]
             window.removeEventListener('online', this._onWindowOnline, false);
             // $FlowFixMe[method-unbinding]

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -571,8 +571,14 @@ class Map extends Camera {
             window.addEventListener('resize', this._onWindowResize, false);
             // $FlowFixMe[method-unbinding]
             window.addEventListener('orientationchange', this._onWindowResize, false);
+
+            const fullscreenchange = 'onfullscreenchange' in window.document ?
+                'fullscreenchange' :
+                'webkitfullscreenchange';
+
             // $FlowFixMe[method-unbinding]
-            window.addEventListener('webkitfullscreenchange', this._onWindowResize, false);
+            window.addEventListener(fullscreenchange, this._onWindowResize, false);
+
             // $FlowFixMe[method-unbinding]
             window.addEventListener('visibilitychange', this._onVisibilityChange, false);
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -567,8 +567,8 @@ class Map extends Camera {
 
         if (typeof window !== 'undefined') {
             this._fullscreenchangeEvent = 'onfullscreenchange' in window.document ?
-                    'fullscreenchange' :
-                    'webkitfullscreenchange';
+                'fullscreenchange' :
+                'webkitfullscreenchange';
 
             // $FlowFixMe[method-unbinding]
             window.addEventListener('online', this._onWindowOnline, false);


### PR DESCRIPTION
Closes #12718.

Previously, when the browser itself was already full screen and the element containing the map had a fixed size, the map would not properly resize to become full screen if the user clicks an attached Fullscreen Control.

This issue was caused by the map registering listeners for `webkitfullscreenchange` and not for un-prefixed `fullscreenchange`. This meant that a `fullscreenchange` event wouldn't cause the map to resize.

The map expanded as expected in most cases because the size of the browser window typically changes when entering fullscreen. The map did correctly register `resize` events to cause a map resize. If the browser was already fullscreen the browser window wouldn't need to change size, so the `resize` event wouldn't fire.

This means that the bug doesn't reproduce in most `iframes`, since the `iframe` doesn't fill the entire screen even if the browser itself is in full screen.

To fix this, I added a check when registering listeners in `map.js` to use the unprefixed `fullscreenchange` if it is available.

## Changes made:
* When adding event listeners, `map.js` now checks if unprefixed `fullscreenchange` is supported and uses that instead of the previous `webkitfullscreenchange`.

## Before
![image](https://github.com/mapbox/mapbox-gl-js/assets/43593885/5edc38b6-fcfc-440c-8037-e85d01ad1445)
![image](https://github.com/mapbox/mapbox-gl-js/assets/43593885/c55fd8f1-abcb-4872-86f6-65cb7b8c899b)

## After
![image](https://github.com/mapbox/mapbox-gl-js/assets/43593885/0fa4646a-4fb3-4834-bc89-7db7a22b7a3f)
![image](https://github.com/mapbox/mapbox-gl-js/assets/43593885/67b4230e-2dd0-42d6-b955-170534e8ef09)

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix map not resizing when using a Fullscreen Control while the browser is already in fullscreen.</changelog>`
