### PR TITLE
Fix rendering of rare CJK glyphs

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -461,8 +461,10 @@ class SymbolBucket implements Bucket {
 
     calculateGlyphDependencies(text: string, stack: {[_: number]: boolean}, textAlongLine: boolean, allowVerticalPlacement: boolean, doesAllowVerticalWritingMode: boolean) {
         for (let i = 0; i < text.length; i++) {
-            stack[text.charCodeAt(i)] = true;
-            if (allowVerticalPlacement && doesAllowVerticalWritingMode) {
+            const codePoint = text.codePointAt(i);
+            if (codePoint === undefined) break;
+            stack[codePoint] = true;
+            if (allowVerticalPlacement && doesAllowVerticalWritingMode && codePoint <= 65535) {
                 const verticalChar = verticalizedCharacterMap[text.charAt(i)];
                 if (verticalChar) {
                     stack[verticalChar.charCodeAt(0)] = true;

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -187,13 +187,16 @@ class GlyphManager {
             return !!this.localFontFamily;
         } else {
             /* eslint-disable new-cap */
-            return !!this.localFontFamily &&
-            ((isChar['CJK Unified Ideographs'](id) ||
+            return !!this.localFontFamily && (
+                isChar['CJK Unified Ideographs'](id) ||
                 isChar['Hangul Syllables'](id) ||
                 isChar['Hiragana'](id) ||
-                isChar['Katakana'](id)) ||
+                isChar['Katakana'](id) ||
                 // gl-native parity: Extend Ideographs rasterization range to include CJK symbols and punctuations
-                isChar['CJK Symbols and Punctuation'](id));
+                isChar['CJK Symbols and Punctuation'](id) ||
+                isChar['CJK Unified Ideographs Extension A'](id) ||
+                isChar['CJK Unified Ideographs Extension B'](id) // very rare surrogate characters
+            );
             /* eslint-enable new-cap */
         }
     }
@@ -224,7 +227,7 @@ class GlyphManager {
             return this.localGlyphs[tinySDF.fontWeight][id];
         }
 
-        const char = String.fromCharCode(id);
+        const char = String.fromCodePoint(id);
         const {data, width, height, glyphWidth, glyphHeight, glyphLeft, glyphTop, glyphAdvance} = tinySDF.draw(char);
         /*
         TinySDF's "top" is the distance from the alphabetic baseline to the

--- a/src/symbol/quads.js
+++ b/src/symbol/quads.js
@@ -384,7 +384,7 @@ export function getGlyphQuads(anchor: Anchor,
                 const verticalAdvance = positionedGlyph.imageName ? metrics.advance * positionedGlyph.scale :
                     ONE_EM * positionedGlyph.scale;
                 // Check wether the glyph is generated from server side or locally
-                const chr = String.fromCharCode(positionedGlyph.glyph);
+                const chr = String.fromCodePoint(positionedGlyph.glyph);
                 if (isVerticalClosePunctuation(chr)) {
                     // Place vertical punctuation in right place, pull down 1 pixel's space for close punctuations
                     tl.x += (-rectBuffer + 1) * positionedGlyph.scale;

--- a/src/symbol/shaping.js
+++ b/src/symbol/shaping.js
@@ -153,8 +153,8 @@ class TaggedString {
         return this.sectionIndex[index];
     }
 
-    getCharCode(index: number): number {
-        return this.text.charCodeAt(index);
+    getCodePoint(index: number): number {
+        return this.text.codePointAt(index);
     }
 
     verticalizePunctuation(skipContextChecking: boolean) {
@@ -216,7 +216,7 @@ class TaggedString {
             return;
         }
 
-        this.text += String.fromCharCode(nextImageSectionCharCode);
+        this.text += String.fromCodePoint(nextImageSectionCharCode);
         this.sections.push(SectionOptions.forImage(imageName));
         this.sectionIndex.push(this.sections.length - 1);
     }
@@ -379,7 +379,7 @@ function determineAverageLineWidth(logicalInput: TaggedString,
 
     for (let index = 0; index < logicalInput.length(); index++) {
         const section = logicalInput.getSection(index);
-        totalWidth += getGlyphAdvance(logicalInput.getCharCode(index), section, glyphMap, imagePositions, spacing, layoutTextSize);
+        totalWidth += getGlyphAdvance(logicalInput.getCodePoint(index), section, glyphMap, imagePositions, spacing, layoutTextSize);
     }
 
     const lineCount = Math.max(1, Math.ceil(totalWidth / maxWidth));
@@ -491,7 +491,7 @@ function determineLineBreaks(logicalInput: TaggedString,
 
     for (let i = 0; i < logicalInput.length(); i++) {
         const section = logicalInput.getSection(i);
-        const codePoint = logicalInput.getCharCode(i);
+        const codePoint = logicalInput.getCodePoint(i);
         if (!whitespace[codePoint]) currentX += getGlyphAdvance(codePoint, section, glyphMap, imagePositions, spacing, layoutTextSize);
 
         // Ideographic characters, spaces, and word-breaking punctuation that often appear without
@@ -506,7 +506,7 @@ function determineLineBreaks(logicalInput: TaggedString,
                         currentX,
                         targetWidth,
                         potentialLineBreaks,
-                        calculatePenalty(codePoint, logicalInput.getCharCode(i + 1), ideographicBreak && hasServerSuggestedBreakpoints),
+                        calculatePenalty(codePoint, logicalInput.getCodePoint(i + 1), ideographicBreak && hasServerSuggestedBreakpoints),
                         false));
             }
         }
@@ -614,7 +614,7 @@ function shapeLines(shaping: Shaping,
         for (let i = 0; i < line.length(); i++) {
             const section = line.getSection(i);
             const sectionIndex = line.getSectionIndex(i);
-            const codePoint = line.getCharCode(i);
+            const codePoint = line.getCodePoint(i);
 
             let sectionScale = section.scale;
             let metrics = null;

--- a/src/util/is_char_in_unicode_block.js
+++ b/src/util/is_char_in_unicode_block.js
@@ -167,7 +167,7 @@ const unicodeBlockLookup: UnicodeBlockLookup = {
     'CJK Compatibility Forms': (char) => char >= 0xFE30 && char <= 0xFE4F,
     'Small Form Variants': (char) => char >= 0xFE50 && char <= 0xFE6F,
     'Arabic Presentation Forms-B': (char) => char >= 0xFE70 && char <= 0xFEFF,
-    'Halfwidth and Fullwidth Forms': (char) => char >= 0xFF00 && char <= 0xFFEF
+    'Halfwidth and Fullwidth Forms': (char) => char >= 0xFF00 && char <= 0xFFEF,
     // 'Specials': (char) => char >= 0xFFF0 && char <= 0xFFFF,
     // 'Linear B Syllabary': (char) => char >= 0x10000 && char <= 0x1007F,
     // 'Linear B Ideograms': (char) => char >= 0x10080 && char <= 0x100FF,
@@ -296,7 +296,7 @@ const unicodeBlockLookup: UnicodeBlockLookup = {
     // 'Supplemental Symbols and Pictographs': (char) => char >= 0x1F900 && char <= 0x1F9FF,
     // 'Chess Symbols': (char) => char >= 0x1FA00 && char <= 0x1FA6F,
     // 'Symbols and Pictographs Extended-A': (char) => char >= 0x1FA70 && char <= 0x1FAFF,
-    // 'CJK Unified Ideographs Extension B': (char) => char >= 0x20000 && char <= 0x2A6DF,
+    'CJK Unified Ideographs Extension B': (char) => char >= 0x20000 && char <= 0x2A6DF,
     // 'CJK Unified Ideographs Extension C': (char) => char >= 0x2A700 && char <= 0x2B73F,
     // 'CJK Unified Ideographs Extension D': (char) => char >= 0x2B740 && char <= 0x2B81F,
     // 'CJK Unified Ideographs Extension E': (char) => char >= 0x2B820 && char <= 0x2CEAF,

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -218,12 +218,12 @@ test('GlyphManager locally generates latin glyphs', (t) => {
 
     const manager = createGlyphManager('sans-serif', true);
 
-    manager.getGlyphs({'Arial Unicode MS': ['A']}, (err, result) => {
+    manager.getGlyphs({'Arial Unicode MS': [65]}, (err, result) => {
         t.ifError(err);
         const glyphs = result['Arial Unicode MS'].glyphs;
-        t.equal(glyphs['A'].metrics.advance, 10);
-        t.equal(glyphs['A'].metrics.width, 14);
-        t.equal(glyphs['A'].metrics.height, 18);
+        t.equal(glyphs[65].metrics.advance, 10);
+        t.equal(glyphs[65].metrics.width, 14);
+        t.equal(glyphs[65].metrics.height, 18);
         t.end();
     });
 });


### PR DESCRIPTION
Fixes rendering of rare CJK glyphs such as the one here (before / after):

<img width="365" alt="image" src="https://github.com/mapbox/mapbox-gl-js/assets/25395/e6f2c342-ca10-47e3-8bed-deee2b813230">
<img width="365" alt="image" src="https://github.com/mapbox/mapbox-gl-js/assets/25395/83875eeb-39e8-41b5-b8e1-1bcb8c6d4e19">

Previously, we would fail to render any characters that go beyond the UTF16 range, such as unicode surrogate pairs in the [CJK Unified Ideographs Extension B](https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_B) range. I also fixed rendering of characters in [CJK Unified Ideographs Extension A](https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_Extension_A) (even though it's in UTF16 range) because it looked like an omission.

Marking as a draft until I fix tests and add a render test.

cc @disorder26 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix rendering of rare CJK glyphs (specifically, unified ideographs extensions A and B</changelog>`
