### PR TITLE
[GLJS-393] Remove dependency fill-extrusion-ambient-occlusion-radius to fill-extrusion-edge-radius

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4723,9 +4723,6 @@
       },
       "transition": true,
       "doc": "Shades area near ground and concave angles between walls where the radius defines only vertical impact. Default value 3.0 corresponds to height of one floor and brings the most plausible results for buildings.",
-      "requires": [
-        "fill-extrusion-edge-radius"
-      ],
       "sdk-support": {
         "basic functionality": {
           "js": "2.10.0",


### PR DESCRIPTION

It got unintentionally introduced in past https://github.com/mapbox/mapbox-gl-js/pull/12188/files#r953897029

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
