### PR TITLE
Add className option to Marker

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -292,7 +292,7 @@ class GeolocateControl extends Evented {
         }
 
         if (this.options.showUserLocation) {
-            this._dotElement.classList.remove('mapboxgl-user-location-dot-stale');
+            this._userLocationDotMarker.removeClassName('mapboxgl-user-location-dot-stale');
         }
 
         this.fire(new Event('geolocate', position));
@@ -364,9 +364,9 @@ class GeolocateControl extends Evented {
     _updateMarkerRotation() {
         if (this._userLocationDotMarker && typeof this._heading === 'number') {
             this._userLocationDotMarker.setRotation(this._heading);
-            this._dotElement.classList.add('mapboxgl-user-location-show-heading');
+            this._userLocationDotMarker.addClassName('mapboxgl-user-location-show-heading');
         } else {
-            this._dotElement.classList.remove('mapboxgl-user-location-show-heading');
+            this._userLocationDotMarker.removeClassName('mapboxgl-user-location-show-heading');
             this._userLocationDotMarker.setRotation(0);
         }
     }
@@ -406,7 +406,7 @@ class GeolocateControl extends Evented {
         }
 
         if (this._watchState !== 'OFF' && this.options.showUserLocation) {
-            this._dotElement.classList.add('mapboxgl-user-location-dot-stale');
+            this._userLocationDotMarker.addClassName('mapboxgl-user-location-dot-stale');
         }
 
         this.fire(new Event('error', error));

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -88,7 +88,6 @@ export default class Marker extends Evented {
     _updateFrameId: number;
     _updateMoving: () => void;
     _occludedOpacity: number;
-    _classList: Set<string>;
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -167,6 +166,7 @@ export default class Marker extends Evented {
         }
 
         if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');
+        this._element.classList.add('mapboxgl-marker');
         this._element.addEventListener('dragstart', (e: DragEvent) => {
             e.preventDefault();
         });
@@ -178,10 +178,13 @@ export default class Marker extends Evented {
         for (const key in anchorTranslate) {
             classList.remove(`mapboxgl-marker-anchor-${key}`);
         }
-        this._classList = new Set([
-            ...this._element.classList,
+        classList.add(`mapboxgl-marker-anchor-${this._anchor}`);
+        const optionClasses = new Set([
             ...(options && options.className ? options.className.trim().split(/\s+/) : [])
         ]);
+        optionClasses.forEach((className) => {
+            this._element.classList.add(className);
+        });
 
         this._popup = null;
     }
@@ -564,17 +567,6 @@ export default class Marker extends Evented {
         return rotation ? `rotateZ(${rotation}deg)` : '';
     }
 
-    _updateClassList() {
-        if (!this._element) return;
-
-        const classes = [...this._classList];
-        classes.push('mapboxgl-marker');
-        if (this._anchor) {
-            classes.push(`mapboxgl-marker-anchor-${this._anchor}`);
-        }
-        this._element.className = classes.join(' ');
-    }
-
     _update(delaySnap?: boolean) {
         window.cancelAnimationFrame(this._updateFrameId);
         const map = this._map;
@@ -612,8 +604,6 @@ export default class Marker extends Evented {
                 this._fadeTimer = setTimeout(this._evaluateOpacity.bind(this), 60);
             }
         });
-
-        this._updateClassList();
     }
 
     /**
@@ -652,8 +642,7 @@ export default class Marker extends Evented {
      * marker.addClassName('some-class');
      */
     addClassName(className: string): this {
-        this._classList.add(className);
-        this._updateClassList();
+        this._element.classList.add(className);
         return this;
     }
 
@@ -669,8 +658,7 @@ export default class Marker extends Evented {
      * marker.removeClassName('some');
      */
     removeClassName(className: string): this {
-        this._classList.delete(className);
-        this._updateClassList();
+        this._element.classList.remove(className);
         return this;
     }
 
@@ -686,15 +674,7 @@ export default class Marker extends Evented {
      * marker.toggleClassName('highlighted');
      */
     toggleClassName(className: string): boolean {
-        let finalState: boolean;
-        if (this._classList.delete(className)) {
-            finalState = false;
-        } else {
-            this._classList.add(className);
-            finalState = true;
-        }
-        this._updateClassList();
-        return finalState;
+        return this._element.classList.toggle(className);
     }
 
     _onMove(e: MapMouseEvent | MapTouchEvent) {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -179,10 +179,8 @@ export default class Marker extends Evented {
             classList.remove(`mapboxgl-marker-anchor-${key}`);
         }
         classList.add(`mapboxgl-marker-anchor-${this._anchor}`);
-        const optionClasses = new Set([
-            ...(options && options.className ? options.className.trim().split(/\s+/) : [])
-        ]);
-        optionClasses.forEach((className) => {
+        const classNames = options && options.className ? options.className.trim().split(/\s+/) : [];
+        classNames.forEach((className) => {
             this._element.classList.add(className);
         });
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -180,9 +180,7 @@ export default class Marker extends Evented {
         }
         classList.add(`mapboxgl-marker-anchor-${this._anchor}`);
         const classNames = options && options.className ? options.className.trim().split(/\s+/) : [];
-        classNames.forEach((className) => {
-            this._element.classList.add(className);
-        });
+        classList.add(...classNames);
 
         this._popup = null;
     }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -663,7 +663,7 @@ export default class Marker extends Evented {
      * @param {string} className Non-empty string with CSS class name to remove from marker element.
      *
      * @returns {Marker} Returns itself to allow for method chaining.
-     * 
+     *
      * @example
      * const marker = new mapboxgl.Marker({className: 'some classes'});
      * marker.removeClassName('some');

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -83,6 +83,128 @@ test('Marker#addTo adds the marker element to the canvas container', (t) => {
     t.end();
 });
 
+test('Marker adds classes from className option, methods for class manipulation work properly', (t) => {
+    const map = createMap(t);
+    const marker = new Marker({className: 'some classes'})
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    const markerElement = marker.getElement();
+    t.ok(markerElement.classList.contains('some'));
+    t.ok(markerElement.classList.contains('classes'));
+
+    marker.addClassName('addedClass');
+    t.ok(markerElement.classList.contains('addedClass'));
+
+    marker.removeClassName('addedClass');
+    t.ok(!markerElement.classList.contains('addedClass'));
+
+    marker.toggleClassName('toggle');
+    t.ok(markerElement.classList.contains('toggle'));
+
+    marker.toggleClassName('toggle');
+    t.ok(!markerElement.classList.contains('toggle'));
+
+    t.end();
+});
+
+test('Marker adds classes from element option, make sure it persists between class manipulations', (t) => {
+    const map = createMap(t);
+    const el = window.document.createElement('div');
+    el.className = 'marker';
+
+    const marker = new Marker({element: el})
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    const markerElement = marker.getElement();
+    t.ok(markerElement.classList.contains('marker'));
+
+    marker.addClassName('addedClass');
+    t.ok(markerElement.classList.contains('addedClass'));
+    t.ok(markerElement.classList.contains('marker'));
+
+    marker.removeClassName('addedClass');
+    t.ok(!markerElement.classList.contains('addedClass'));
+    t.ok(markerElement.classList.contains('marker'));
+
+    marker.toggleClassName('toggle');
+    t.ok(markerElement.classList.contains('toggle'));
+    t.ok(markerElement.classList.contains('marker'));
+
+    marker.toggleClassName('toggle');
+    t.ok(!markerElement.classList.contains('toggle'));
+    t.ok(markerElement.classList.contains('marker'));
+
+    t.end();
+});
+
+test('Marker#addClassName adds classes when called before adding marker to map', (t) => {
+    const map = createMap(t);
+    const marker = new Marker();
+    marker.addClassName('some');
+    marker.addClassName('classes');
+
+    marker.setLngLat([0, 0])
+        .addTo(map);
+
+    const markerElement = marker.getElement();
+    t.ok(markerElement.classList.contains('some'));
+    t.ok(markerElement.classList.contains('classes'));
+    t.end();
+});
+
+test('Marker className option and addClassName both add classes', (t) => {
+    const map = createMap(t);
+    const marker = new Marker({className: 'some classes'});
+    marker.addClassName('even')
+        .addClassName('more');
+
+    marker.setLngLat([0, 0])
+        .addTo(map);
+
+    marker.addClassName('one-more');
+
+    const markerElement = marker.getElement();
+    t.ok(markerElement.classList.contains('some'));
+    t.ok(markerElement.classList.contains('classes'));
+    t.ok(markerElement.classList.contains('even'));
+    t.ok(markerElement.classList.contains('more'));
+    t.ok(markerElement.classList.contains('one-more'));
+    t.end();
+});
+
+test('Methods for class manipulation work properly when marker is not on map', (t) => {
+    const map = createMap(t);
+    const marker = new Marker()
+        .setLngLat([0, 0])
+        .addClassName('some')
+        .addClassName('classes');
+
+    let markerElement = marker.addTo(map).getElement();
+    t.ok(markerElement.classList.contains('some'));
+    t.ok(markerElement.classList.contains('classes'));
+
+    marker.remove();
+    marker.removeClassName('some');
+    markerElement = marker.addTo(map).getElement();
+
+    t.ok(!markerElement.classList.contains('some'));
+
+    marker.remove();
+    marker.toggleClassName('toggle');
+    markerElement = marker.addTo(map).getElement();
+
+    t.ok(markerElement.classList.contains('toggle'));
+
+    marker.remove();
+    marker.toggleClassName('toggle');
+    markerElement = marker.addTo(map).getElement();
+
+    t.ok(!markerElement.classList.contains('toggle'));
+    t.end();
+});
+
 test('Marker provides LngLat accessors', (t) => {
     t.equal(new Marker().getLngLat(), undefined);
 


### PR DESCRIPTION
Add `className` option to Marker,  also add `addClassName`, `removeClassName` and `toggleClassName` methods to be more consistent with the Popup.

Outside of wanting Marker and Popup to have more consistent options/APIs, had a use case where we need to specify different class names based on the category of a marker, like setting `z-index` to have hierarchy in which markers should alway be on top while dynamically adding and removing markers depending on users preference for the map.
We were able to achieve  this by directly accessing `marker.getElement().classList` but having a native way similar to the Popup to add and manipulate `className` feel more ideal.

### Example
```js
var marker = new mapboxgl.Marker({
  className: 'some custom classes'
});
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page (tested both `debug/markers.html` and `/debug/markers-custom.html`)
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add addClassName, removeClassName, and toggleClassName Marker methods</changelog>`
