### PR TITLE
Remove tabindex when non-interactive map

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3254,16 +3254,17 @@ class Map extends Camera {
         this._detectMissingCSS();
 
         const canvasContainer = this._canvasContainer = DOM.create('div', 'mapboxgl-canvas-container', container);
+        this._canvas = DOM.create('canvas', 'mapboxgl-canvas', canvasContainer);
+
         if (this._interactive) {
             canvasContainer.classList.add('mapboxgl-interactive');
+            this._canvas.setAttribute('tabindex', '0');
         }
 
-        this._canvas = DOM.create('canvas', 'mapboxgl-canvas', canvasContainer);
         // $FlowFixMe[method-unbinding]
         this._canvas.addEventListener('webglcontextlost', this._contextLost, false);
         // $FlowFixMe[method-unbinding]
         this._canvas.addEventListener('webglcontextrestored', this._contextRestored, false);
-        this._canvas.setAttribute('tabindex', '0');
         this._canvas.setAttribute('aria-label', this._getUIString('Map.Title'));
         this._canvas.setAttribute('role', 'region');
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -3858,6 +3858,15 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('should not have tabindex attribute when non-interactive', (t) => {
+        const map = createMap(t, {interactive: false});
+
+        t.notOk(map.getCanvas().getAttribute('tabindex'));
+
+        map.remove();
+        t.end();
+    });
+
     t.test('should calculate correct canvas size when transform css property is applied', (t) => {
         const map = createMap(t);
         Object.defineProperty(window, 'getComputedStyle',


### PR DESCRIPTION
Handling the good first issue https://github.com/mapbox/mapbox-gl-js/issues/12822, removing `tabindex` attribute when map is set as non-interactive.

**[Before]**
![before](https://github.com/mapbox/mapbox-gl-js/assets/28984604/c1416a53-a88c-431b-b768-1e85f9e462e6)

**[After]**
![after](https://github.com/mapbox/mapbox-gl-js/assets/28984604/ee913828-a1fa-4c00-a231-f3be9855fe90)

### Note about Attribution
Since `Attribution` which has links and is tabbable seems to be [a must to have](https://docs.mapbox.com/help/getting-started/attribution/) on map, its behavior is still kept as it is like this: http://g.recordit.co/ET7dF5c9Ny.gif

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Remove tabindex attribute when map is non-interactive</changelog>`

---
closes #12822