### PR TITLE
[accessibility] Remove role="list" from Attribution

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -64,7 +64,6 @@ class AttributionControl {
         this._compactButton.addEventListener('click', this._toggleAttribution);
         this._setElementTitle(this._compactButton, 'ToggleAttribution');
         this._innerContainer = DOM.create('div', 'mapboxgl-ctrl-attrib-inner', this._container);
-        this._innerContainer.setAttribute('role', 'list');
 
         if (compact) {
             this._container.classList.add('mapboxgl-compact');

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -168,12 +168,9 @@ class AttributionControl {
             const sourceCache = sourceCaches[id];
             if (sourceCache.used) {
                 const source = sourceCache.getSource();
-                if (source?.attribution && attributions.indexOf(source.attribution) < 0) {
+                if (source.attribution && attributions.indexOf(source.attribution) < 0) {
                     // $FlowFixMe[incompatible-call] - Flow can't infer that attribution is a string
-                    if (typeof source.attribution === "string") {
-                        const attributionRoleRemoved = source.attribution.replaceAll(`role=\"listitem\"`, "");
-                        attributions.push(attributionRoleRemoved);
-                    }
+                    attributions.push(source.attribution);
                 }
             }
         }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -168,9 +168,12 @@ class AttributionControl {
             const sourceCache = sourceCaches[id];
             if (sourceCache.used) {
                 const source = sourceCache.getSource();
-                if (source.attribution && attributions.indexOf(source.attribution) < 0) {
+                if (source?.attribution && attributions.indexOf(source.attribution) < 0) {
                     // $FlowFixMe[incompatible-call] - Flow can't infer that attribution is a string
-                    attributions.push(source.attribution);
+                    if (typeof source.attribution === "string") {
+                        const attributionRoleRemoved = source.attribution.replaceAll(`role=\"listitem\"`, "");
+                        attributions.push(attributionRoleRemoved);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Handling the good first issue https://github.com/mapbox/mapbox-gl-js/issues/11033, removing `role="list"` and `role="listitem"` from Attribution.

**[Before]**
![before](https://github.com/mapbox/mapbox-gl-js/assets/28984604/dc303337-1ed6-4d3f-a350-4ad39b9b7243)


**[After]**
![after](https://github.com/mapbox/mapbox-gl-js/assets/28984604/3e8408a3-a17e-44da-b694-0e9bd2762f87)



### Note about removing role="listitem"
Attribution link elements seem to be provided from TileJSON and this original source should be fixed. 
![attibution style server data](https://github.com/mapbox/mapbox-gl-js/assets/28984604/5368de45-e390-4fe9-9d67-20bfa8074bee)

~I don't seem to have access to fix it so I removed it from the attribution source obtained by `this._map.style._sourceCaches` in this PR as a quick fix.~

I hope **someone in the Mapbox team** could handle this part. 
- [x] Remove `role="listitem"` from TileJSON

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Remove role="list" and role="listitem" from Attribution</changelog>`
