### PR TITLE
Fix setLayoutProperty to handle custom layers

### DIFF
--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -143,11 +143,12 @@ class StyleLayer extends Evented {
             }
         }
 
-        this._unevaluatedLayout.setValue(name, value);
-        this.isConfigDependent = this.isConfigDependent || this._unevaluatedLayout.isConfigDependent;
+        this?._unevaluatedLayout?.setValue(name, value);
+        this.isConfigDependent = this.isConfigDependent || !!this?._unevaluatedLayout?.isConfigDependent;
 
         if (name === 'visibility') {
-            this.visibility = this._unevaluatedLayout._values.visibility.possiblyEvaluate({zoom: 0});
+            const visibility = this.type === "custom" ? value : this?._unevaluatedLayout?._values?.visibility?.possiblyEvaluate({zoom: 0});
+            this.visibility = visibility;
         }
     }
 

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -254,6 +254,21 @@ test('StyleLayer#setLayoutProperty', (t) => {
         t.end();
     });
 
+    t.test('sets and updates visibility property to custom type layer', (t) => {
+        const layer = createStyleLayer({
+            "id": "custom",
+            "type": "custom"
+        });
+
+        layer.setLayoutProperty('visibility', 'none');
+        t.deepEqual(layer.getLayoutProperty('visibility'), 'none');
+
+        layer.setLayoutProperty('visibility', 'visible');
+        t.deepEqual(layer.getLayoutProperty('visibility'), 'visible');
+
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Fixing the issue https://github.com/mapbox/mapbox-gl-js/issues/12858
Handle `custom` type layer for `setLayoutProperty`

**[Before]**
![before](https://github.com/mapbox/mapbox-gl-js/assets/28984604/c0f4886c-8ac5-4b69-82fb-43f63f1add4f)

**[After]**
Error message disappears
![after](https://github.com/mapbox/mapbox-gl-js/assets/28984604/06ddf476-423b-4865-93eb-b4ad6d16e3bd)

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix setLayoutProperty to handle custom layers</changelog>`

---
Fixes https://github.com/mapbox/mapbox-gl-js/issues/12858