### PR TITLE
Fixed #12467 : Override Issue of Center and Zoom on Initalise of Map

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -622,10 +622,10 @@ class Map extends Camera {
         const hashName = (typeof options.hash === 'string' && options.hash) || undefined;
         if (options.hash) this._hash = (new Hash(hashName)).addTo(this);
         // don't set position from options if set through hash
-        if ((options.center && !(options.center[0] === 0 && options.center[1] === 0)) || !this._hash || !this._hash._onHashChange()) {
+        if ((options.zoom && options.zoom !== defaultOptions.zoom) || (options.center && !(options.center[0] === defaultOptions.center[0] && options.center[1] === defaultOptions.center[1])) || !this._hash || !this._hash._onHashChange()) {
             this.jumpTo({
-                center: options.center,
-                zoom: options.zoom,
+                center: options?.center ? options.center : defaultOptions.center,
+                zoom: options?.zoom ? options.zoom : defaultOptions.zoom,
                 bearing: options.bearing,
                 pitch: options.pitch
             });

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -622,7 +622,7 @@ class Map extends Camera {
         const hashName = (typeof options.hash === 'string' && options.hash) || undefined;
         if (options.hash) this._hash = (new Hash(hashName)).addTo(this);
         // don't set position from options if set through hash
-        if (!this._hash || !this._hash._onHashChange()) {
+        if ((options.center && !(options.center[0] === 0 && options.center[1] === 0)) || !this._hash || !this._hash._onHashChange()) {
             this.jumpTo({
                 center: options.center,
                 zoom: options.zoom,


### PR DESCRIPTION
 - Added check to figure out whether center or zoom is defined in Map options passed to the Map object if yes then jump to the defined center with given zoom in the constructor of the Map class in the ui/map.js file
 - 
![image](https://github.com/mapbox/mapbox-gl-js/assets/87220756/d0d2f982-7261-4742-b69d-c33facf79c24)

- Based on what I could infer from the issue I tried to fix it, provide your feedback as this is my first open source PR it would be very helpful!
