### PR TITLE
[style-spec] update line-gradient doc, add an example expression

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -6083,7 +6083,24 @@
     },
     "line-gradient": {
       "type": "color",
-      "doc": "Defines a gradient with which to color a line feature. Can only be used with GeoJSON sources that specify `\"lineMetrics\": true`.",
+      "doc": "A gradient used to color a line feature at various distances along its length. Defined using a `step` or `interpolate` expression which outputs a color for each corresponding `line-progress` input value. `line-progress` is a percentage of the line feature's total length as measured on the webmercator projected coordinate plane (a `number` between `0` and `1`).  Can only be used with GeoJSON sources that specify `\"lineMetrics\": true`.",
+      "example": [
+        "interpolate",
+        [ "linear" ],
+        [ "line-progress" ],
+        0,
+        "blue",
+        0.1,
+        "royalblue",
+        0.3,
+        "cyan",
+        0.5,
+        "lime",
+        0.7,
+        "yellow",
+        1,
+        "red"
+      ],
       "transition": false,
       "requires": [
         {


### PR DESCRIPTION
This PR updates the `doc` value for the `line-gradient` property in the style spec.

The previous information was ambiguous and only stated that this property defines a gradient.

The updated information explains that the value must be an expression that makes use of the `line-progress` input.  Especially important is the note that `line-progress` is the percent distance along the line as measured in the webmercator projected coordinate space (not the length as measured on the wgs84 spheroid).  

(This bit of information was critical in debugging some misalignments when attempting to use `line-gradient` to visualize EV state of charge in the directions api playground)

Also adds an `example` espression, the same expression used in the [line-gradient GL JS example](https://docs.mapbox.com/mapbox-gl-js/example/line-gradient/).

<img width="742" alt="image" src="https://github.com/mapbox/mapbox-gl-js/assets/1833820/89340b15-b076-488c-807b-3570f9e39e8f">
