### PR TITLE
Fixed #12883 accessibility issue by adding role attribute alongside aria-label

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -165,7 +165,14 @@ export default class Marker extends Evented {
             this._offset = Point.convert((options && options.offset) || [0, 0]);
         }
 
-        if (!this._element.hasAttribute('aria-label')) this._element.setAttribute('aria-label', 'Map marker');
+        if (!this._element.hasAttribute('aria-label')) {
+            this._element.setAttribute('aria-label', 'Map marker');
+        }
+
+        if (!this._element.hasAttribute('role')) {
+            this._element.setAttribute('role', 'img');
+        }
+
         this._element.classList.add('mapboxgl-marker');
         this._element.addEventListener('dragstart', (e: DragEvent) => {
             e.preventDefault();


### PR DESCRIPTION
Fixed accessibility issue by adding role attribute alongside aria-label. Closes #12883 

## Launch Checklist

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add a role to the Marker element per W3 guidelines</changelog>`
