### PR TITLE
security: Validate origin on 'message' events to prevent XSS DOM Attacks

### DIFF
--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -68,6 +68,7 @@ class Actor {
             targetMapId,
             mustQueue,
             sourceMapId: this.mapId,
+            origin: window.location.origin,
             data: serialize(data, buffers)
         }, buffers);
         return {
@@ -80,6 +81,7 @@ class Actor {
                     id,
                     type: '<cancel>',
                     targetMapId,
+                    origin: window.location.origin,
                     sourceMapId: this.mapId
                 });
             }
@@ -91,6 +93,11 @@ class Actor {
             id = data.id;
 
         if (!id) {
+            return;
+        }
+
+        if (data.origin !== window.location.origin) {
+            // Validate the source of the message to prevent DOM XSS attacks.
             return;
         }
 
@@ -148,6 +155,7 @@ class Actor {
                     type: '<response>',
                     sourceMapId: this.mapId,
                     error: err ? serialize(err) : null,
+                    origin: window.location.origin,
                     data: serialize(data, buffers)
                 }, buffers);
             } : (_) => {


### PR DESCRIPTION
The message event can be sent from any other tabs, it's better to implement validation of the origin of the message to prevent bad actors to run code from a separate tab.

more info: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page