### PR TITLE
Fix small spec inconsistencies with model types

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1269,6 +1269,7 @@
     },
     "model-id": {
       "type": "string",
+      "default": "",
       "doc": "Model to render.",
       "property-type": "data-driven",
       "expression": {
@@ -8450,7 +8451,7 @@
       "default": 0.0,
       "minimum": 0,
       "maximum": 5,
-      "units": "number",
+      "units": "intensity",
       "doc": "Strength of the emission. There is no emission for value 0. For value 1.0, only emissive component (no shading) is displayed and values above 1.0 produce light contribution to surrounding area, for some of the parts (e.g. doors). Expressions that depend on measure-light are not supported when using GeoJSON or vector tile as the model layer source.",
       "expression": {
         "interpolated": true,


### PR DESCRIPTION
- Provide a default value of `""` for `model-id`
- Change the `model-emissive-strength` unit value to `intensity`