### PR TITLE
Remove GL stats collection CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,15 +92,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - collect-stats:
-          requires:
-            - build
-            - install-mbx-ci
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              only: main
       - deploy-release:
           requires:
             - install-mbx-ci
@@ -335,20 +326,6 @@ jobs:
           command: |
             yarn run codegen
             git add -A && git diff --staged --exit-code | tee check.patch
-
-  collect-stats:
-    <<: *linux-defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - browser-tools/install-chrome
-      - run:
-          name: Collect performance stats
-          command: node bench/gl-stats.js
-      - aws-cli/install
-      - run:
-          name: Upload performance stats
-          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_metrics_staging/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
 
   test-browser:
     <<: *linux-defaults


### PR DESCRIPTION
This job has been broken for a while and isn't relevant at the moment. We could restore it in the future, but for now it's more important to keep the CI green.

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).