### PR TITLE
Fix (accessibility): Remove redundant aria-label that fails accessibility conformance

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -106,7 +106,6 @@ class AttributionControl {
 
     _setElementTitle(element: HTMLElement, title: string) {
         const str = this._map._getUIString(`AttributionControl.${title}`);
-        element.setAttribute('aria-label', str);
         element.removeAttribute('title');
         if (element.firstElementChild) element.firstElementChild.setAttribute('title', str);
     }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/12955

## Summary

* The "Improve this map" link fails accessibility standards defined in [WCAG SC 2.5.3: Label in Name (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html) because the visible link text is not included in the `aria-label` attribute. 
* This error is present in every default installation of Mapbox that includes the attribution block: 
![image](https://github.com/mapbox/mapbox-gl-js/assets/228885/fa42b9ca-bbb6-420c-a608-80e5604faf35)
* Removing the `aria-label` (a single line in the source) means we don't need to create a hacky workaround to eliminate the accessible name mismatch, and would benefit all users of Mapbox, especially those who rely on assistive tech (voice control, screen readers, etc)
* This fix may also improve Mapbox's feedback analytics :)

## Verified locally
* the `aria-label` is no longer present on the "Improve this map" link 
* screen reader announces the visible text correctly when the link is focused (VoiceOver with Safari, MacOS 14.1) 
* Chrome DevTools correctly identifies the link's accessible name as "Improve this map", and matches the visible  link text


## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
