### PR TITLE
Fix compact attribution style when using global CSS that sets `box-sizing: border-box;`

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -409,6 +409,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         position: relative;
         background-color: #fff;
         border-radius: 12px;
+        box-sizing: content-box;
     }
 
     .mapboxgl-ctrl-attrib.mapboxgl-compact-show {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/10585

![Recording 2023-11-21 220744](https://github.com/mapbox/mapbox-gl-js/assets/9056487/16bb9f8b-6ec0-4fd1-9d0b-46f2fbd36de1)

## Summary
- For front-end developers it's common practice to globally set the CSS `box-sizing` property to `border-box` for all elements. Like [w3schools.com writes](https://www.w3schools.com/css/css3_box-sizing.asp): _"Applying this to all elements is safe and wise"_.
- The CSS of the attribute control is written assuming `box-sizing` is set to `content-box`, causing developers that have globally set `box-sizing: border-box` to have the visual bug as seen in the GIF above.
- My solution would be specifying the CSS property `box-sizing` value for `.mapboxgl-ctrl-attrib` so global user preferences don't influence the styling of the compact attribution control. 
- This approach was [already taken](https://github.com/mapbox/mapbox-gl-js/blob/37624d45b7185d5a213b8a5cd094ed95a9eb49d4/src/css/mapbox-gl.css#L520) for `.mapboxgl-ctrl-scale` so I would say it's a consistent solution.

## Steps to Trigger Behavior
1) Setup a map with an compact attribution control. 
2) Define the following CSS anywhere in your application:
```css
* {
  box-sizing: border-box;
}
```

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
