### PR TITLE
Allow updating an image before it loads or fails to load.

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -227,7 +227,7 @@ class ImageSource extends Evented implements Source {
      * });
      */
     updateImage(options: {url: string, coordinates?: Coordinates}): this {
-        if (!this.image || !options.url) {
+        if (!options.url) {
             return this;
         }
         if (this._imageRequest && options.url !== this.options.url) {

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -55,6 +55,12 @@ test('ImageSource', (t) => {
         img.onload();
         img.data = new Uint8Array(req.response);
     };
+    const respondNotFound = () => {
+        const req = requests.shift();
+        req.setStatus(404);
+        req.onerror();
+        req.response = new ArrayBuffer(1);
+    };
     t.stub(browser, 'getImageData').callsFake(() => new ArrayBuffer(1));
 
     t.test('constructor', (t) => {
@@ -253,6 +259,23 @@ test('ImageSource', (t) => {
         source.updateImage({url: '/image.png'});
 
         t.equal(spy.callCount, 0);
+        t.end();
+    });
+
+    t.test('updates image before first image was loaded', (t) => {
+        const source = createSource({url : '/notfound.png'});
+        const map = new StubMap();
+        const spy = t.spy(map._requestManager, 'transformRequest');
+        const errorStub = t.stub(console, 'error');
+        source.onAdd(map);
+        respondNotFound();
+        t.ok(errorStub.calledOnce);
+        t.notOk(source.image);
+        source.updateImage({url: '/image2.png'});
+        respond();
+        t.ok(spy.calledTwice);
+        t.equal(spy.getCall(1).args[0], '/image2.png');
+        t.equal(spy.getCall(1).args[1], 'Image');
         t.end();
     });
 


### PR DESCRIPTION
Rebase of #12928. Allow updating an ImageSource image before loading or after it fails to load.

Closes #11725, #12928

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Write tests for all new functionality and make sure the CI checks pass.
