### PR TITLE
v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1
+
+### Bug fixes 🐞
+
+- Fix attribution not being displayed for imported fragments.
+
 ## 3.0.0
 
 Mapbox GL JS v3 enables the [Mapbox Standard Style](https://www.mapbox.com/blog/standard-core-style), a new realistic 3D lighting system, building shadows and many other visual enhancements, and an ergonomic API for using a new kind of rich, evolving, configurable map styles and seamless integration with custom data. You can get more information about the new features in the [Mapbox GL JS v3 migration guide](./MIGRATION_GUIDE_v3.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -163,7 +163,7 @@ class AttributionControl {
             this.styleId = stylesheet.id;
         }
 
-        const sourceCaches = this._map.style._sourceCaches;
+        const sourceCaches = this._map.style._mergedSourceCaches;
         for (const id in sourceCaches) {
             const sourceCache = sourceCaches[id];
             if (sourceCache.used) {

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -265,6 +265,45 @@ test('AttributionControl hides attributions for sources that are not currently v
     });
 });
 
+test('AttributionControl shows attribution from both root style and its imports', (t) => {
+
+    const map =  globalCreateMap(t, {
+        attributionControl: false,
+        accessToken: 'pk.123',
+        style: {
+            version: 8,
+            imports: [{
+                id: 'streets',
+                url: '',
+                data: {
+                    version: 8,
+                    sources: {
+                        '2': {type: 'geojson', data: {type: 'FeatureCollection', features: []}, attribution: 'Hello'}
+                    },
+                    layers: [
+                        {id: '2', type: 'fill', source: '2'}
+                    ]
+                }
+            }],
+            sources: {
+                '1': {type: 'geojson', data: {type: 'FeatureCollection', features: []}, attribution: 'World'}
+            },
+            layers: [
+                {id: '1', type: 'fill', source: '1'}
+            ],
+            owner: 'mapbox',
+            id: 'test'
+        }
+    });
+    const attribution = new AttributionControl();
+    map.addControl(attribution);
+
+    map.on('load', () => {
+        t.equal(attribution._innerContainer.innerHTML, 'Hello | World');
+        t.end();
+    });
+});
+
 test('AttributionControl toggles attributions for sources whose visibility changes when zooming', (t) => {
     const map = createMap(t);
     const attribution = new AttributionControl();


### PR DESCRIPTION
Mapbox GL JS v3 enables the [Mapbox Standard Style](https://www.mapbox.com/blog/standard-core-style), a new realistic 3D lighting system, building shadows and many other visual enhancements, and an ergonomic API for using a new kind of rich, evolving, configurable map styles and seamless integration with custom data. You can get more information about the new features in the [Mapbox GL JS v3 migration guide](https://docs.mapbox.com/mapbox-gl-js/guides/migrate-to-v3/).

## v3.0.1

### Bug fixes 🐞

- Fix attribution not being displayed for imported fragments.
