### PR TITLE
Set Filter method for GeoJSON Source

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -190,6 +190,48 @@ class GeoJSONSource extends Evented implements Source {
     }
 
     /**
+     * Sets filter for the GeoJSON data source and re-renders the map.
+     *
+     * @param {Array | string} filter An array for the filter expression.
+     * @returns {GeoJSONSource} Returns itself to allow for method chaining.
+     * @example
+     * map.addSource('source_id', {
+     *     type: 'geojson',
+     *     data: {
+     *         "type": "FeatureCollection",
+     *         "features": [{
+     *             "type": "Feature",
+     *             "properties": {"name": "Null Island"},
+     *             "geometry": {
+     *                 "type": "Point",
+     *                 "coordinates": [ 0, 0 ]
+     *             }
+     *         },
+     *         {
+     *             "type": "Feature",
+     *             "properties": {"name": "Another Island"},
+     *             "geometry": {
+     *                 "type": "Point",
+     *                 "coordinates": [ 1, 1 ]
+     *             }
+     *         }]
+     *     }
+     * });
+     * const geojsonSource = map.getSource('source_id');
+     * // Update the filter after the GeoJSON source was created
+     * geojsonSource.setFilter([
+     *     "==",
+     *     ["get", "name"],
+     *     "Another Island"
+     * ]);
+     */
+    setFilter(filter: Array | string): this {
+        this.workerOptions = extend$1({ filter: filter }, this.workerOptions);
+        this._updateWorkerData();
+        return this;
+    }
+
+    /**
      * For clustered sources, fetches the zoom at which the given cluster expands.
      *
      * @param {number} clusterId The value of the cluster's `cluster_id` property.


### PR DESCRIPTION
Adding setFilter method for GeoJSON source, to allow filtering data without passing new ones with setData function

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
