### PR TITLE
Fix - Remove hidden alert role attribute

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -422,7 +422,7 @@ class ScrollZoomHandler {
 
         this._alertTimer = setTimeout(() => {
             this._alertContainer.classList.remove('mapboxgl-scroll-zoom-blocker-show');
-            this._alertContainer.setAttribute("role", "null");
+            this._alertContainer.removeAttribute("role");
         }, 200);
     }
 

--- a/src/ui/handler/touch_pan.js
+++ b/src/ui/handler/touch_pan.js
@@ -156,7 +156,7 @@ export default class TouchPanHandler {
 
         this._alertTimer = setTimeout(() => {
             this._alertContainer.classList.remove('mapboxgl-touch-pan-blocker-show');
-            this._alertContainer.setAttribute("role", "null");
+            this._alertContainer.removeAttribute("role");
         }, 500);
     }
 


### PR DESCRIPTION
## Launch Checklist

Closes #12912

 - [X] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [X] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [X] Manually test the debug page.

Remove hidden alert role attribute.
There's no role "null" for HTML elements as mentioned by the author of the issue. My changes remove this attribute when alert is  not visible. These are scroll zoom and touch pan alerts.
I could also use "none" role, but both approaches seem to look correct.

Tested on Chrome and Firefox on Windows 10 with axe devtools and NVDA screen reader. 

See issue https://github.com/mapbox/mapbox-gl-js/issues/12912

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute