### PR TITLE
Fix memory leak when removing map

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -3037,7 +3037,7 @@ class Style extends Evented {
 
     destroy() {
         this._clearWorkerCaches();
-        this.fragments.forEach(fragment=>{
+        this.fragments.forEach(fragment => {
             fragment.style._remove();
         });
         if (this.terrainSetForDrapingOnly()) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -3037,6 +3037,9 @@ class Style extends Evented {
 
     destroy() {
         this._clearWorkerCaches();
+        this.fragments.forEach(fragment=>{
+            fragment.style._remove();
+        });
         if (this.terrainSetForDrapingOnly()) {
             delete this.terrain;
             delete this.stylesheet.terrain;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -5,7 +5,7 @@ import {asyncAll, extend, bindAll, warnOnce, uniqueId, isSafariWithAntialiasingB
 import browser from '../util/browser.js';
 import * as DOM from '../util/dom.js';
 import {getImage, getJSON, ResourceType} from '../util/ajax.js';
-import {RequestManager, getMapSessionAPI, postPerformanceEvent, postMapLoadEvent, AUTH_ERR_MSG, storeAuthState, removeAuthState} from '../util/mapbox.js';
+import {RequestManager, mapSessionAPI, getMapSessionAPI, postPerformanceEvent, postMapLoadEvent, AUTH_ERR_MSG, storeAuthState, removeAuthState} from '../util/mapbox.js';
 import Style from '../style/style.js';
 import EvaluationParameters from '../style/evaluation_parameters.js';
 import Painter from '../render/painter.js';
@@ -4012,6 +4012,9 @@ class Map extends Camera {
 
         PerformanceUtils.clearMetrics();
         removeAuthState(this.painter.context.gl);
+
+        mapSessionAPI.remove();
+
         this._removed = true;
         this.fire(new Event('remove'));
     }

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -576,6 +576,11 @@ export class MapSessionAPI extends TelemetryEvent {
             }
         }, customAccessToken);
     }
+
+    remove() {
+        // $FlowFixMe[incompatible-type]
+        this.errorCb = null;
+    }
 }
 
 export class TurnstileEvent extends TelemetryEvent {
@@ -660,9 +665,9 @@ export const performanceEvent_: PerformanceEvent = new PerformanceEvent();
 // $FlowFixMe[method-unbinding]
 export const postPerformanceEvent: (?string, LivePerformanceData) => void = performanceEvent_.postPerformanceEvent.bind(performanceEvent_);
 
-const mapSessionAPI_ = new MapSessionAPI();
+export const mapSessionAPI: MapSessionAPI = new MapSessionAPI();
 // $FlowFixMe[method-unbinding]
-export const getMapSessionAPI: (number, string, ?string, EventCallback) => void = mapSessionAPI_.getSessionAPI.bind(mapSessionAPI_);
+export const getMapSessionAPI: (number, string, ?string, EventCallback) => void = mapSessionAPI.getSessionAPI.bind(mapSessionAPI);
 
 const authenticatedMaps = new Set();
 export function storeAuthState(gl: WebGL2RenderingContext, state: boolean) {


### PR DESCRIPTION
Hey, so I digged a little in code to resolve this issue https://github.com/mapbox/mapbox-gl-js/issues/9126 and it kinda seems like I found what the issue is (for a bare map, nothing was touched after mounting).

Tested it using `FinalizationRegistry` and heap snapshots

Before:
When Map was added and removed using `map.remove()` it was piling up in memory heap snapshot.

After my changes:
When Map is removed and another instance of map is being mounted, previous instance is garbage collected.

![image](https://github.com/mapbox/mapbox-gl-js/assets/138137613/870cdae2-f35a-4d10-ad46-548d4a82c409)

Which wasn't exactly what I wanted.
I suspect that another issue lies in:

`src/ui/map.js`
```
 3881  const gl = this.painter.context.gl;
```
in `_authenticate` -> `getMapSessionAPI` -> `error callback`
which holds `this.painter` forever as
`const mapSessionAPI_ = new MapSessionAPI();` is created in global scope and never freed.

but that code is just below warning about terms of service, so I'm not touching that :p

For future issues: Do I have permission to modify/debug this code with good intentions? All changes that improve mapbox would be put out in public PRs to approve by mapbox team.

@mourner @stepankuzmin let me know if that works and if you could handle issue in code that is under TOS 🤝 
