### PR TITLE
Fix memory leak in MapLoadEvent

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -5,7 +5,17 @@ import {asyncAll, extend, bindAll, warnOnce, uniqueId, isSafariWithAntialiasingB
 import browser from '../util/browser.js';
 import * as DOM from '../util/dom.js';
 import {getImage, getJSON, ResourceType} from '../util/ajax.js';
-import {RequestManager, mapSessionAPI, getMapSessionAPI, postPerformanceEvent, postMapLoadEvent, AUTH_ERR_MSG, storeAuthState, removeAuthState} from '../util/mapbox.js';
+import {
+    RequestManager,
+    mapSessionAPI,
+    getMapSessionAPI,
+    postPerformanceEvent,
+    postMapLoadEvent,
+    AUTH_ERR_MSG,
+    storeAuthState,
+    removeAuthState,
+    mapLoadEvent_
+} from '../util/mapbox.js';
 import Style from '../style/style.js';
 import EvaluationParameters from '../style/evaluation_parameters.js';
 import Painter from '../render/painter.js';
@@ -4014,6 +4024,7 @@ class Map extends Camera {
         removeAuthState(this.painter.context.gl);
 
         mapSessionAPI.remove();
+        mapLoadEvent_.remove();
 
         this._removed = true;
         this.fire(new Event('remove'));

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -8,13 +8,13 @@ import {getImage, getJSON, ResourceType} from '../util/ajax.js';
 import {
     RequestManager,
     mapSessionAPI,
+    mapLoadEvent,
     getMapSessionAPI,
     postPerformanceEvent,
     postMapLoadEvent,
     AUTH_ERR_MSG,
     storeAuthState,
-    removeAuthState,
-    mapLoadEvent_
+    removeAuthState
 } from '../util/mapbox.js';
 import Style from '../style/style.js';
 import EvaluationParameters from '../style/evaluation_parameters.js';
@@ -3901,6 +3901,7 @@ class Map extends Camera {
                 }
             }
         });
+
         postMapLoadEvent(this._getMapId(), this._requestManager._skuToken, this._requestManager._customAccessToken, () => {});
     }
 
@@ -4024,7 +4025,7 @@ class Map extends Camera {
         removeAuthState(this.painter.context.gl);
 
         mapSessionAPI.remove();
-        mapLoadEvent_.remove();
+        mapLoadEvent.remove();
 
         this._removed = true;
         this.fire(new Event('remove'));

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -514,6 +514,11 @@ export class MapLoadEvent extends TelemetryEvent {
 
         }, customAccessToken);
     }
+
+    remove() {
+        // $FlowFixMe[incompatible-type]
+        this.errorCb = null;
+    }
 }
 
 export class MapSessionAPI extends TelemetryEvent {
@@ -657,7 +662,7 @@ const turnstileEvent_ = new TurnstileEvent();
 // $FlowFixMe[method-unbinding]
 export const postTurnstileEvent: (tileUrls: Array<string>, customAccessToken?: ?string) => void = turnstileEvent_.postTurnstileEvent.bind(turnstileEvent_);
 
-const mapLoadEvent_ = new MapLoadEvent();
+export const mapLoadEvent_ = new MapLoadEvent();
 // $FlowFixMe[method-unbinding]
 export const postMapLoadEvent: (number, string, ?string, EventCallback) => void = mapLoadEvent_.postMapLoadEvent.bind(mapLoadEvent_);
 
@@ -670,6 +675,7 @@ export const mapSessionAPI: MapSessionAPI = new MapSessionAPI();
 export const getMapSessionAPI: (number, string, ?string, EventCallback) => void = mapSessionAPI.getSessionAPI.bind(mapSessionAPI);
 
 const authenticatedMaps = new Set();
+
 export function storeAuthState(gl: WebGL2RenderingContext, state: boolean) {
     if (state) {
         authenticatedMaps.add(gl);

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -675,7 +675,6 @@ export const mapSessionAPI: MapSessionAPI = new MapSessionAPI();
 export const getMapSessionAPI: (number, string, ?string, EventCallback) => void = mapSessionAPI.getSessionAPI.bind(mapSessionAPI);
 
 const authenticatedMaps = new Set();
-
 export function storeAuthState(gl: WebGL2RenderingContext, state: boolean) {
     if (state) {
         authenticatedMaps.add(gl);

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -662,7 +662,7 @@ const turnstileEvent_ = new TurnstileEvent();
 // $FlowFixMe[method-unbinding]
 export const postTurnstileEvent: (tileUrls: Array<string>, customAccessToken?: ?string) => void = turnstileEvent_.postTurnstileEvent.bind(turnstileEvent_);
 
-export const mapLoadEvent = new MapLoadEvent();
+export const mapLoadEvent: MapLoadEvent = new MapLoadEvent();
 // $FlowFixMe[method-unbinding]
 export const postMapLoadEvent: (number, string, ?string, EventCallback) => void = mapLoadEvent.postMapLoadEvent.bind(mapLoadEvent);
 

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -662,9 +662,9 @@ const turnstileEvent_ = new TurnstileEvent();
 // $FlowFixMe[method-unbinding]
 export const postTurnstileEvent: (tileUrls: Array<string>, customAccessToken?: ?string) => void = turnstileEvent_.postTurnstileEvent.bind(turnstileEvent_);
 
-export const mapLoadEvent_ = new MapLoadEvent();
+export const mapLoadEvent = new MapLoadEvent();
 // $FlowFixMe[method-unbinding]
-export const postMapLoadEvent: (number, string, ?string, EventCallback) => void = mapLoadEvent_.postMapLoadEvent.bind(mapLoadEvent_);
+export const postMapLoadEvent: (number, string, ?string, EventCallback) => void = mapLoadEvent.postMapLoadEvent.bind(mapLoadEvent);
 
 export const performanceEvent_: PerformanceEvent = new PerformanceEvent();
 // $FlowFixMe[method-unbinding]


### PR DESCRIPTION
Hey @stepankuzmin, as promised there is my PR fixing memory leak in mapbox. Right now whole Map is being cleaned when it's unmounted.

That's actually pretty funny how this line
```
postMapLoadEvent(this._getMapId(), this._requestManager._skuToken, this._requestManager._customAccessToken, () => {});
```

caused memory leak, function `() => {}` passed as error callback has access to `this` which is actually a Map object. Function was never cleaned therefore it was holding everything alive :D To my understanding any definition of function like so:

```
function errCb(){}

postMapLoadEvent(this._getMapId(), this._requestManager._skuToken, this._requestManager._customAccessToken, errCb);
```

would also leak as `errCb` also has indirect access to whatever is in `_authenticate` function which ultimately holds `this.painter.context.gl` but that's something I'm not sure about.

Hope it makes sense 💯 