### PR TITLE
Updated comment for LngLatBounds to discuss the range of valid input for this method in order to reflect in the API docs on site

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -205,7 +205,9 @@ export default LngLat;
 
 /**
  * A `LngLatBounds` object represents a geographical bounding box,
- * defined by its southwest and northeast points in longitude and latitude.
+ * defined by its southwest and northeast points in [`longitude`](https://docs.mapbox.com/help/glossary/lat-lon/) and [`latitude`](https://docs.mapbox.com/help/glossary/lat-lon/).
+ * `Longitude` values are typically set between `-180` to `180`, but can exceed this range if necessary. 
+ * `Latitude` values must be within `-90` to `90`.
  *
  * If no arguments are provided to the constructor, a `null` bounding box is created.
  *

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -206,8 +206,7 @@ export default LngLat;
 /**
  * A `LngLatBounds` object represents a geographical bounding box,
  * defined by its southwest and northeast points in [`longitude`](https://docs.mapbox.com/help/glossary/lat-lon/) and [`latitude`](https://docs.mapbox.com/help/glossary/lat-lon/).
- * `Longitude` values are typically set between `-180` to `180`, but can exceed this range if necessary. 
- * `Latitude` values must be within `-90` to `90`.
+ * `Longitude` values are typically set between `-180` to `180`, but can exceed this range if necessary. `Latitude` values must be within `-90` to `90`.
  *
  * If no arguments are provided to the constructor, a `null` bounding box is created.
  *

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -6,7 +6,9 @@ import type {LngLatLike} from './lng_lat.js';
 
 /**
  * A `LngLatBounds` object represents a geographical bounding box,
- * defined by its southwest and northeast points in longitude and latitude.
+ * defined by its southwest and northeast points in [`longitude`](https://docs.mapbox.com/help/glossary/lat-lon/) and [`latitude`](https://docs.mapbox.com/help/glossary/lat-lon/).
+ * `Longitude` values are typically set between `-180` to `180`, but can exceed this range if necessary. 
+ * `Latitude` values must be within `-90` to `90`.
  *
  * If no arguments are provided to the constructor, a `null` bounding box is created.
  *

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -7,8 +7,7 @@ import type {LngLatLike} from './lng_lat.js';
 /**
  * A `LngLatBounds` object represents a geographical bounding box,
  * defined by its southwest and northeast points in [`longitude`](https://docs.mapbox.com/help/glossary/lat-lon/) and [`latitude`](https://docs.mapbox.com/help/glossary/lat-lon/).
- * `Longitude` values are typically set between `-180` to `180`, but can exceed this range if necessary. 
- * `Latitude` values must be within `-90` to `90`.
+ * `Longitude` values are typically set between `-180` to `180`, but can exceed this range if necessary. `Latitude` values must be within `-90` to `90`.
  *
  * If no arguments are provided to the constructor, a `null` bounding box is created.
  *


### PR DESCRIPTION
In parallel with a customer request about [fitbounds](https://github.com/mapbox/mapbox-gl-js-docs/pull/1002), I've added a description to the LngLatBounds API comment to specify the limitations of the longitude and latitude ranges so it can be reflected in the site's API documentation.

This has been edited in both lng_lat.js and lng_lat_bounds.js since the original comment appeared in both locations, however from tests it only seems the comment in lng_lat.js actually made a change to the generated API docs.

![LngLatBounds](https://github.com/mapbox/mapbox-gl-js/assets/165188524/e78af9a6-7ded-44a1-8443-8204c7ae0537)

## Launch Checklist

 - [X] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [X] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [X] Manually test the debug page.
 - [N/A] Write tests for all new functionality and make sure the CI checks pass.
 - [X] Document any changes to public APIs.
 - [N/A] Post benchmark scores if the change could affect performance.
 - [N/A] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [N/A] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
