### PR TITLE
enforce no wrapIndent for jsdoc comments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -129,7 +129,8 @@
         "jsdoc/require-property-description": "off",
         "jsdoc/require-property-name": "off",
         "jsdoc/require-property-type": "off",
-        "jsdoc/require-returns-type": "off",
+        "jsdoc/require-returns-type": "off"
+        
       }
     },
     {
@@ -160,7 +161,7 @@
             "matchingFileName": "src/fake_filename_for_jsdoc_examples",
             "rejectExampleCodeRegex": "<script>"
         }],
-        "jsdoc/check-line-alignment": ["error", "any", {"wrapIndent": "    "}],
+        "jsdoc/check-line-alignment": ["error"],
         "jsdoc/check-property-names": "error",
         "jsdoc/check-types": "error",
         "jsdoc/tag-lines": ["error", "any", {"startLines": 1}],

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -420,7 +420,7 @@ export class LngLatBounds {
      * Returns the bounding box represented as an array.
      *
      * @returns {Array<Array<number>>} The bounding box represented as an array, consisting of the
-     *     southwest and northeast coordinates of the bounding represented as arrays of numbers.
+     * southwest and northeast coordinates of the bounding represented as arrays of numbers.
      * @example
      * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toArray(); // = [[-73.9876, 40.7661], [-73.9397, 40.8002]]
@@ -433,7 +433,7 @@ export class LngLatBounds {
      * Return the bounding box represented as a string.
      *
      * @returns {string} The bounding box represents as a string of the format
-     *     `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
+     * `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
      * @example
      * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toString(); // = "LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))"

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -221,7 +221,7 @@ class LngLatBounds {
      * Returns the bounding box represented as an array.
      *
      * @returns {Array<Array<number>>} The bounding box represented as an array, consisting of the
-     *     southwest and northeast coordinates of the bounding represented as arrays of numbers.
+     * southwest and northeast coordinates of the bounding represented as arrays of numbers.
      * @example
      * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toArray(); // = [[-73.9876, 40.7661], [-73.9397, 40.8002]]
@@ -234,7 +234,7 @@ class LngLatBounds {
      * Return the bounding box represented as a string.
      *
      * @returns {string} The bounding box represents as a string of the format
-     *     `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
+     * `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
      * @example
      * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toString(); // = "LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))"

--- a/src/index.js
+++ b/src/index.js
@@ -297,9 +297,9 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @function supported
  * @param {Object} [options]
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`,
- *     the function will return `false` if the performance of Mapbox GL JS would
- *     be dramatically worse than expected (for example, a software WebGL renderer
- *     would be used).
+ * the function will return `false` if the performance of Mapbox GL JS would
+ * be dramatically worse than expected (for example, a software WebGL renderer
+ * would be used).
  * @return {boolean}
  * @example
  * // Show an alert if the browser does not support Mapbox GL
@@ -317,7 +317,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @param {string} pluginURL URL pointing to the Mapbox RTL text plugin source.
  * @param {Function} callback Called with an error argument if there is an error, or no arguments if the plugin loads successfully.
  * @param {boolean} lazy If set to `true`, MapboxGL will defer loading the plugin until right-to-left text is encountered, and
- *     right-to-left text will be rendered only after the plugin finishes loading.
+ * right-to-left text will be rendered only after the plugin finishes loading.
  * @example
  * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
  * @see [Example: Add support for right-to-left scripts](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-rtl-text/)

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -184,9 +184,9 @@ class CanvasSource extends ImageSource {
      * @instance
      * @memberof CanvasSource
      * @param {Array<Array<number>>} coordinates Four geographical coordinates,
-     *     represented as arrays of longitude and latitude numbers, which define the corners of the canvas.
-     *     The coordinates start at the top left corner of the canvas and proceed in clockwise order.
-     *     They do not have to represent a rectangle.
+     * represented as arrays of longitude and latitude numbers, which define the corners of the canvas.
+     * The coordinates start at the top left corner of the canvas and proceed in clockwise order.
+     * They do not have to represent a rectangle.
      * @returns {CanvasSource} Returns itself to allow for method chaining.
      */
 

--- a/src/source/custom_source.js
+++ b/src/source/custom_source.js
@@ -130,7 +130,7 @@ function isRaster(data: any): boolean {
  * @param {Object} options Options.
  * @param {AbortSignal} options.signal A signal object that communicates when the map cancels the tile loading request.
  * @returns {Promise<TextureImage | undefined | null>} The promise that resolves to the tile image data as an `HTMLCanvasElement`, `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`.
- *     If `loadTile` resolves to `undefined`, a map will render an overscaled parent tile in the tile’s space. If `loadTile` resolves to `null`, a map will render nothing in the tile’s space.
+ * If `loadTile` resolves to `undefined`, a map will render an overscaled parent tile in the tile’s space. If `loadTile` resolves to `null`, a map will render nothing in the tile’s space.
  */
 export type CustomSourceInterface<T> = {
     id: string;

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -326,9 +326,9 @@ class ImageSource extends Evented implements Source {
      * @param {Object} options Options object.
      * @param {string} [options.url] Required image URL.
      * @param {Array<Array<number>>} [options.coordinates] Four geographical coordinates,
-     *     represented as arrays of longitude and latitude numbers, which define the corners of the image.
-     *     The coordinates start at the top left corner of the image and proceed in clockwise order.
-     *     They do not have to represent a rectangle.
+     * represented as arrays of longitude and latitude numbers, which define the corners of the image.
+     * The coordinates start at the top left corner of the image and proceed in clockwise order.
+     * They do not have to represent a rectangle.
      * @returns {ImageSource} Returns itself to allow for method chaining.
      * @example
      * // Add to an image source to the map with some initial URL and coordinates
@@ -415,9 +415,9 @@ class ImageSource extends Evented implements Source {
      * Sets the image's coordinates and re-renders the map.
      *
      * @param {Array<Array<number>>} coordinates Four geographical coordinates,
-     *     represented as arrays of longitude and latitude numbers, which define the corners of the image.
-     *     The coordinates start at the top left corner of the image and proceed in clockwise order.
-     *     They do not have to represent a rectangle.
+     * represented as arrays of longitude and latitude numbers, which define the corners of the image.
+     * The coordinates start at the top left corner of the image and proceed in clockwise order.
+     * They do not have to represent a rectangle.
      * @returns {ImageSource} Returns itself to allow for method chaining.
      * @example
      * // Add an image source to the map with some initial coordinates

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -55,15 +55,15 @@ type Required<T> = $ObjMap<T, <V>(v: V) => $NonMaybeType<V>>;
  * @property {LngLatLike} center The location to place at the screen center.
  * @property {number} zoom The desired zoom level.
  * @property {number} bearing The desired bearing in degrees. The bearing is the compass direction that
- *     is "up". For example, `bearing: 90` orients the map so that east is up.
+ * is "up". For example, `bearing: 90` orients the map so that east is up.
  * @property {number} pitch The desired pitch in degrees. The pitch is the angle towards the horizon
- *     measured in degrees with a range between 0 and 85 degrees. For example, pitch: 0 provides the appearance
- *     of looking straight down at the map, while pitch: 60 tilts the user's perspective towards the horizon.
- *     Increasing the pitch value is often used to display 3D objects.
+ * measured in degrees with a range between 0 and 85 degrees. For example, pitch: 0 provides the appearance
+ * of looking straight down at the map, while pitch: 60 tilts the user's perspective towards the horizon.
+ * Increasing the pitch value is often used to display 3D objects.
  * @property {LngLatLike} around The location serving as the origin for a change in `zoom`, `pitch` and/or `bearing`.
- *     This location will remain at the same screen position following the transform.
- *     This is useful for drawing attention to a location that is not in the screen center.
- *     `center` is ignored if `around` is included.
+ * This location will remain at the same screen position following the transform.
+ * This is useful for drawing attention to a location that is not in the screen center.
+ * `center` is ignored if `around` is included.
  * @property {PaddingOptions} padding Dimensions in pixels applied on each side of the viewport for shifting the vanishing point.
  * @example
  * // set the map's initial perspective with CameraOptions
@@ -103,29 +103,29 @@ export type FullCameraOptions = {
  * @typedef {Object} AnimationOptions
  * @property {number} duration The animation's duration, measured in milliseconds.
  * @property {Function} easing A function taking a time in the range 0..1 and returning a number where 0 is
- *     the initial state and 1 is the final state.
+ * the initial state and 1 is the final state.
  * @property {PointLike} offset The target center's offset relative to real map container center at the end of animation.
  * @property {boolean} animate If `false`, no animation will occur.
  * @property {boolean} essential If `true`, then the animation is considered essential and will not be affected by
- *     [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
+ * [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
  * @property {boolean} preloadOnly If `true`, it will trigger tiles loading across the animation path, but no animation will occur.
  * @property {number} curve The zooming "curve" that will occur along the
- *     flight path. A high value maximizes zooming for an exaggerated animation, while a low
- *     value minimizes zooming for an effect closer to {@link Map#easeTo}. 1.42 is the average
- *     value selected by participants in the user study discussed in
- *     [van Wijk (2003)](https://www.win.tue.nl/~vanwijk/zoompan.pdf). A value of
- *     `Math.pow(6, 0.25)` would be equivalent to the root mean squared average velocity. A
- *     value of 1 would produce a circular motion. If `minZoom` is specified, this option will be ignored.
+ * flight path. A high value maximizes zooming for an exaggerated animation, while a low
+ * value minimizes zooming for an effect closer to {@link Map#easeTo}. 1.42 is the average
+ * value selected by participants in the user study discussed in
+ * [van Wijk (2003)](https://www.win.tue.nl/~vanwijk/zoompan.pdf). A value of
+ * `Math.pow(6, 0.25)` would be equivalent to the root mean squared average velocity. A
+ * value of 1 would produce a circular motion. If `minZoom` is specified, this option will be ignored.
  * @property {number} minZoom The zero-based zoom level at the peak of the flight path. If
- *     this option is specified, `curve` will be ignored.
+ * this option is specified, `curve` will be ignored.
  * @property {number} speed The average speed of the animation defined in relation to
- *     `curve`. A speed of 1.2 means that the map appears to move along the flight path
- *     by 1.2 times `curve` screenfuls every second. A _screenful_ is the map's visible span.
- *     It does not correspond to a fixed physical distance, but varies by zoom level.
+ * `curve`. A speed of 1.2 means that the map appears to move along the flight path
+ * by 1.2 times `curve` screenfuls every second. A _screenful_ is the map's visible span.
+ * It does not correspond to a fixed physical distance, but varies by zoom level.
  * @property {number} screenSpeed The average speed of the animation measured in screenfuls
- *     per second, assuming a linear timing curve. If `speed` is specified, this option is ignored.
+ * per second, assuming a linear timing curve. If `speed` is specified, this option is ignored.
  * @property {number} maxDuration The animation's maximum duration, measured in milliseconds.
- *     If duration exceeds maximum duration, it resets to 0.
+ * If duration exceeds maximum duration, it resets to 0.
  * @see [Example: Slowly fly to a location](https://docs.mapbox.com/mapbox-gl-js/example/flyto-options/)
  * @see [Example: Customize camera animations](https://docs.mapbox.com/mapbox-gl-js/example/camera-animation/)
  * @see [Example: Navigate the map with game-like controls](https://docs.mapbox.com/mapbox-gl-js/example/game-controls/)
@@ -467,7 +467,7 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {number} bearing The desired bearing.
      * @param {EasingOptions | null} options Options describing the destination and animation of the transition.
-     *     Accepts {@link CameraOptions} and {@link AnimationOptions}.
+     * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires Map.event:movestart
      * @fires Map.event:moveend
@@ -489,7 +489,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {EasingOptions | null} options Options describing the destination and animation of the transition.
-     *     Accepts {@link CameraOptions} and {@link AnimationOptions}.
+     * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires Map.event:movestart
      * @fires Map.event:moveend
@@ -508,7 +508,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {EasingOptions | null} options Options describing the destination and animation of the transition.
-     *     Accepts {@link CameraOptions} and {@link AnimationOptions}.
+     * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires Map.event:movestart
      * @fires Map.event:moveend
@@ -532,7 +532,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {EasingOptions | null} options Options describing the destination and animation of the transition.
-     *     Accepts {@link CameraOptions} and {@link AnimationOptions}.
+     * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires Map.event:movestart
      * @fires Map.event:moveend
@@ -584,8 +584,8 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Calculate the center for these bounds in the viewport and use
-     *     the highest zoom level up to and including `Map#getMaxZoom()` that fits
-     *     in the viewport. LngLatBounds represent a box that is always axis-aligned with bearing 0.
+     * the highest zoom level up to and including `Map#getMaxZoom()` that fits
+     * in the viewport. LngLatBounds represent a box that is always axis-aligned with bearing 0.
      * @param {CameraOptions | null} options Options object.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {number} [options.bearing=0] Desired map bearing at end of animation, in degrees.
@@ -593,7 +593,7 @@ class Camera extends Evented {
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the camera would transition to the specified bounds.
      * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns `CameraOptions` with
-     *     `center`, `zoom`, and `bearing`. If map is unable to fit, method will warn and return undefined.
+     * `center`, `zoom`, and `bearing`. If map is unable to fit, method will warn and return undefined.
      * @example
      * const bbox = [[-79, 43], [-73, 45]];
      * const newCameraTransform = map.cameraForBounds(bbox, {
@@ -790,7 +790,7 @@ class Camera extends Evented {
      * @param {LngLatLike} lnglat The geographical location at which to query.
      * @param {ElevationQueryOptions} [options] Options object.
      * @param {boolean} [options.exaggerated=true] When `true` returns the terrain elevation with the value of `exaggeration` from the style already applied.
-     *     When `false`, returns the raw value of the underlying data without styling applied.
+     * When `false`, returns the raw value of the underlying data without styling applied.
      * @returns {number | null} The elevation in meters.
      * @example
      * const coordinate = [-122.420679, 37.772537];
@@ -910,14 +910,14 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
-     *     zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
+     * zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
      * @param {Object} [options] Options supports all properties from {@link AnimationOptions} and {@link CameraOptions} in addition to the fields below.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {number} [options.pitch=0] Desired map pitch at end of animation, in degrees.
      * @param {number} [options.bearing=0] Desired map bearing at end of animation, in degrees.
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
-     *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
-     *     those functions and {@link AnimationOptions} for information about options available.
+     * {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
+     * those functions and {@link AnimationOptions} for information about options available.
      * @param {Function} [options.easing] An easing function for the animated transition. See {@link AnimationOptions}.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
@@ -947,11 +947,11 @@ class Camera extends Evented {
      * @param {PointLike} p1 Second point on screen, in pixel coordinates.
      * @param {number} bearing Desired map bearing at end of animation, in degrees.
      * @param {EasingOptions | null} options Options object.
-     *     Accepts {@link CameraOptions} and {@link AnimationOptions}.
+     * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
-     *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
-     *     those functions and {@link AnimationOptions} for information about options available.
+     * {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
+     * those functions and {@link AnimationOptions} for information about options available.
      * @param {number} [options.pitch=0] Desired map pitch at end of animation, in degrees.
      * @param {Function} [options.easing] An easing function for the animated transition. See {@link AnimationOptions}.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
@@ -1221,7 +1221,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {EasingOptions} options Options describing the destination and animation of the transition.
-     *     Accepts {@link CameraOptions} and {@link AnimationOptions}.
+     * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires Map.event:movestart
      * @fires Map.event:zoomstart
@@ -1457,25 +1457,25 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param {Object} options Options describing the destination and animation of the transition.
-     *     Accepts {@link CameraOptions}, {@link AnimationOptions},
-     *     and the following additional options.
+     * Accepts {@link CameraOptions}, {@link AnimationOptions},
+     * and the following additional options.
      * @param {number} [options.curve=1.42] The zooming "curve" that will occur along the
-     *     flight path. A high value maximizes zooming for an exaggerated animation, while a low
-     *     value minimizes zooming for an effect closer to {@link Map#easeTo}. 1.42 is the average
-     *     value selected by participants in the user study discussed in
-     *     [van Wijk (2003)](https://www.win.tue.nl/~vanwijk/zoompan.pdf). A value of
-     *     `Math.pow(6, 0.25)` would be equivalent to the root mean squared average velocity. A
-     *     value of 1 would produce a circular motion. If `options.minZoom` is specified, this option will be ignored.
+     * flight path. A high value maximizes zooming for an exaggerated animation, while a low
+     * value minimizes zooming for an effect closer to {@link Map#easeTo}. 1.42 is the average
+     * value selected by participants in the user study discussed in
+     * [van Wijk (2003)](https://www.win.tue.nl/~vanwijk/zoompan.pdf). A value of
+     * `Math.pow(6, 0.25)` would be equivalent to the root mean squared average velocity. A
+     * value of 1 would produce a circular motion. If `options.minZoom` is specified, this option will be ignored.
      * @param {number} [options.minZoom] The zero-based zoom level at the peak of the flight path. If
-     *     this option is specified, `options.curve` will be ignored.
+     * this option is specified, `options.curve` will be ignored.
      * @param {number} [options.speed=1.2] The average speed of the animation defined in relation to
-     *     `options.curve`. A speed of 1.2 means that the map appears to move along the flight path
-     *     by 1.2 times `options.curve` screenfuls every second. A _screenful_ is the map's visible span.
-     *     It does not correspond to a fixed physical distance, but varies by zoom level.
+     * `options.curve`. A speed of 1.2 means that the map appears to move along the flight path
+     * by 1.2 times `options.curve` screenfuls every second. A _screenful_ is the map's visible span.
+     * It does not correspond to a fixed physical distance, but varies by zoom level.
      * @param {number} [options.screenSpeed] The average speed of the animation measured in screenfuls
-     *     per second, assuming a linear timing curve. If `options.speed` is specified, this option is ignored.
+     * per second, assuming a linear timing curve. If `options.speed` is specified, this option is ignored.
      * @param {number} [options.maxDuration] The animation's maximum duration, measured in milliseconds.
-     *     If duration exceeds maximum duration, it resets to 0.
+     * If duration exceeds maximum duration, it resets to 0.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires Map.event:movestart
      * @fires Map.event:zoomstart

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -409,11 +409,11 @@ export type MapBoxZoomEvent = {
  * @property {Object} [source] The [style spec representation of the source](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) if the event has a `dataType` of `source`.
  * @property {string} [sourceId] The `id` of the [`source`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) that triggered the event, if the event has a `dataType` of `source`. Same as the `id` of the object in the `source` property.
  * @property {string} [sourceDataType] Included if the event has a `dataType` of `source` and the event signals
- *     that internal data has been received or changed. Possible values are `metadata`, `content`, `visibility`, and `error`.
+ * that internal data has been received or changed. Possible values are `metadata`, `content` and `visibility`, and `error`.
  * @property {Object} [tile] The tile being loaded or changed, if the event has a `dataType` of `source` and
- *     the event is related to loading of a tile.
+ * the event is related to loading of a tile.
  * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and
- *     the event is related to loading of a tile.
+ * the event is related to loading of a tile.
  * @example
  * // Example of a MapDataEvent of type "sourcedata"
  * map.on('sourcedata', (e) => {

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -167,7 +167,7 @@ class KeyboardHandler implements Handler {
      * interaction is enabled.
      *
      * @returns {boolean} `true` if the "keyboard rotate and zoom"
-     *     interaction is enabled.
+     * interaction is enabled.
      * @example
      * const isKeyboardEnabled = map.keyboard.isEnabled();
      */
@@ -180,7 +180,7 @@ class KeyboardHandler implements Handler {
      * zoom/rotate gesture.
      *
      * @returns {boolean} `true` if the handler is enabled and has detected the
-     *     start of a zoom/rotate gesture.
+     * start of a zoom/rotate gesture.
      * @example
      * const isKeyboardActive = map.keyboard.isActive();
      */

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -263,35 +263,35 @@ class DebugParams {
  * @param {number} [options.minPitch=0] The minimum pitch of the map (0-85).
  * @param {number} [options.maxPitch=85] The maximum pitch of the map (0-85).
  * @param {Object | string} [options.style='mapbox://styles/mapbox/standard'] The map's Mapbox style. This must be an a JSON object conforming to
- *     the schema described in the [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL
- *     to such JSON. Can accept a null value to allow adding a style manually.
+ * the schema described in the [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL
+ * to such JSON. Can accept a null value to allow adding a style manually.
  *
- *     To load a style from the Mapbox API, you can use a URL of the form `mapbox://styles/:owner/:style`,
- *     where `:owner` is your Mapbox account name and `:style` is the style ID. You can also use a
- *     [Mapbox-owned style](https://docs.mapbox.com/api/maps/styles/#mapbox-styles):
+ * To load a style from the Mapbox API, you can use a URL of the form `mapbox://styles/:owner/:style`,
+ * where `:owner` is your Mapbox account name and `:style` is the style ID. You can also use a
+ * [Mapbox-owned style](https://docs.mapbox.com/api/maps/styles/#mapbox-styles):
  *
- *     * `mapbox://styles/mapbox/standard`
- *     * `mapbox://styles/mapbox/streets-v12`
- *     * `mapbox://styles/mapbox/outdoors-v12`
- *     * `mapbox://styles/mapbox/light-v11`
- *     * `mapbox://styles/mapbox/dark-v11`
- *     * `mapbox://styles/mapbox/satellite-v9`
- *     * `mapbox://styles/mapbox/satellite-streets-v12`
- *     * `mapbox://styles/mapbox/navigation-day-v1`
- *     * `mapbox://styles/mapbox/navigation-night-v1`.
+ * * `mapbox://styles/mapbox/standard`
+ * * `mapbox://styles/mapbox/streets-v12`
+ * * `mapbox://styles/mapbox/outdoors-v12`
+ * * `mapbox://styles/mapbox/light-v11`
+ * * `mapbox://styles/mapbox/dark-v11`
+ * * `mapbox://styles/mapbox/satellite-v9`
+ * * `mapbox://styles/mapbox/satellite-streets-v12`
+ * * `mapbox://styles/mapbox/navigation-day-v1`
+ * * `mapbox://styles/mapbox/navigation-night-v1`.
  *
- *     Tilesets hosted with Mapbox can be style-optimized if you append `?optimize=true` to the end of your style URL, like `mapbox://styles/mapbox/streets-v11?optimize=true`.
- *     Learn more about style-optimized vector tiles in our [API documentation](https://www.mapbox.com/api-documentation/maps/#retrieve-tiles).
+ * Tilesets hosted with Mapbox can be style-optimized if you append `?optimize=true` to the end of your style URL, like `mapbox://styles/mapbox/streets-v11?optimize=true`.
+ * Learn more about style-optimized vector tiles in our [API documentation](https://www.mapbox.com/api-documentation/maps/#retrieve-tiles).
  *
  * @param {(boolean|string)} [options.hash=false] If `true`, the map's [position](https://docs.mapbox.com/help/glossary/camera) (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.
- *     For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
- *     An additional string may optionally be provided to indicate a parameter-styled hash,
- *     for example http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where `foo`
- *     is a custom parameter and `bar` is an arbitrary hash distinct from the map hash.
+ * For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
+ * An additional string may optionally be provided to indicate a parameter-styled hash,
+ * for example http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where `foo`
+ * is a custom parameter and `bar` is an arbitrary hash distinct from the map hash.
  * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners will be attached to the map, so it will not respond to interaction.
  * @param {number} [options.bearingSnap=7] The threshold, measured in degrees, that determines when the map's
- *     bearing will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
- *     the map within 7 degrees of north, the map will automatically snap to exact north.
+ * bearing will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
+ * the map within 7 degrees of north, the map will automatically snap to exact north.
  * @param {boolean} [options.pitchWithRotate=true] If `false`, the map's pitch (tilt) control with "drag to rotate" interaction will be disabled.
  * @param {number} [options.clickTolerance=3] The max number of pixels a user can shift the mouse pointer during a click for it to be considered a valid click (as opposed to a mouse drag).
  * @param {boolean} [options.attributionControl=true] If `true`, an {@link AttributionControl} will be added to the map.
@@ -320,50 +320,50 @@ class DebugParams {
  * @param {LngLatBoundsLike} [options.bounds=null] The initial bounds of the map. If `bounds` is specified, it overrides `center` and `zoom` constructor options.
  * @param {Object} [options.fitBoundsOptions=null] A {@link Map#fitBounds} options object to use _only_ when fitting the initial `bounds` provided above.
  * @param {'auto' | string | string[]} [options.language=null] A string with a BCP 47 language tag, or an array of such strings representing the desired languages used for the map's labels and UI components. Languages can only be set on Mapbox vector tile sources.
- *     By default, GL JS will not set a language so that the language of Mapbox tiles will be determined by the vector tile source's TileJSON.
- *     Valid language strings must be a [BCP-47 language code](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_subtags). Unsupported BCP-47 codes will not include any translations. Invalid codes will result in an recoverable error.
- *     If a label has no translation for the selected language, it will display in the label's local language.
- *     If option is set to `auto`, GL JS will select a user's preferred language as determined by the browser's [`window.navigator.language`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) property.
- *     If the `locale` property is not set separately, this language will also be used to localize the UI for supported languages.
+ * By default, GL JS will not set a language so that the language of Mapbox tiles will be determined by the vector tile source's TileJSON.
+ * Valid language strings must be a [BCP-47 language code](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_subtags). Unsupported BCP-47 codes will not include any translations. Invalid codes will result in an recoverable error.
+ * If a label has no translation for the selected language, it will display in the label's local language.
+ * If option is set to `auto`, GL JS will select a user's preferred language as determined by the browser's [`window.navigator.language`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) property.
+ * If the `locale` property is not set separately, this language will also be used to localize the UI for supported languages.
  * @param {string} [options.worldview=null] Sets the map's worldview. A worldview determines the way that certain disputed boundaries
- *     are rendered. By default, GL JS will not set a worldview so that the worldview of Mapbox tiles will be determined by the vector tile source's TileJSON.
- *     Valid worldview strings must be an [ISO alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes). Unsupported
- *     ISO alpha-2 codes will fall back to the TileJSON's default worldview. Invalid codes will result in a recoverable error.
+ * are rendered. By default, GL JS will not set a worldview so that the worldview of Mapbox tiles will be determined by the vector tile source's TileJSON.
+ * Valid worldview strings must be an [ISO alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes). Unsupported
+ * ISO alpha-2 codes will fall back to the TileJSON's default worldview. Invalid codes will result in a recoverable error.
  * @param {boolean} [options.renderWorldCopies=true] If `true`, multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude. If set to `false`:
- *     - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
- *     container, there will be blank space beyond 180 and -180 degrees longitude.
- *     - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
- *     map and the other on the left edge of the map) at every zoom level.
+ * - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
+ * container, there will be blank space beyond 180 and -180 degrees longitude.
+ * - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
+ * map and the other on the left edge of the map) at every zoom level.
  * @param {number} [options.minTileCacheSize=null] The minimum number of tiles stored in the tile cache for a given source. Larger viewports use more tiles and need larger caches. Larger viewports are more likely to be found on devices with more memory and on pages where the map is more important. If omitted, the cache will be dynamically sized based on the current viewport.
  * @param {number} [options.maxTileCacheSize=null] The maximum number of tiles stored in the tile cache for a given source. If omitted, the cache will be dynamically sized based on the current viewport.
  * @param {string} [options.localIdeographFontFamily='sans-serif'] Defines a CSS font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana', 'Hangul Syllables' and 'CJK Symbols and Punctuation' ranges.
- *     In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
- *     Set to `false`, to enable font settings from the map's style for these glyph ranges. Note that [Mapbox Studio](https://studio.mapbox.com/) sets this value to `false` by default.
- *     The purpose of this option is to avoid bandwidth-intensive glyph server requests. For an example of this option in use, see [Use locally generated ideographs](https://www.mapbox.com/mapbox-gl-js/example/local-ideographs).
+ * In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
+ * Set to `false`, to enable font settings from the map's style for these glyph ranges. Note that [Mapbox Studio](https://studio.mapbox.com/) sets this value to `false` by default.
+ * The purpose of this option is to avoid bandwidth-intensive glyph server requests. For an example of this option in use, see [Use locally generated ideographs](https://www.mapbox.com/mapbox-gl-js/example/local-ideographs).
  * @param {string} [options.localFontFamily=null] Defines a CSS
- *     font-family for locally overriding generation of all glyphs. Font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
- *     If set, this option overrides the setting in localIdeographFontFamily.
+ * font-family for locally overriding generation of all glyphs. Font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
+ * If set, this option overrides the setting in localIdeographFontFamily.
  * @param {RequestTransformFunction} [options.transformRequest=null] A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
- *     Expected to return a {@link RequestParameters} object with a `url` property and optionally `headers` and `credentials` properties.
+ * Expected to return a {@link RequestParameters} object with a `url` property and optionally `headers` and `credentials` properties.
  * @param {boolean} [options.collectResourceTiming=false] If `true`, Resource Timing API information will be collected for requests made by GeoJSON and Vector Tile web workers (this information is normally inaccessible from the main Javascript thread). Information will be returned in a `resourceTiming` property of relevant `data` events.
  * @param {number} [options.fadeDuration=300] Controls the duration of the fade-in/fade-out animation for label collisions, in milliseconds. This setting affects all symbol layers. This setting does not affect the duration of runtime styling transitions or raster tile cross-fading.
  * @param {boolean} [options.respectPrefersReducedMotion=true] If set to `true`, the map will respect the user's `prefers-reduced-motion` browser setting and apply a reduced motion mode, minimizing animations and transitions. When set to `false`, the map will always ignore the `prefers-reduced-motion` settings, regardless of the user's preference, making all animations essential.
  * @param {boolean} [options.crossSourceCollisions=true] If `true`, symbols from multiple sources can collide with each other during collision detection. If `false`, collision detection is run separately for the symbols in each source.
  * @param {string} [options.accessToken=null] If specified, map will use this [token](https://docs.mapbox.com/help/glossary/access-token/) instead of the one defined in `mapboxgl.accessToken`.
  * @param {Object} [options.locale=null] A patch to apply to the default localization table for UI strings such as control tooltips. The `locale` object maps namespaced UI string IDs to translated strings in the target language;
- *     see [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js) for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
+ * see [`src/ui/default_locale.js`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/default_locale.js) for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @param {boolean} [options.testMode=false] Silences errors and warnings generated due to an invalid accessToken, useful when using the library to write unit tests.
  * @param {ProjectionSpecification} [options.projection='mercator'] The [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) the map should be rendered in.
- *     Supported projections are:
- *     * [Albers](https://en.wikipedia.org/wiki/Albers_projection) equal-area conic projection as `albers`
- *     * [Equal Earth](https://en.wikipedia.org/wiki/Equal_Earth_projection) equal-area pseudocylindrical projection as `equalEarth`
- *     * [Equirectangular](https://en.wikipedia.org/wiki/Equirectangular_projection) (Plate Carrée/WGS84) as `equirectangular`
- *     * 3d Globe as `globe`
- *     * [Lambert Conformal Conic](https://en.wikipedia.org/wiki/Lambert_conformal_conic_projection) as `lambertConformalConic`
- *     * [Mercator](https://en.wikipedia.org/wiki/Mercator_projection) cylindrical map projection as `mercator`
- *     * [Natural Earth](https://en.wikipedia.org/wiki/Natural_Earth_projection) pseudocylindrical map projection as `naturalEarth`
- *     * [Winkel Tripel](https://en.wikipedia.org/wiki/Winkel_tripel_projection) azimuthal map projection as `winkelTripel`
- *     Conic projections such as Albers and Lambert have configurable `center` and `parallels` properties that allow developers to define the region in which the projection has minimal distortion; see the example for how to configure these properties.
+ * Supported projections are:
+ * * [Albers](https://en.wikipedia.org/wiki/Albers_projection) equal-area conic projection as `albers`
+ * * [Equal Earth](https://en.wikipedia.org/wiki/Equal_Earth_projection) equal-area pseudocylindrical projection as `equalEarth`
+ * * [Equirectangular](https://en.wikipedia.org/wiki/Equirectangular_projection) (Plate Carrée/WGS84) as `equirectangular`
+ * * 3d Globe as `globe`
+ * * [Lambert Conformal Conic](https://en.wikipedia.org/wiki/Lambert_conformal_conic_projection) as `lambertConformalConic`
+ * * [Mercator](https://en.wikipedia.org/wiki/Mercator_projection) cylindrical map projection as `mercator`
+ * * [Natural Earth](https://en.wikipedia.org/wiki/Natural_Earth_projection) pseudocylindrical map projection as `naturalEarth`
+ * * [Winkel Tripel](https://en.wikipedia.org/wiki/Winkel_tripel_projection) azimuthal map projection as `winkelTripel`
+ * Conic projections such as Albers and Lambert have configurable `center` and `parallels` properties that allow developers to define the region in which the projection has minimal distortion; see the example for how to configure these properties.
  * @example
  * const map = new mapboxgl.Map({
  *     container: 'map', // container ID
@@ -749,7 +749,7 @@ class Map extends Camera {
      *
      * @param {IControl} control The {@link IControl} to add.
      * @param {string} [position] Position on the map to which the control will be added.
-     *     Valid values are `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`. Defaults to `'top-right'`.
+     * Valid values are `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`. Defaults to `'top-right'`.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Add zoom and rotation controls to the map.
@@ -877,8 +877,8 @@ class Map extends Camera {
      * or when the map is shown after being initially hidden with CSS.
      *
      * @param {Object | null} eventData Additional properties to be passed to `movestart`, `move`, `resize`, and `moveend`
-     *     events that get triggered as a result of resize. This can be useful for differentiating the
-     *     source of an event (for example, user-initiated or programmatically-triggered events).
+     * events that get triggered as a result of resize. This can be useful for differentiating the
+     * source of an event (for example, user-initiated or programmatically-triggered events).
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Resize the map when the map container is shown
@@ -977,7 +977,7 @@ class Map extends Camera {
      * no matter what the `minZoom` is set to.
      *
      * @param {number | null | undefined} minZoom The minimum zoom level to set (-2 - 24).
-     *     If `null` or `undefined` is provided, the function removes the current minimum zoom and it will be reset to -2.
+     * If `null` or `undefined` is provided, the function removes the current minimum zoom and it will be reset to -2.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMinZoom(12.25);
@@ -1018,7 +1018,7 @@ class Map extends Camera {
      * the map will zoom to the new maximum.
      *
      * @param {number | null | undefined} maxZoom The maximum zoom level to set.
-     *     If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
+     * If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMaxZoom(18.75);
@@ -1103,7 +1103,7 @@ class Map extends Camera {
      * the map will pitch to the new maximum.
      *
      * @param {number | null | undefined} maxPitch The maximum pitch to set.
-     *     If `null` or `undefined` is provided, the function removes the current maximum pitch (sets it to 85).
+     * If `null` or `undefined` is provided, the function removes the current maximum pitch (sets it to 85).
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMaxPitch(70);
@@ -1160,12 +1160,12 @@ class Map extends Camera {
      * Sets the state of `renderWorldCopies`.
      *
      * @param {boolean} renderWorldCopies If `true`, multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude. If set to `false`:
-     *     - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
-     *     container, there will be blank space beyond 180 and -180 degrees longitude.
-     *     - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
-     *     map and the other on the left edge of the map) at every zoom level.
+     * - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
+     * container, there will be blank space beyond 180 and -180 degrees longitude.
+     * - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
+     * map and the other on the left edge of the map) at every zoom level.
      *
-     *     `undefined` is treated as `true`, `null` is treated as `false`.
+     * `undefined` is treated as `true`, `null` is treated as `false`.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setRenderWorldCopies(true);
@@ -1307,7 +1307,7 @@ class Map extends Camera {
      * Sets the map's projection. If called with `null` or `undefined`, the map will reset to Mercator.
      *
      * @param {ProjectionSpecification | string | null | undefined} projection The projection that the map should be rendered in.
-     *     This can be a [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) object or a string of the projection's name.
+     * This can be a [projection](https://docs.mapbox.com/mapbox-gl-js/style-spec/projection/) object or a string of the projection's name.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setProjection('albers');
@@ -1524,67 +1524,67 @@ class Map extends Camera {
      * optionally limited to features in a specified style layer.
      *
      * @param {string} type The event type to listen for. Events compatible with the optional `layerId` parameter are triggered
-     *     when the cursor enters a visible portion of the specified layer from outside that layer or outside the map canvas.
+     * when the cursor enters a visible portion of the specified layer from outside that layer or outside the map canvas.
      *
-     *     | Event                                                     | Compatible with `layerId` |
-     *     |-----------------------------------------------------------|---------------------------|
-     *     | [`mousedown`](#map.event:mousedown)                       | yes                       |
-     *     | [`mouseup`](#map.event:mouseup)                           | yes                       |
-     *     | [`mouseover`](#map.event:mouseover)                       | yes                       |
-     *     | [`mouseout`](#map.event:mouseout)                         | yes                       |
-     *     | [`mousemove`](#map.event:mousemove)                       | yes                       |
-     *     | [`mouseenter`](#map.event:mouseenter)                     | yes (required)            |
-     *     | [`mouseleave`](#map.event:mouseleave)                     | yes (required)            |
-     *     | [`preclick`](#map.event:preclick)                         |                           |
-     *     | [`click`](#map.event:click)                               | yes                       |
-     *     | [`dblclick`](#map.event:dblclick)                         | yes                       |
-     *     | [`contextmenu`](#map.event:contextmenu)                   | yes                       |
-     *     | [`touchstart`](#map.event:touchstart)                     | yes                       |
-     *     | [`touchend`](#map.event:touchend)                         | yes                       |
-     *     | [`touchcancel`](#map.event:touchcancel)                   | yes                       |
-     *     | [`wheel`](#map.event:wheel)                               |                           |
-     *     | [`resize`](#map.event:resize)                             |                           |
-     *     | [`remove`](#map.event:remove)                             |                           |
-     *     | [`touchmove`](#map.event:touchmove)                       |                           |
-     *     | [`movestart`](#map.event:movestart)                       |                           |
-     *     | [`move`](#map.event:move)                                 |                           |
-     *     | [`moveend`](#map.event:moveend)                           |                           |
-     *     | [`dragstart`](#map.event:dragstart)                       |                           |
-     *     | [`drag`](#map.event:drag)                                 |                           |
-     *     | [`dragend`](#map.event:dragend)                           |                           |
-     *     | [`zoomstart`](#map.event:zoomstart)                       |                           |
-     *     | [`zoom`](#map.event:zoom)                                 |                           |
-     *     | [`zoomend`](#map.event:zoomend)                           |                           |
-     *     | [`rotatestart`](#map.event:rotatestart)                   |                           |
-     *     | [`rotate`](#map.event:rotate)                             |                           |
-     *     | [`rotateend`](#map.event:rotateend)                       |                           |
-     *     | [`pitchstart`](#map.event:pitchstart)                     |                           |
-     *     | [`pitch`](#map.event:pitch)                               |                           |
-     *     | [`pitchend`](#map.event:pitchend)                         |                           |
-     *     | [`boxzoomstart`](#map.event:boxzoomstart)                 |                           |
-     *     | [`boxzoomend`](#map.event:boxzoomend)                     |                           |
-     *     | [`boxzoomcancel`](#map.event:boxzoomcancel)               |                           |
-     *     | [`webglcontextlost`](#map.event:webglcontextlost)         |                           |
-     *     | [`webglcontextrestored`](#map.event:webglcontextrestored) |                           |
-     *     | [`load`](#map.event:load)                                 |                           |
-     *     | [`render`](#map.event:render)                             |                           |
-     *     | [`idle`](#map.event:idle)                                 |                           |
-     *     | [`error`](#map.event:error)                               |                           |
-     *     | [`data`](#map.event:data)                                 |                           |
-     *     | [`styledata`](#map.event:styledata)                       |                           |
-     *     | [`sourcedata`](#map.event:sourcedata)                     |                           |
-     *     | [`dataloading`](#map.event:dataloading)                   |                           |
-     *     | [`styledataloading`](#map.event:styledataloading)         |                           |
-     *     | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
-     *     | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
-     *     | [`style.load`](#map.event:style.load)                     |                           |
+     * | Event                                                     | Compatible with `layerId` |
+     * |-----------------------------------------------------------|---------------------------|
+     * | [`mousedown`](#map.event:mousedown)                       | yes                       |
+     * | [`mouseup`](#map.event:mouseup)                           | yes                       |
+     * | [`mouseover`](#map.event:mouseover)                       | yes                       |
+     * | [`mouseout`](#map.event:mouseout)                         | yes                       |
+     * | [`mousemove`](#map.event:mousemove)                       | yes                       |
+     * | [`mouseenter`](#map.event:mouseenter)                     | yes (required)            |
+     * | [`mouseleave`](#map.event:mouseleave)                     | yes (required)            |
+     * | [`preclick`](#map.event:preclick)                         |                           |
+     * | [`click`](#map.event:click)                               | yes                       |
+     * | [`dblclick`](#map.event:dblclick)                         | yes                       |
+     * | [`contextmenu`](#map.event:contextmenu)                   | yes                       |
+     * | [`touchstart`](#map.event:touchstart)                     | yes                       |
+     * | [`touchend`](#map.event:touchend)                         | yes                       |
+     * | [`touchcancel`](#map.event:touchcancel)                   | yes                       |
+     * | [`wheel`](#map.event:wheel)                               |                           |
+     * | [`resize`](#map.event:resize)                             |                           |
+     * | [`remove`](#map.event:remove)                             |                           |
+     * | [`touchmove`](#map.event:touchmove)                       |                           |
+     * | [`movestart`](#map.event:movestart)                       |                           |
+     * | [`move`](#map.event:move)                                 |                           |
+     * | [`moveend`](#map.event:moveend)                           |                           |
+     * | [`dragstart`](#map.event:dragstart)                       |                           |
+     * | [`drag`](#map.event:drag)                                 |                           |
+     * | [`dragend`](#map.event:dragend)                           |                           |
+     * | [`zoomstart`](#map.event:zoomstart)                       |                           |
+     * | [`zoom`](#map.event:zoom)                                 |                           |
+     * | [`zoomend`](#map.event:zoomend)                           |                           |
+     * | [`rotatestart`](#map.event:rotatestart)                   |                           |
+     * | [`rotate`](#map.event:rotate)                             |                           |
+     * | [`rotateend`](#map.event:rotateend)                       |                           |
+     * | [`pitchstart`](#map.event:pitchstart)                     |                           |
+     * | [`pitch`](#map.event:pitch)                               |                           |
+     * | [`pitchend`](#map.event:pitchend)                         |                           |
+     * | [`boxzoomstart`](#map.event:boxzoomstart)                 |                           |
+     * | [`boxzoomend`](#map.event:boxzoomend)                     |                           |
+     * | [`boxzoomcancel`](#map.event:boxzoomcancel)               |                           |
+     * | [`webglcontextlost`](#map.event:webglcontextlost)         |                           |
+     * | [`webglcontextrestored`](#map.event:webglcontextrestored) |                           |
+     * | [`load`](#map.event:load)                                 |                           |
+     * | [`render`](#map.event:render)                             |                           |
+     * | [`idle`](#map.event:idle)                                 |                           |
+     * | [`error`](#map.event:error)                               |                           |
+     * | [`data`](#map.event:data)                                 |                           |
+     * | [`styledata`](#map.event:styledata)                       |                           |
+     * | [`sourcedata`](#map.event:sourcedata)                     |                           |
+     * | [`dataloading`](#map.event:dataloading)                   |                           |
+     * | [`styledataloading`](#map.event:styledataloading)         |                           |
+     * | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
+     * | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
+     * | [`style.load`](#map.event:style.load)                     |                           |
      *
      * @param {string | Array<string>} layerIds (optional) The ID(s) of a style layer(s). If you provide a `layerId`,
-     *     the listener will be triggered only if its location is within a visible feature in these layers,
-     *     and the event will have a `features` property containing an array of the matching features.
-     *     If you do not provide `layerIds`, the listener will be triggered by a corresponding event
-     *     happening anywhere on the map, and the event will not have a `features` property.
-     *     Note that many event types are not compatible with the optional `layerIds` parameter.
+     * the listener will be triggered only if its location is within a visible feature in these layers,
+     * and the event will have a `features` property containing an array of the matching features.
+     * If you do not provide `layerIds`, the listener will be triggered by a corresponding event
+     * happening anywhere on the map, and the event will not have a `features` property.
+     * Note that many event types are not compatible with the optional `layerIds` parameter.
      * @param {Function} listener The function to be called when the event is fired.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
@@ -1667,17 +1667,17 @@ class Map extends Camera {
      * optionally limited to events occurring on features in a specified style layer.
      *
      * @param {string} type The event type to listen for; one of `'mousedown'`, `'mouseup'`, `'preclick'`, `'click'`, `'dblclick'`,
-     *     `'mousemove'`, `'mouseenter'`, `'mouseleave'`, `'mouseover'`, `'mouseout'`, `'contextmenu'`, `'touchstart'`,
-     *     `'touchend'`, or `'touchcancel'`. `mouseenter` and `mouseover` events are triggered when the cursor enters
-     *     a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
-     *     and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
-     *     the map canvas.
+     * `'mousemove'`, `'mouseenter'`, `'mouseleave'`, `'mouseover'`, `'mouseout'`, `'contextmenu'`, `'touchstart'`,
+     * `'touchend'`, or `'touchcancel'`. `mouseenter` and `mouseover` events are triggered when the cursor enters
+     * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
+     * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
+     * the map canvas.
      * @param {string | Array<string>} layerIds (optional) The ID(s) of a style layer(s). If you provide `layerIds`,
-     *     the listener will be triggered only if its location is within a visible feature in these layers,
-     *     and the event will have a `features` property containing an array of the matching features.
-     *     If you do not provide `layerIds`, the listener will be triggered by a corresponding event
-     *     happening anywhere on the map, and the event will not have a `features` property.
-     *     Note that many event types are not compatible with the optional `layerIds` parameter.
+     * the listener will be triggered only if its location is within a visible feature in these layers,
+     * and the event will have a `features` property containing an array of the matching features.
+     * If you do not provide `layerIds`, the listener will be triggered by a corresponding event
+     * happening anywhere on the map, and the event will not have a `features` property.
+     * Note that many event types are not compatible with the optional `layerIds` parameter.
      * @param {Function} listener The function to be called when the event is fired.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
@@ -1806,48 +1806,48 @@ class Map extends Camera {
      * representing visible features that satisfy the query parameters.
      *
      * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region in pixels:
-     *     either a single point or bottom left and top right points describing a bounding box, where the origin is at the top left.
-     *     Omitting this parameter (by calling {@link Map#queryRenderedFeatures} with zero arguments,
-     *     or with only an `options` argument) is equivalent to passing a bounding box encompassing the entire
-     *     map viewport.
-     *     Only values within the existing viewport are supported.
+     * either a single point or bottom left and top right points describing a bounding box, where the origin is at the top left.
+     * Omitting this parameter (by calling {@link Map#queryRenderedFeatures} with zero arguments,
+     * or with only an `options` argument) is equivalent to passing a bounding box encompassing the entire
+     * map viewport.
+     * Only values within the existing viewport are supported.
      * @param {Object} [options] Options object.
      * @param {Array<string>} [options.layers] An array of [style layer IDs](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-id) for the query to inspect.
-     *     Only features within these layers will be returned. If this parameter is undefined, all layers will be checked.
+     * Only features within these layers will be returned. If this parameter is undefined, all layers will be checked.
      * @param {Array} [options.filter] A [filter](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter)
-     *     to limit query results.
+     * to limit query results.
      * @param {boolean} [options.validate=true] Whether to check if the [options.filter] conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      *
      * @returns {Array<Object>} An array of [GeoJSON](http://geojson.org/)
-     *     [feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
+     * [feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
      *
-     *     The `properties` value of each returned feature object contains the properties of its source feature. For GeoJSON sources, only
-     *     string and numeric property values are supported. `null`, `Array`, and `Object` values are not supported.
+     * The `properties` value of each returned feature object contains the properties of its source feature. For GeoJSON sources, only
+     * string and numeric property values are supported. `null`, `Array`, and `Object` values are not supported.
      *
-     *     Each feature includes top-level `layer`, `source`, and `sourceLayer` properties. The `layer` property is an object
-     *     representing the style layer to  which the feature belongs. Layout and paint properties in this object contain values
-     *     which are fully evaluated for the given zoom level and feature.
+     * Each feature includes top-level `layer`, `source`, and `sourceLayer` properties. The `layer` property is an object
+     * representing the style layer to  which the feature belongs. Layout and paint properties in this object contain values
+     * which are fully evaluated for the given zoom level and feature.
      *
-     *     Only features that are currently rendered are included. Some features will **not** be included, like:
+     * Only features that are currently rendered are included. Some features will **not** be included, like:
      *
-     *     - Features from layers whose `visibility` property is `"none"`.
-     *     - Features from layers whose zoom range excludes the current zoom level.
-     *     - Symbol features that have been hidden due to text or icon collision.
+     * - Features from layers whose `visibility` property is `"none"`.
+     * - Features from layers whose zoom range excludes the current zoom level.
+     * - Symbol features that have been hidden due to text or icon collision.
      *
-     *     Features from all other layers are included, including features that may have no visible
-     *     contribution to the rendered result; for example, because the layer's opacity or color alpha component is set to 0.
+     * Features from all other layers are included, including features that may have no visible
+     * contribution to the rendered result; for example, because the layer's opacity or color alpha component is set to 0.
      *
-     *     The topmost rendered feature appears first in the returned array, and subsequent features are sorted by
-     *     descending z-order. Features that are rendered multiple times (due to wrapping across the antimeridian at low
-     *     zoom levels) are returned only once (though subject to the following caveat).
+     * The topmost rendered feature appears first in the returned array, and subsequent features are sorted by
+     * descending z-order. Features that are rendered multiple times (due to wrapping across the antimeridian at low
+     * zoom levels) are returned only once (though subject to the following caveat).
      *
-     *     Because features come from tiled vector data or GeoJSON data that is converted to tiles internally, feature
-     *     geometries may be split or duplicated across tile boundaries and, as a result, features may appear multiple
-     *     times in query results. For example, suppose there is a highway running through the bounding rectangle of a query.
-     *     The results of the query will be those parts of the highway that lie within the map tiles covering the bounding
-     *     rectangle, even if the highway extends into other tiles, and the portion of the highway within each map tile
-     *     will be returned as a separate feature. Similarly, a point feature near a tile boundary may appear in multiple
-     *     tiles due to tile buffering.
+     * Because features come from tiled vector data or GeoJSON data that is converted to tiles internally, feature
+     * geometries may be split or duplicated across tile boundaries and, as a result, features may appear multiple
+     * times in query results. For example, suppose there is a highway running through the bounding rectangle of a query.
+     * The results of the query will be those parts of the highway that lie within the map tiles covering the bounding
+     * rectangle, even if the highway extends into other tiles, and the portion of the highway within each map tile
+     * will be returned as a separate feature. Similarly, a point feature near a tile boundary may appear in multiple
+     * tiles due to tile buffering.
      *
      * @example
      * // Find all features at a point
@@ -1920,26 +1920,26 @@ class Map extends Camera {
      * @param {string} sourceId The ID of the vector tile or GeoJSON source to query.
      * @param {Object} [parameters] Options object.
      * @param {string} [parameters.sourceLayer] The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/)
-     *     to query. *For vector tile sources, this parameter is required.* For GeoJSON sources, it is ignored.
+     * to query. *For vector tile sources, this parameter is required.* For GeoJSON sources, it is ignored.
      * @param {Array} [parameters.filter] A [filter](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter)
-     *     to limit query results.
+     * to limit query results.
      * @param {boolean} [parameters.validate=true] Whether to check if the [parameters.filter] conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      *
      * @returns {Array<Object>} An array of [GeoJSON](http://geojson.org/)
-     *     [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
+     * [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
      *
-     *     In contrast to {@link Map#queryRenderedFeatures}, this function returns all features matching the query parameters,
-     *     whether or not they are rendered by the current style (in other words, are visible). The domain of the query includes all currently-loaded
-     *     vector tiles and GeoJSON source tiles: this function does not check tiles outside the currently
-     *     visible viewport.
+     * In contrast to {@link Map#queryRenderedFeatures}, this function returns all features matching the query parameters,
+     * whether or not they are rendered by the current style (in other words, are visible). The domain of the query includes all currently-loaded
+     * vector tiles and GeoJSON source tiles: this function does not check tiles outside the currently
+     * visible viewport.
      *
-     *     Because features come from tiled vector data or GeoJSON data that is converted to tiles internally, feature
-     *     geometries may be split or duplicated across tile boundaries and, as a result, features may appear multiple
-     *     times in query results. For example, suppose there is a highway running through the bounding rectangle of a query.
-     *     The results of the query will be those parts of the highway that lie within the map tiles covering the bounding
-     *     rectangle, even if the highway extends into other tiles, and the portion of the highway within each map tile
-     *     will be returned as a separate feature. Similarly, a point feature near a tile boundary may appear in multiple
-     *     tiles due to tile buffering.
+     * Because features come from tiled vector data or GeoJSON data that is converted to tiles internally, feature
+     * geometries may be split or duplicated across tile boundaries and, as a result, features may appear multiple
+     * times in query results. For example, suppose there is a highway running through the bounding rectangle of a query.
+     * The results of the query will be those parts of the highway that lie within the map tiles covering the bounding
+     * rectangle, even if the highway extends into other tiles, and the portion of the highway within each map tile
+     * will be returned as a separate feature. Similarly, a point feature near a tile boundary may appear in multiple
+     * tiles due to tile buffering.
      *
      * @example
      * // Find all features in one source layer in a vector source
@@ -1986,15 +1986,15 @@ class Map extends Camera {
      * the given one from scratch.
      *
      * @param {Object | string| null} style A JSON object conforming to the schema described in the
-     *     [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL to such JSON.
+     * [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL to such JSON.
      * @param {Object} [options] Options object.
      * @param {boolean} [options.diff=true] If false, force a 'full' update, removing the current style
-     *     and building the given one instead of attempting a diff-based update.
+     * and building the given one instead of attempting a diff-based update.
      * @param {string} [options.localIdeographFontFamily='sans-serif'] Defines a CSS
-     *     font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana' and 'Hangul Syllables' ranges.
-     *     In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
-     *     Set to `false`, to enable font settings from the map's style for these glyph ranges.
-     *     Forces a full update.
+     * font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana' and 'Hangul Syllables' ranges.
+     * In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
+     * Set to `false`, to enable font settings from the map's style for these glyph ranges.
+     * Forces a full update.
      * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
@@ -2138,8 +2138,8 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the source to add. Must not conflict with existing sources.
      * @param {Object} source The source object, conforming to the
-     *     Mapbox Style Specification's [source definition](https://www.mapbox.com/mapbox-gl-style-spec/#sources) or
-     *     {@link CanvasSourceOptions}.
+     * Mapbox Style Specification's [source definition](https://www.mapbox.com/mapbox-gl-style-spec/#sources) or
+     * {@link CanvasSourceOptions}.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.addSource('my-data', {
@@ -2245,10 +2245,10 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the source to get.
      * @returns {?Object} The style source with the specified ID or `undefined` if the ID
-     *     corresponds to no existing sources.
-     *     The shape of the object varies by source type.
-     *     A list of options for each source type is available on the Mapbox Style Specification's
-     *     [Sources](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) page.
+     * corresponds to no existing sources.
+     * The shape of the object varies by source type.
+     * A list of options for each source type is available on the Mapbox Style Specification's
+     * [Sources](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) page.
      * @example
      * const sourceObject = map.getSource('points');
      * @see [Example: Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
@@ -2277,7 +2277,7 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the image.
      * @param {HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: (Uint8Array | Uint8ClampedArray)} | StyleImageInterface} image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
-     *     properties with the same format as `ImageData`.
+     * properties with the same format as `ImageData`.
      * @param {Object | null} options Options object.
      * @param {number} options.pixelRatio The ratio of pixels in the image to physical pixels on the screen.
      * @param {boolean} options.sdf Whether the image should be interpreted as an SDF image.
@@ -2356,7 +2356,7 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the image.
      * @param {HTMLImageElement | ImageBitmap | ImageData | StyleImageInterface} image The image as an `HTMLImageElement`, [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData), [`ImageBitmap`](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap) or object with `width`, `height`, and `data`
-     *     properties with the same format as `ImageData`.
+     * properties with the same format as `ImageData`.
      *
      * @example
     * // Load an image from an external URL.
@@ -2579,62 +2579,63 @@ class Map extends Camera {
      * and available paint and layout properties in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers).
      *
      * @param {Object | CustomLayerInterface} layer The layer to add, conforming to either the Mapbox Style Specification's [layer definition](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers) or, less commonly, the {@link CustomLayerInterface} specification.
-     *     The Mapbox Style Specification's layer definition is appropriate for most layers.
+     * The Mapbox Style Specification's layer definition is appropriate for most layers.
      *
      * @param {string} layer.id A unique identifier that you define.
      * @param {string} layer.type The type of layer (for example `fill` or `symbol`).
-     *     A list of layer types is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#type).
-     *     This can also be `custom`. For more information, see {@link CustomLayerInterface}.
+     * A list of layer types is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#type).
+     *
+     * This can also be `custom`. For more information, see {@link CustomLayerInterface}.
      * @param {string | Object} [layer.source] The data source for the layer.
-     *     Reference a source that has _already been defined_ using the source's unique id.
-     *     Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
-     *     This is **required** for all `layer.type` options _except_ for `custom` and `background`.
+     * Reference a source that has _already been defined_ using the source's unique id.
+     * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
+     * This is **required** for all `layer.type` options _except_ for `custom` and `background`.
      * @param {string} [layer.sourceLayer] (optional) The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
-     *     This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
+     * This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
      * @param {string} [layer.slot] (optional) The identifier of a [`slot`](https://docs.mapbox.com/style-spec/reference/slots/) layer that will be used to position this style layer.
-     *     A `slot` layer serves as a predefined position in the layer order for inserting associated layers.
-     *     *Note*: During 3D globe and terrain rendering, GL JS aims to batch multiple layers together for optimal performance.
-     *     This process might lead to a rearrangement of layers. Layers draped over globe and terrain,
-     *     such as `fill`, `line`, `background`, `hillshade`, and `raster`, are rendered first.
-     *     These layers are rendered underneath symbols, regardless of whether they are placed
-     *     in the middle or top slots or without a designated slot.
+     * A `slot` layer serves as a predefined position in the layer order for inserting associated layers.
+     * *Note*: During 3D globe and terrain rendering, GL JS aims to batch multiple layers together for optimal performance.
+     * This process might lead to a rearrangement of layers. Layers draped over globe and terrain,
+     * such as `fill`, `line`, `background`, `hillshade`, and `raster`, are rendered first.
+     * These layers are rendered underneath symbols, regardless of whether they are placed
+     * in the middle or top slots or without a designated slot.
      * @param {Array} [layer.filter] (optional) An expression specifying conditions on source features.
-     *     Only features that match the filter are displayed.
-     *     The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
-     *     and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
-     *     If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
+     * Only features that match the filter are displayed.
+     * The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
+     * and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
+     * If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
      * @param {Object} [layer.paint] (optional) Paint properties for the layer.
-     *     Available paint properties vary by `layer.type`.
-     *     A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
-     *     If no paint properties are specified, default values will be used.
+     * Available paint properties vary by `layer.type`.
+     * A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
+     * If no paint properties are specified, default values will be used.
      * @param {Object} [layer.layout] (optional) Layout properties for the layer.
-     *     Available layout properties vary by `layer.type`.
-     *     A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
-     *     If no layout properties are specified, default values will be used.
+     * Available layout properties vary by `layer.type`.
+     * A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
+     * If no layout properties are specified, default values will be used.
      * @param {number} [layer.maxzoom] (optional) The maximum zoom level for the layer.
-     *     At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
-     *     The value can be any number between `0` and `24` (inclusive).
-     *     If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
+     * At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
+     * The value can be any number between `0` and `24` (inclusive).
+     * If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
      * @param {number} [layer.minzoom] (optional) The minimum zoom level for the layer.
-     *     At zoom levels less than the minzoom, the layer will be hidden.
-     *     The value can be any number between `0` and `24` (inclusive).
-     *     If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
+     * At zoom levels less than the minzoom, the layer will be hidden.
+     * The value can be any number between `0` and `24` (inclusive).
+     * If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
      * @param {Object} [layer.metadata] (optional) Arbitrary properties useful to track with the layer, but do not influence rendering.
      * @param {string} [layer.renderingMode] This is only applicable for layers with the type `custom`.
-     *     See {@link CustomLayerInterface} for more information.
+     * See {@link CustomLayerInterface} for more information.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before,
-     *     resulting in the new layer appearing visually beneath the existing layer.
-     *     If this argument is not specified, the layer will be appended to the end of the layers array
-     *     and appear visually above all other layers.
-     *     *Note*: Layers can only be rearranged within the same `slot`. The new layer must share the
-     *     same `slot` as the existing layer to be positioned underneath it. If the
-     *     layers are in different slots, the `beforeId` parameter will be ignored and
-     *     the new layer will be appended to the end of the layers array.
-     *     During 3D globe and terrain rendering, GL JS aims to batch multiple layers together for optimal performance.
-     *     This process might lead to a rearrangement of layers. Layers draped over globe and terrain,
-     *     such as `fill`, `line`, `background`, `hillshade`, and `raster`, are rendered first.
-     *     These layers are rendered underneath symbols, regardless of whether they are placed
-     *     in the middle or top slots or without a designated slot.
+     * resulting in the new layer appearing visually beneath the existing layer.
+     * If this argument is not specified, the layer will be appended to the end of the layers array
+     * and appear visually above all other layers.
+     * *Note*: Layers can only be rearranged within the same `slot`. The new layer must share the
+     * same `slot` as the existing layer to be positioned underneath it. If the
+     * layers are in different slots, the `beforeId` parameter will be ignored and
+     * the new layer will be appended to the end of the layers array.
+     * During 3D globe and terrain rendering, GL JS aims to batch multiple layers together for optimal performance.
+     * This process might lead to a rearrangement of layers. Layers draped over globe and terrain,
+     * such as `fill`, `line`, `background`, `hillshade`, and `raster`, are rendered first.
+     * These layers are rendered underneath symbols, regardless of whether they are placed
+     * in the middle or top slots or without a designated slot.
      *
      * @returns {Map} Returns itself to allow for method chaining.
      *
@@ -2886,18 +2887,18 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the layer to move.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before.
-     *     When viewing the map, the `id` layer will appear beneath the `beforeId` layer.
-     *     If `beforeId` is omitted, the layer will be appended to the end of the layers array
-     *     and appear above all other layers on the map.
-     *     *Note*: Layers can only be rearranged within the same `slot`. The new layer must share the
-     *     same `slot` as the existing layer to be positioned underneath it. If the
-     *     layers are in different slots, the `beforeId` parameter will be ignored and
-     *     the new layer will be appended to the end of the layers array.
-     *     During 3D globe and terrain rendering, GL JS aims to batch multiple layers together for optimal performance.
-     *     This process might lead to a rearrangement of layers. Layers draped over globe and terrain,
-     *     such as `fill`, `line`, `background`, `hillshade`, and `raster`, are rendered first.
-     *     These layers are rendered underneath symbols, regardless of whether they are placed
-     *     in the middle or top slots or without a designated slot.
+     * When viewing the map, the `id` layer will appear beneath the `beforeId` layer.
+     * If `beforeId` is omitted, the layer will be appended to the end of the layers array
+     * and appear above all other layers on the map.
+     * *Note*: Layers can only be rearranged within the same `slot`. The new layer must share the
+     * same `slot` as the existing layer to be positioned underneath it. If the
+     * layers are in different slots, the `beforeId` parameter will be ignored and
+     * the new layer will be appended to the end of the layers array.
+     * During 3D globe and terrain rendering, GL JS aims to batch multiple layers together for optimal performance.
+     * This process might lead to a rearrangement of layers. Layers draped over globe and terrain,
+     * such as `fill`, `line`, `background`, `hillshade`, and `raster`, are rendered first.
+     * These layers are rendered underneath symbols, regardless of whether they are placed
+     * in the middle or top slots or without a designated slot.
      * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
@@ -2940,7 +2941,7 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the layer to get.
      * @returns {?Object} The layer with the specified ID, or `undefined`
-     *     if the ID corresponds to no existing layers.
+     * if the ID corresponds to no existing layers.
      *
      * @example
      * const stateDataLayer = map.getLayer('state-data');
@@ -2997,7 +2998,7 @@ class Map extends Camera {
      *
      * @param {string} layerId The ID of the layer to which the filter will be applied.
      * @param {Array | null | undefined} filter The filter, conforming to the Mapbox Style Specification's
-     *     [filter definition](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter).  If `null` or `undefined` is provided, the function removes any existing filter from the layer.
+     * [filter definition](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter).  If `null` or `undefined` is provided, the function removes any existing filter from the layer.
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      * @returns {Map} Returns itself to allow for method chaining.
@@ -3048,7 +3049,7 @@ class Map extends Camera {
      * @param {string} layerId The ID of the layer to set the paint property in.
      * @param {string} name The name of the paint property to set.
      * @param {*} value The value of the paint property to set.
-     *     Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
+     * Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if `value` conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      * @returns {Map} Returns itself to allow for method chaining.
@@ -3255,8 +3256,8 @@ class Map extends Camera {
      * Sets the terrain property of the style.
      *
      * @param {TerrainSpecification} terrain Terrain properties to set. Must conform to the [Terrain Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/terrain/).
-     *     If `null` or `undefined` is provided, function removes terrain.
-     *     Exaggeration could be updated for the existing terrain without explicitly specifying the `source`.
+     * If `null` or `undefined` is provided, function removes terrain.
+     * Exaggeration could be updated for the existing terrain without explicitly specifying the `source`.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.addSource('mapbox-dem', {
@@ -3296,7 +3297,7 @@ class Map extends Camera {
      * Sets the fog property of the style.
      *
      * @param {FogSpecification} fog The fog properties to set. Must conform to the [Fog Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/fog/).
-     *     If `null` or `undefined` is provided, this function call removes the fog from the map.
+     * If `null` or `undefined` is provided, this function call removes the fog from the map.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setFog({
@@ -3389,7 +3390,7 @@ class Map extends Camera {
      * _Note: You can use the [`feature-state` expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state) to access the values in a feature's state object for the purposes of styling_.
      *
      * @param {Object} feature Feature identifier. Feature objects returned from
-     *     {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
+     * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required*.
@@ -3431,7 +3432,7 @@ class Map extends Camera {
      * Features are identified by their `feature.id` attribute, which can be any number or string.
      *
      * @param {Object} feature Identifier of where to remove state. It can be a source, a feature, or a specific key of feature.
-     *     Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
+     * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} [feature.id] (optional) Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional) For vector tile sources, `sourceLayer` is required.
@@ -3485,7 +3486,7 @@ class Map extends Camera {
      * _Note: To access the values in a feature's state object for the purposes of styling the feature, use the [`feature-state` expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state)_.
      *
      * @param {Object} feature Feature identifier. Feature objects returned from
-     *     {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
+     * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required*.
@@ -4553,9 +4554,9 @@ export default Map;
  * @name onAdd
  * @param {Map} map The Map this control will be added to.
  * @returns {HTMLElement} The control's container element. This should
- *     be created by the control and returned by onAdd without being attached
- *     to the DOM: the map will insert the control's element into the DOM
- *     as necessary.
+ * be created by the control and returned by onAdd without being attached
+ * to the DOM: the map will insert the control's element into the DOM
+ * as necessary.
  */
 
 /**

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -37,7 +37,7 @@ type Options = {
  * @param {Object} [options]
  * @param {HTMLElement} [options.element] DOM element to use as a marker. The default is a light blue, droplet-shaped SVG marker.
  * @param {string} [options.anchor='center'] A string indicating the part of the Marker that should be positioned closest to the coordinate set via {@link Marker#setLngLat}.
- *     Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
+ * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @param {string} [options.color='#3FB1CE'] The color to use for the default marker if `options.element` is not provided. The default is light blue.
  * @param {number} [options.scale=1] The scale to use for the default marker if `options.element` is not provided. The default scale corresponds to a height of `41px` and a width of `27px`.
@@ -322,7 +322,7 @@ export default class Marker extends Evented {
      * Binds a {@link Popup} to the {@link Marker}.
      *
      * @param {Popup | null} popup An instance of the {@link Popup} class. If undefined or null, any popup
-     *     set on this {@link Marker} instance is unset.
+     * set on this {@link Marker} instance is unset.
      * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * const marker = new mapboxgl.Marker()

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -51,31 +51,31 @@ const focusQuerySelector = [
  *
  * @param {Object} [options]
  * @param {boolean} [options.closeButton=true] If `true`, a close button will appear in the
- *     top right corner of the popup.
+ * top right corner of the popup.
  * @param {boolean} [options.closeOnClick=true] If `true`, the popup will close when the
- *     map is clicked.
+ * map is clicked.
  * @param {boolean} [options.closeOnMove=false] If `true`, the popup will close when the
- *     map moves.
+ * map moves.
  * @param {boolean} [options.focusAfterOpen=true] If `true`, the popup will try to focus the
- *     first focusable element inside the popup.
+ * first focusable element inside the popup.
  * @param {string} [options.anchor] - A string indicating the part of the popup that should
- *     be positioned closest to the coordinate, set via {@link Popup#setLngLat}.
- *     Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
- *     `'top-right'`, `'bottom-left'`, and `'bottom-right'`. If unset, the anchor will be
- *     dynamically set to ensure the popup falls within the map container with a preference
- *     for `'bottom'`.
+ * be positioned closest to the coordinate, set via {@link Popup#setLngLat}.
+ * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
+ * `'top-right'`, `'bottom-left'`, and `'bottom-right'`. If unset, the anchor will be
+ * dynamically set to ensure the popup falls within the map container with a preference
+ * for `'bottom'`.
  * @param {number | PointLike | Object} [options.offset] -
- *     A pixel offset applied to the popup's location specified as:
- *     - a single number specifying a distance from the popup's location
- *     - a {@link PointLike} specifying a constant offset
- *     - an object of {@link Point}s specifing an offset for each anchor position.
+ * A pixel offset applied to the popup's location specified as:
+ * - a single number specifying a distance from the popup's location
+ * - a {@link PointLike} specifying a constant offset
+ * - an object of {@link Point}s specifing an offset for each anchor position.
  *
- *     Negative offsets indicate left and up.
+ * Negative offsets indicate left and up.
  * @param {string} [options.className] Space-separated CSS class names to add to popup container.
  * @param {string} [options.maxWidth='240px'] -
- *     A string that sets the CSS property of the popup's maximum width (for example, `'300px'`).
- *     To ensure the popup resizes to fit its content, set this property to `'none'`.
- *     See the MDN documentation for the list of [available values](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width).
+ * A string that sets the CSS property of the popup's maximum width (for example, `'300px'`).
+ * To ensure the popup resizes to fit its content, set this property to `'none'`.
+ * See the MDN documentation for the list of [available values](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width).
  * @example
  * const markerHeight = 50;
  * const markerRadius = 10;


### PR DESCRIPTION
This PR addresses an issue that caused incorrect rendering of generated documentation on docs.mapbox.com.  

The JSDoc comments for some parameters span multiple lines, and indentation of lines is enforced by the `jsdoc/check-line-alignment` eslint rule. This repo has additional configuration to force an indentation of 4 spaces on wrapped lines.

This indentation of subsequent lines results in markdown parsing issues.  For example, the markdown to be parsed for Map.options.style looks like:

```
The map's Mapbox style. This must be an a JSON object conforming to
    the schema described in the [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL
    to such JSON. Can accept a null value to allow adding a style manually.
    
    To load a style from the Mapbox API, you can use a URL of the form `mapbox://styles/:owner/:style`,
    where `:owner` is your Mapbox account name and `:style` is the style ID. You can also use a
    [Mapbox-owned style](https://docs.mapbox.com/api/maps/styles/#mapbox-styles):
    * `mapbox://styles/mapbox/standard`
    * `mapbox://styles/mapbox/streets-v12`
    * `mapbox://styles/mapbox/outdoors-v12`
    * `mapbox://styles/mapbox/light-v11`
    * `mapbox://styles/mapbox/dark-v11`
    * `mapbox://styles/mapbox/satellite-v9`
    * `mapbox://styles/mapbox/satellite-streets-v12`
    * `mapbox://styles/mapbox/navigation-day-v1`
    * `mapbox://styles/mapbox/navigation-night-v1`.
```
The first three lines are parsed as a paragraph, but the lines after the empty line are parsed as a codeblock, and renders as such on docs.mapbox.com:

<img width="662" alt="image" src="https://github.com/mapbox/mapbox-gl-js/assets/1833820/fc6083e7-6246-4721-ab27-f1ea6d67825e">

This PR removes the `wrapIndent` option, enforcing no indentation on wrapped lines.  The resulting JSDoc comments were tested locally with `mapbox-gl-js-docs` and result in correct rendering in the docs:

<img width="681" alt="image" src="https://github.com/mapbox/mapbox-gl-js/assets/1833820/c7a6061d-311c-4311-b4c3-e99298bda5a4">

I am not clear on the repercussions of this change to other things that make use of the JSDoc comments, if any, and seek guidance from others with more experience with this codebase on whether this change is safe. 

## Launch Checklist

 - [ ] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
