### PR TITLE
Restored 2.7 behavior of setting  using new point if this._pos is undefined in _updateDOM

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -492,7 +492,7 @@ export default class Marker extends Evented {
     }
 
     _updateDOM() {
-        const pos = this._pos;
+        const pos = this._pos || new Point(0, 0);
         const map = this._map;
         if (!pos || !map) { return; }
 


### PR DESCRIPTION
Address issue #13145

When attempting to upgrade from 2.7 to latest version my code for adding a marker to the map which breaks with the newer versions.

The difference between the offending function in 2.7 and later versions is that the _updateDOM in 2.7 did not assume that a point is set when _updateDOM is called and created one at 0,0 if a point was unset, presumably so the marker gets added to the DOM and then gets repositioned after an animation frame or other delay at which point the point is officially set.
