### PR TITLE
Fix circular dependency handling for Windows 10/11 prod environment i…

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ const {BUILD, MINIFY} = process.env;
 const minified = MINIFY === 'true';
 const bench = BUILD === 'bench';
 const production = BUILD === 'production' || bench;
-
+import {normalize} from "path";
 function buildType(build, minified) {
     switch (build) {
     case 'production':
@@ -91,7 +91,7 @@ function sourcemaps() {
 function onwarn(warning) {
     if (warning.code === 'CIRCULAR_DEPENDENCY') {
         // Ignore circular dependencies in style-spec and throw on all others
-        if (!warning.ids[0].includes('/src/style-spec')) throw new Error(warning.message);
+        if (!warning.ids[0].includes(normalize('/src/style-spec'))) throw new Error(warning.message);
     } else {
         console.error(`(!) ${warning.message}`);
     }


### PR DESCRIPTION
Hey
###Question
The issue arises from the different ways in which file paths are represented in Windows and Linux systems, leading to the inability to properly ignore specific circular references during the production build on Windows, consequently causing the build process to fail.
![Snipaste_2024-05-13_17-43-17](https://github.com/mapbox/mapbox-gl-js/assets/49798681/002deac1-d35a-4838-a2b7-891e1a98abb1)
I discovered and successfully resolved this issue on Windows by utilizing the normalize function in Node.js (or alternatively, regular expressions could be used), which ensures consistent and normalized file paths. This solution does not affect Mac and Linux systems, allowing the build process to proceed without any issues related to circular references. I conducted some simple tests, and below are the successful build results.
![Snipaste_2024-05-13_16-07-17](https://github.com/mapbox/mapbox-gl-js/assets/49798681/3ba4789a-01dc-4536-a74d-ab138a776c12)
![Snipaste_2024-05-13_16-08-25](https://github.com/mapbox/mapbox-gl-js/assets/49798681/a3254bad-ed3b-48a8-b76f-299c46c8ebe4)
![Snipaste_2024-05-13_16-08-47](https://github.com/mapbox/mapbox-gl-js/assets/49798681/b763605b-04b4-4a0e-95b2-cef3e42b4f11)
### Scope of Impact
rollup.config.js

## Launch Checklist

 - [x]  briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

