### PR TITLE
Fix type narrowing of image source types

### DIFF
--- a/src/source/canvas_source.ts
+++ b/src/source/canvas_source.ts
@@ -54,7 +54,7 @@ export type CanvasSourceSpecification = {
  * map.removeSource('some id');  // remove
  * @see [Example: Add a canvas source](https://docs.mapbox.com/mapbox-gl-js/example/canvas-source/)
  */
-class CanvasSource extends ImageSource {
+class CanvasSource extends ImageSource<'canvas'> {
     options: CanvasSourceSpecification;
     animate: boolean;
     canvas: HTMLCanvasElement;
@@ -67,6 +67,7 @@ class CanvasSource extends ImageSource {
      */
     constructor(id: string, options: CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super(id, options, dispatcher, eventedParent);
+        this.type = 'canvas';
 
         // We build in some validation here, since canvas sources aren't included in the style spec:
         if (!options.coordinates) {

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -215,8 +215,8 @@ function sortTriangles(centerLatitudes: number[], indices: TriangleIndexArray): 
  * @see [Example: Add an image](https://www.mapbox.com/mapbox-gl-js/example/image-on-a-map/)
  * @see [Example: Animate a series of images](https://www.mapbox.com/mapbox-gl-js/example/animate-images/)
  */
-class ImageSource extends Evented implements ISource {
-    type: string;
+class ImageSource<T extends 'canvas' | 'image' | 'video' = 'image'> extends Evented implements ISource {
+    type: T;
     id: string;
     scope: string;
     minzoom: number;
@@ -276,7 +276,7 @@ class ImageSource extends Evented implements ISource {
         this.dispatcher = dispatcher;
         this.coordinates = options.coordinates;
 
-        this.type = 'image';
+        this.type = 'image' as T;
         this.minzoom = 0;
         this.maxzoom = 22;
         this.tileSize = 512;

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -107,7 +107,6 @@ class SourceCache extends Evented {
         this._isRaster =
             this._source.type === 'raster' ||
             this._source.type === 'raster-dem' || this._source.type === 'raster-array' ||
-            // @ts-expect-error - TS2339 - Property '_dataType' does not exist on type 'VideoSource | ImageSource | CanvasSource | CustomSource<ImageBitmap | HTMLCanvasElement | HTMLImageElement | ImageData>'.
             (this._source.type === 'custom' && this._source._dataType === 'raster');
     }
 

--- a/src/source/video_source.ts
+++ b/src/source/video_source.ts
@@ -42,7 +42,7 @@ import type {VideoSourceSpecification} from '../style-spec/types';
  * map.removeSource('some id');  // remove
  * @see [Example: Add a video](https://www.mapbox.com/mapbox-gl-js/example/video-on-a-map/)
  */
-class VideoSource extends ImageSource {
+class VideoSource extends ImageSource<'video'> {
     options: VideoSourceSpecification;
     urls: Array<string>;
     video: HTMLVideoElement;


### PR DESCRIPTION
This is a draft PR attempting to fix #13220. I don't think it's the best approach, but it might be useful for discussions.

The core problem of #13220 is that the new `ImageSource` type is serving double-duty as the basis for the `CanvasSource` and `VideoSource` types. This means that the `type` property is currently typed as `string`, which prevents type narrowing from working on the `Source` type.

The solution here _does_ work, but having `ImageSource` be a generic type is probably not the nicest way to do it. Perhaps the `ImageSource` type should be separated from its implementation?

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page. _(N/A: no behavioural changes)_
 - [ ] Write tests for all new functionality and make sure the CI checks pass. _(I wasn't able to because Vitest type tests don't seem to work in this project's test suite)_
 - [ ] Document any changes to public APIs. _(N/A: no behavioural changes)_
 - [ ] Post benchmark scores if the change could affect performance. _(N/A: no behavioural changes)_
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes. _(N/A)_
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port. _(N/A)_
