### PR TITLE
support supercluster#244 arrayType option within cluster sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "quickselect": "^3.0.0",
     "rw": "^1.3.3",
     "serialize-to-js": "^3.1.2",
-    "supercluster": "^8.0.1",
+    "supercluster": "andrewharvey/supercluster#244",
     "tinyqueue": "^3.0.0",
     "tweakpane": "^4.0.4",
     "vt-pbf": "^3.1.3"

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -156,7 +156,8 @@ class GeoJSONSource extends Evented<SourceEvents> implements ISource {
                 extent: EXTENT,
                 radius: (options.clusterRadius !== undefined ? options.clusterRadius : 50) * scale,
                 log: false,
-                generateId: options.generateId || false
+                generateId: options.generateId || false,
+                arrayType: options.clusterArrayType || 'Float32Array'
             },
             clusterProperties: options.clusterProperties,
             filter: options.filter,

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -321,6 +321,12 @@ function getSuperclusterOptions({
         }
     };
 
+    // convert String option value into a TypedArray constructor
+    const arrayTypes = {
+        Float32Array, Float64Array
+    };
+    superclusterOptions.arrayType = arrayTypes[superclusterOptions.arrayType];
+
     return superclusterOptions;
 }
 

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1005,6 +1005,19 @@
       "type": "*",
       "doc": "An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from clustered points. Has the form `{\"property_name\": [operator, map_expression]}`. `operator` is any expression function that accepts at least 2 operands (e.g. `\"+\"` or `\"max\"`) — it accumulates the property value from clusters/points the cluster contains; `map_expression` produces the value of a single point.\n\nExample: `{\"sum\": [\"+\", [\"get\", \"scalerank\"]]}`.\n\nFor more advanced use cases, in place of `operator`, you can use a custom reduce expression that references a special `[\"accumulated\"]` value, e.g.:\n`{\"sum\": [[\"+\", [\"accumulated\"], [\"get\", \"sum\"]], [\"get\", \"scalerank\"]]}`"
     },
+    "clusterArrayType": {
+      "type": "enum",
+      "default": "Float32Array",
+      "values": {
+        "Float32Array": {
+          "doc": "A Float32Array"
+        },
+        "Float64Array": {
+          "doc": "A Float64Array"
+        }
+      },
+      "doc": "TypedArray to use for clustering, for clusterMaxZoom values and lower clusterRadius values you may need to increase this to Float64Array for more accurate clusters."
+    },
     "lineMetrics": {
       "type": "boolean",
       "default": false,

--- a/src/style-spec/types.ts
+++ b/src/style-spec/types.ts
@@ -255,6 +255,7 @@ export type GeoJSONSourceSpecification = {
     "clusterMaxZoom"?: number,
     "clusterMinPoints"?: number,
     "clusterProperties"?: unknown,
+    "clusterArrayType"?: "Float32Array" | "Float64Array",
     "lineMetrics"?: boolean,
     "generateId"?: boolean,
     "promoteId"?: PromoteIdSpecification,


### PR DESCRIPTION
At high clusterMaxZoom values and low clusterRadius values with data very close together, the default supercluster Float32Array type starts causing some features to cluster when they shouldn't based on your set clusterRadius.

To resolve this I've exposed an option on cluster sources to set the supercluster type to Float64Array.

I've posted this PR as a WIP for now as I don't think we should actually expose this option like this. I'm thinking we should try to determine based on the clusterMaxZoom and clusterRadius set that (we we just assume there will be very close data present) if Float32Array would suffice or if we need Float64Array and set it transparently.

## Launch Checklist

 - [] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
