### PR TITLE
adding type to the _controlPositions property of Map class

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -419,7 +419,7 @@ export class Map extends Camera {
     _canvasContainer: HTMLElement;
     _controlContainer: HTMLElement;
     _controlPositions: {
-        [_: string]: HTMLElement;
+        [P in ControlPosition]: HTMLElement;
     };
     _interactive?: boolean;
     _showTileBoundaries?: boolean;


### PR DESCRIPTION
Fix the type of the _controlpositions property of Map class:
 ```ts
 _controlPositions: {
        [P in ControlPosition]: HTMLElement; // instead of [_: string] 
  }
  ```
 