### PR TITLE
remove private status for 3 fill-extrusion properties

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1679,7 +1679,6 @@
     "fill-extrusion-edge-radius": {
       "type": "number",
       "experimental": true,
-      "private": true,
       "default": 0,
       "minimum": 0,
       "maximum": 1,
@@ -5633,7 +5632,6 @@
     "fill-extrusion-ambient-occlusion-intensity": {
       "property-type": "data-constant",
       "type": "number",
-      "private": true,
       "default": 0.0,
       "minimum": 0,
       "maximum": 1,
@@ -5656,7 +5654,6 @@
     "fill-extrusion-ambient-occlusion-radius": {
       "property-type": "data-constant",
       "type": "number",
-      "private": true,
       "default": 3.0,
       "minimum": 0,
       "expression": {


### PR DESCRIPTION
Removes `private: true` for the following properties:

- `fill-extrusion-edge-radius`
- `fill-extrusion-ambient-occlusion-intensity`
- `fill-extrusion-ambient-occlusion-radius`

