### PR TITLE
style-spec@v14.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16048,7 +16048,7 @@
     },
     "src/style-spec": {
       "name": "@mapbox/mapbox-gl-style-spec",
-      "version": "14.7.0",
+      "version": "14.7.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
-  "version": "14.7.0",
+  "version": "14.7.1",
   "description": "a specification for mapbox gl styles",
   "author": "Mapbox",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -230,6 +230,10 @@
   },
   "featureset": {
     "experimental": true,
+    "metadata": {
+      "type": "*",
+      "doc": "Arbitrary properties useful to track with the stylesheet, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'mapbox:'."
+    },
     "selectors": {
       "type": "array",
       "value": "selector",

--- a/src/style-spec/types.ts
+++ b/src/style-spec/types.ts
@@ -198,6 +198,7 @@ export type FeaturesetsSpecification = {
  * @experimental This is experimental and subject to change in future versions.
  */
 export type FeaturesetSpecification = {
+    "metadata"?: unknown,
     "selectors"?: Array<SelectorSpecification>
 }
 


### PR DESCRIPTION
Adds a `metadata` property definition in the style spec for the upcoming `featuresets` feature.