### PR TITLE
Documentation: Fix links to CSP directives

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ const exported = {
      * This is useful if your site needs to operate in a strict CSP (Content Security Policy) environment
      * wherein you are not allowed to load JavaScript code from a [`Blob` URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL), which is default behavior.
      *
-     * See our documentation on [CSP Directives](https://docs.mapbox.com/mapbox-gl-js/api/#csp-directives) for more details.
+     * See our documentation on [CSP Directives](https://docs.mapbox.com/mapbox-gl-js/guides/browsers/#csp-directives) for more details.
      *
      * @var {string} workerUrl
      * @returns {string} A URL hosting a JavaScript bundle for mapbox-gl's WebWorker.
@@ -283,7 +283,7 @@ const exported = {
      * This is useful if your site needs to operate in a strict CSP (Content Security Policy) environment
      * wherein you are not allowed to load JavaScript code from a [`Blob` URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL), which is default behavior.
      *
-     * See our documentation on [CSP Directives](https://docs.mapbox.com/mapbox-gl-js/api/#csp-directives) for more details.
+     * See our documentation on [CSP Directives](https://docs.mapbox.com/mapbox-gl-js/guides/browsers/#csp-directives) for more details.
      *
      * @var {string} dracoUrl
      * @returns {string} A URL hosting Google Draco decoding library (`draco_wasm_wrapper_gltf.js` and `draco_decoder_gltf.wasm`).


### PR DESCRIPTION
A very small PR. I found that the links in the documentation to a section on CSP Directives did not work. It appears that the location of those has moved so I have updated the links accordingly.

Original Link: [CSP Directives](https://docs.mapbox.com/mapbox-gl-js/api/#csp-directives)
Fixed Link: [CSP Directives](https://docs.mapbox.com/mapbox-gl-js/guides/browsers/#csp-directives)

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
