### PR TITLE
Stop marker from flashing on initial load if it's occluded by the globe

### DIFF
--- a/test/unit/terrain/terrain.test.ts
+++ b/test/unit/terrain/terrain.test.ts
@@ -1523,9 +1523,6 @@ describe('Marker interaction and raycast', () => {
         });
 
         test('Occluded', async () => {
-            marker._fadeTimer = null;
-            // Occlusion is happening with Timers API. Advance them
-            vi.spyOn(window, 'setTimeout').mockImplementation((cb) => cb());
             marker.setLngLat(terrainTopLngLat);
             const bottomLngLat = tr.pointLocation3D(new Point(terrainTop.x, tr.height));
             // Raycast returns distance to closer point evaluates to occluded marker.

--- a/test/unit/ui/marker.test.ts
+++ b/test/unit/ui/marker.test.ts
@@ -1128,6 +1128,8 @@ describe('Marker and fog', () => {
         map.setBearing(90);
         map.setPitch(70);
         marker.setLngLat([4, 0]);
+        
+        expect(marker.getElement().style.opacity).toEqual('0');
 
         await new Promise(resolve => {
             setTimeout(() => {


### PR DESCRIPTION
This pull request fixes issue #13000. See this video for a demonstration of the bug:

https://github.com/user-attachments/assets/8519a3f2-93d9-4852-950d-2651bb0555ec

Here is the same example, after the fix:

https://github.com/user-attachments/assets/222c0dbc-3af1-4e43-8731-c29ae61fa6ae

Here is a possibly relevant conversation from when the throttling was initially added in 2021: https://github.com/mapbox/mapbox-gl-js/pull/10564#discussion_r627568130. I didn't notice any performance issues when testing the fix, but maybe someone more experienced can tell if this fix causes problems somewhere.

I tested also with adding an `isInitialLoad` boolean to `Marker`'s `_update` function so that we could keep the `_fadeTimer`. It caused problems with popups flashing on initial load, but I managed to fix them. That solution was less clean than this one in my opinion, but I think it's still a possibility if we want to keep the fade timer.

This is my first PR to Mapbox, please tell me if there is something that I did incorrectly or that I should still fix, I'm open to all feedback! :)

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [X] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [X] Manually test the debug page.
 - [X] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
