### PR TITLE
Prevent Marker Shifting on Map Double Click

### DIFF
--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -591,6 +591,7 @@ export default class Marker extends Evented<MarkerEvents> {
             if (!this._map) return;
 
             if (this._element && this._pos && this._anchor) {
+                this._pos = this._pos.round();
                 this._updateDOM();
             }
 


### PR DESCRIPTION
Signed-off-by: C2thehris <chriskreat@hotmail.com>

There is currently a subtle shift when double clicking a map which is most apparent when using a map with a fixed zoom. This is caused by one of the entry points for the marker's "updateDOM" method not rounding the position.

## Launch Checklist

 - [ X] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
