### PR TITLE
fix: added missing export type of MapBoxZoomEvent

### DIFF
--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -403,6 +403,11 @@ export type MapInteractionEventType = MapMouseEventType | MapTouchEventType | Ma
  * @see [Reference: `Map` events API documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-events)
  * @see [Example: Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
  */
+export type MapBoxZoomEvent = {
+    type: 'boxzoomstart' | 'boxzoomend' | 'boxzoomcancel';
+    target: Map;
+    originalEvent: MouseEvent;
+};
 
 export type MapStyleDataEvent = {
     dataType: 'style';


### PR DESCRIPTION
Added missing type definition for `MapBoxZoomEvent`. The type definition got accidentally removed in https://github.com/mapbox/mapbox-gl-js/commit/f338be47febc943289abc0676347e548b7d35cfa and in the "revert" the type type definition was not added back https://github.com/mapbox/mapbox-gl-js/commit/1fea1bb91d86aec32c8ea5067d5e8568dabdc8b4.


https://docs.mapbox.com/mapbox-gl-js/api/events/#mapboxzoomevent


## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
