### PR TITLE
Fixed attempt of buckets update before map first render

### DIFF
--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -615,6 +615,7 @@ class Tile {
 
     updateBuckets(painter: Painter, isBrightnessChanged?: boolean) {
         if (!this.latestFeatureIndex) return;
+        if (!painter.style) return;
 
         const vtLayers = this.latestFeatureIndex.loadVTLayers();
         const availableImages = painter.style.listImages();


### PR DESCRIPTION
Time to time, randomly Datadog RUM that is monitoring our application FE reports the following error

```
TypeError: undefined is not an object (evaluating 'i.style.listImages')
  at updateBuckets @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:8:55922
  at refreshFeatureState @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:8:55812
  at initializeTileState @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:8:68593
  at _tileLoaded @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:8:73285
  at u @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:8:27141
  at processTask @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:7:292692
  at receive @ https://example.com/_next/static/chunks/153e222f-eb05776e76b311d1.js:7:292534
```

As `Painter` `style` property is being initialised in the `render` method instead of `constructor`, it seems that `updateBuckets` might be occasionally called even before the first map render when painter is not ready to do their job.

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page. – irrelevant
 - [ ] Write tests for all new functionality and make sure the CI checks pass. – irrelevant
 - [ ] Document any changes to public APIs. – irrelevant
 - [ ] Post benchmark scores if the change could affect performance. – irrelevant
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes. – irrelevant
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port. – irrelevant
