### PR TITLE
Document that trigonometric expressions use radians

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4706,7 +4706,7 @@
         }
       },
       "sin": {
-        "doc": "Returns the sine of the input.",
+        "doc": "Returns the sine of the input, interpreted as radians.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4717,7 +4717,7 @@
         }
       },
       "cos": {
-        "doc": "Returns the cosine of the input.",
+        "doc": "Returns the cosine of the input, interpreted as radians.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4728,7 +4728,7 @@
         }
       },
       "tan": {
-        "doc": "Returns the tangent of the input.",
+        "doc": "Returns the tangent of the input, interpreted as radians.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4739,7 +4739,7 @@
         }
       },
       "asin": {
-        "doc": "Returns the arcsine of the input.",
+        "doc": "Returns the arcsine of the input, in radians between −π/2 and π/2.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4750,7 +4750,7 @@
         }
       },
       "acos": {
-        "doc": "Returns the arccosine of the input.",
+        "doc": "Returns the arccosine of the input, in radians between −π/2 and π/2.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4761,7 +4761,7 @@
         }
       },
       "atan": {
-        "doc": "Returns the arctangent of the input.",
+        "doc": "Returns the arctangent of the input, in radians between −π/2 and π/2.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
Style expressions like `["cos", arg]` take `arg` in radians, and their inverses return radians. This is a reasonable choice, but in context it may be a bit surprising, since latitudes and longitudes are typically expressed in degrees. Other expressions like `["pitch"]` also return degrees. This patch keeps the current behavior and describes it explicitly in the documentation.

cc @mapbox/map-design-team

wchargin-branch: docs-trig-radians

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] ~Manually test the debug page.~
 - [ ] ~Write tests for all new functionality and make sure the CI checks pass.~
 - [x] Document any changes to public APIs.
 - [ ] ~Post benchmark scores if the change could affect performance.~
 - [x] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] ~Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.~
