### PR TITLE
fix: fix popup delay when moving the map

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -4358,7 +4358,9 @@ export class Map extends Camera {
             averageElevationChanged = this._updateAverageElevation(frameStartTime);
             this.style.updateSources(this.transform);
             // Update positions of markers and popups on enabling/disabling terrain
-            this._forceMarkerAndPopupUpdate();
+            if (!this.isMoving()) {
+                this._forceMarkerAndPopupUpdate();
+            }
         } else {
             averageElevationChanged = this._updateAverageElevation(frameStartTime);
         }


### PR DESCRIPTION
Fixes #12998 where popups visibly lag behind when moving the map (introduced in #12242).

Before (release-v2.11.0 and up):

https://github.com/user-attachments/assets/263619c4-249a-4ddc-9e1d-1a9d54948523

After:

https://github.com/user-attachments/assets/6548510b-a8d4-4fb5-a0a0-5a8eab63bac4

I've tested the fix for all issues addressed in #12242 to ensure they remain resolved. Additionally, I ran the unit tests, and all tests passed successfully.

## Launch Checklist
 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
