### PR TITLE
Potential fix DOM text reinterpreted as HTML

### DIFF
--- a/debug/globe-fill-extrusion.html
+++ b/debug/globe-fill-extrusion.html
@@ -262,7 +262,7 @@ document.getElementById('buildings-fauxao-slider').oninput = function() {
 
 document.getElementById('buildings-ao-radius-slider').oninput = function() {
     map.setPaintProperty("country-boundaries", 'fill-extrusion-ambient-occlusion-radius', this.valueAsNumber);
-    document.getElementById('ao_radius').innerHTML = this.value;
+    document.getElementById('ao_radius').textContent = this.value;
 };
 
 document.getElementById('buildings-opacity-slider').oninput = function() {


### PR DESCRIPTION
## Ticket 🎟️ #13419 

To fix the problem, we need to ensure that the value assigned to `innerHTML` is properly escaped to prevent any potential XSS attacks. The best way to do this is to use `textContent` instead of `innerHTML`, as `textContent` will treat the value as plain text rather than HTML, thus preventing any HTML or JavaScript from being executed.


## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
