### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mapbox/gl-js @mapbox/gl-native @mapbox/mapbox-3d-team
+* @mapbox/gl-js


### PR DESCRIPTION
The public repo is only maintained by the GL JS team — no need to involve the other listed teams (which we only need for internal development).