### PR TITLE
Remove `logToElement` 

### DIFF
--- a/src/util/debug.ts
+++ b/src/util/debug.ts
@@ -19,7 +19,6 @@ export const Debug: {
     aabbCorners: Array<vec3>;
     extend: (...args: unknown[]) => void;
     run: (...args: unknown[]) => void;
-    logToElement: (...args: unknown[]) => void;
     drawAabbs: (...args: unknown[]) => void;
     clearAabbs: (...args: unknown[]) => void;
     _drawBox: (...args: unknown[]) => void;
@@ -34,15 +33,6 @@ export const Debug: {
 
     run(fn: () => unknown) {
         fn();
-    },
-
-    logToElement(message: string, overwrite: boolean = false, id: string = "log") {
-        const el = document.getElementById(id);
-        if (el) {
-            if (overwrite) el.innerHTML = '';
-            el.innerHTML += `<br>${message}`;
-        }
-
     },
 
     debugCanvas: null,


### PR DESCRIPTION
This PR removes `Debug::logToElement`.
See the internal #2519 PR for more details.

## Launch Checklist

 - [ ] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
