### PR TITLE
fix(GeolocateControl): include all GeolocationPositionError properties in error event

### DIFF
--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -452,7 +452,13 @@ class GeolocateControl extends Evented<GeolocateControlEvents> implements IContr
             this._userLocationDotMarker.addClassName('mapboxgl-user-location-dot-stale');
         }
 
-        this.fire(new Event('error', error));
+        this.fire(new Event('error', {
+            code: error.code,
+            message: error.message,
+            PERMISSION_DENIED: error.PERMISSION_DENIED,
+            POSITION_UNAVAILABLE: error.POSITION_UNAVAILABLE,
+            TIMEOUT: error.TIMEOUT
+        } as GeolocationPositionError));
 
         this._finish();
     }

--- a/test/unit/ui/control/geolocate.test.ts
+++ b/test/unit/ui/control/geolocate.test.ts
@@ -59,6 +59,36 @@ test('GeolocateControl error event', async () => {
     });
 });
 
+test('GeolocateControl error event includes GeolocationPositionError constants', async () => {
+    const map = createMap();
+    const geolocate = new GeolocateControl();
+    map.addControl(geolocate);
+
+    // Directly call _onError with a mock GeolocationPositionError to test
+    // that PERMISSION_DENIED, POSITION_UNAVAILABLE, and TIMEOUT are passed through.
+    // The mock-geolocation library doesn't support these constants.
+    const mockError = {
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3,
+        code: 1,
+        message: 'User denied Geolocation',
+    } as const satisfies GeolocationPositionError;
+
+    await afterUIChanges((resolve) => {
+        geolocate.on('error', (error) => {
+            expect(error.code).toEqual(1);
+            expect(error.message).toEqual('User denied Geolocation');
+            expect(error.PERMISSION_DENIED).toEqual(1);
+            expect(error.POSITION_UNAVAILABLE).toEqual(2);
+            expect(error.TIMEOUT).toEqual(3);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            resolve();
+        });
+        geolocate._onError(mockError);
+    });
+});
+
 test('GeolocateControl outofmaxbounds event in active lock state', async () => {
     const map = createMap();
     const geolocate = new GeolocateControl();


### PR DESCRIPTION
## Description

Addresses: https://github.com/mapbox/mapbox-gl-js/issues/13576

### Problem
In versions 3.15.0+, the GeolocateControl error event is missing `code`, `message`, `PERMISSION_DENIED`, `POSITION_UNAVAILABLE`, and `TIMEOUT` properties. Users only receive `{ target, type }` instead of the full error information.

### Root Cause
`GeolocationPositionError` is a native DOM object with non-enumerable properties. When passed directly to `new Event('error', error)`, the `Event` constructor uses `Object.assign()` which doesn't copy non-enumerable properties.

### Solution
Explicitly extract properties from `GeolocationPositionError` when creating the error event, matching the pattern already used for the `geolocate` event (fixed in commit 9a1c893f8).

**Before:**
```typescript
this.fire(new Event('error', error));
```

**After:**
```typescript
this.fire(new Event('error', {
    code: error.code,
    message: error.message,
    PERMISSION_DENIED: error.PERMISSION_DENIED,
    POSITION_UNAVAILABLE: error.POSITION_UNAVAILABLE,
    TIMEOUT: error.TIMEOUT
} as GeolocationPositionError));
```

Here is a screenshot where I tested it in Firefox
<img width="2672" height="1527" alt="Screenshot 2025-12-02 at 11 26 57" src="https://github.com/user-attachments/assets/f9a29b62-310b-4204-bdde-4d5dd54515c8" />



---

## Launch Checklist

- [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
- [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
- [x] Manually test the debug page.
- [x] Write tests for all new functionality and make sure the CI checks pass.
- [ ] Document any changes to public APIs. *(N/A - this restores existing documented behavior)*
- [ ] Post benchmark scores if the change could affect performance. *(N/A - no performance impact)*
- [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes. *(N/A)*
- [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port. *(N/A)*
- [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side. *(N/A)*
- [ ] Create a ticket for `gl-native` to groom in the MAPSNAT JIRA queue if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there. *(N/A)*