### PR TITLE
Restore JSDoc change to the Camera section of Map Instance Members

### DIFF
--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -225,7 +225,12 @@ class Camera extends Evented<MapEvents> {
         //addAssertions(this);
     }
 
-    /** @section Camera */
+    /**
+     * @section {Camera}
+     * @method
+     * @instance
+     * @memberof Map
+     */
 
     /**
      * Returns the map's geographical centerpoint.


### PR DESCRIPTION
This PR reverts a JSDoc change made in #13439 that caused a rendering issue with the API reference documentation on docs.mapbox.com.

The change caused `documentation.js` to omit the sub-section `Camera` under instance members, causing all of the camera members (`flyTo()`, `getZoom()`, etc) to be listed under the preceding section `Debug features`.

Restoring the JSDoc comment causes `documentation.js` to properly add the `Camera` section to its output, and the docs site will render it correctly.

## Launch Checklist

 - [ ] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [ ] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.
