### PR TITLE
Use lowercase header names when reading expiry

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -668,8 +668,8 @@ export function parseCacheControl(cacheControl: string): Record<string, number> 
 
 export function getExpiryDataFromHeaders(responseHeaders: Headers | Map<string, string> | undefined) {
     if (!responseHeaders) return {cacheControl: undefined, expires: undefined};
-    const cacheControl = responseHeaders.get('Cache-Control');
-    const expires = responseHeaders.get('Expires');
+    const cacheControl = responseHeaders.get('cache-control');
+    const expires = responseHeaders.get('expires');
     return {cacheControl, expires};
 }
 


### PR DESCRIPTION
Fix for the [issue 13625](https://github.com/mapbox/mapbox-gl-js/issues/13625)

Normalize header lookups to lowercase in getExpiryDataFromHeaders so 'cache-control' and 'expires' are retrieved reliably from Headers/Map implementations that store lowercase keys. This prevents previously returning undefined when headers used lowercase keys.
