### PR TITLE
fix: replace :first-child with :first-of-type in mapbox-gl.css (fixes #13639)

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -147,7 +147,7 @@
     opacity: 0.25;
 }
 
-.mapboxgl-ctrl-group button:first-child {
+.mapboxgl-ctrl-group button:first-of-type {
     border-radius: 4px 4px 0 0;
 }
 


### PR DESCRIPTION
## Launch Checklist

- [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
- [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
- [x] Manually test the debug page.
- [ ] Write tests for all new functionality and make sure the CI checks pass.
- [ ] Document any changes to public APIs.
- [ ] Post benchmark scores if the change could affect performance.
- [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
- [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
- [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
- [ ] Create a ticket for `gl-native` to groom in the MAPSNAT JIRA queue if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.

## Description

Fixes #13639.

Emotion (a popular CSS-in-JS library) warns at runtime when it encounters CSS rules using the `:first-child` pseudo-class, because that selector is not safe for server-side rendering (SSR):

> The pseudo-class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".

### Change

In `src/css/mapbox-gl.css`, the single occurrence of `:first-child`:

```css
/* before */
.mapboxgl-ctrl-group button:first-child {
    border-radius: 4px 4px 0 0;
}
```

was replaced with `:first-of-type`:

```css
/* after */
.mapboxgl-ctrl-group button:first-of-type {
    border-radius: 4px 4px 0 0;
}
```

### Why this is safe

All direct children of `.mapboxgl-ctrl-group` are `<button>` elements, so `:first-child` and `:first-of-type` are semantically equivalent in this context. The change silences the Emotion SSR warning without any visual or behavioural difference.
