### PR TITLE
Fix cameraForBounds not accounting for asymmetrical padding in center result

### DIFF
--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -782,13 +782,10 @@ class Camera extends Evented<MapEvents> {
         const padB = options.padding.bottom || 0;
         const padT = options.padding.top || 0;
 
-        const halfScreenPadX = (padL + padR) * 0.5;
-        const halfScreenPadY = (padT + padB) * 0.5;
-
-        const top = halfScreenPadY;
-        const left = halfScreenPadX;
-        const right = halfScreenPadX;
-        const bottom = halfScreenPadY;
+        const top = padT;
+        const left = padL;
+        const right = padR;
+        const bottom = padB;
 
         const width = tr.width - (left + right);
         const height = tr.height - (top + bottom);

--- a/test/unit/ui/camera.test.ts
+++ b/test/unit/ui/camera.test.ts
@@ -1104,7 +1104,39 @@ describe('camera', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const transform = camera.cameraForBounds(bb, {padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -100.5, lat: 34.7171});
+            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -96.5558, lat: 32.0833});
+        });
+
+        test('asymmetrical left padding shifts center', () => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            const noPadding = camera.cameraForBounds(bb, {padding: {top: 0, right: 0, bottom: 0, left: 0}});
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            const leftPadding = camera.cameraForBounds(bb, {padding: {top: 0, right: 0, bottom: 0, left: 100}});
+
+            // With left padding, the center shifts left (more negative lng) to offset the bounds
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            expect(leftPadding.center.lng).toBeLessThan(noPadding.center.lng);
+            // Zoom should decrease to accommodate the padding
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            expect(leftPadding.zoom).toBeLessThan(noPadding.zoom);
+        });
+
+        test('symmetric padding does not shift center', () => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            const noPadding = camera.cameraForBounds(bb);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            const symPadding = camera.cameraForBounds(bb, {padding: {top: 50, right: 50, bottom: 50, left: 50}});
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            expect(fixedLngLat(noPadding.center, 4)).toEqual(fixedLngLat(symPadding.center, 4));
         });
 
         test('bearing and asymmetrical padding', () => {
@@ -1115,7 +1147,7 @@ describe('camera', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const transform = camera.cameraForBounds(bb, {bearing: 90, padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -100.5, lat: 34.7171});
+            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -103.3761, lat: 31.7099});
         });
 
         test(
@@ -1130,7 +1162,7 @@ describe('camera', () => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
                 const transform = camera.cameraForBounds(bb, {bearing: 90, padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0});
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                expect(fixedLngLat(transform.center, 4)).toEqual({lng: -100.5, lat: 34.7171});
+                expect(fixedLngLat(transform.center, 4)).toEqual({lng: -103.3761, lat: 31.7099});
             }
         );
 
@@ -1164,7 +1196,7 @@ describe('camera', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const transform = camera.cameraForBounds(bb, {padding: {top: 10, right: 75, bottom: 50, left: 25}, offset: [0, 100]});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -100.5, lat: 46.6292});
+            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -96.5558, lat: 44.4189});
         });
 
         test('bearing, asymmetrical padding, and offset', () => {
@@ -1175,7 +1207,7 @@ describe('camera', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const transform = camera.cameraForBounds(bb, {bearing: 90, padding: {top: 10, right: 75, bottom: 50, left: 25}, offset: [0, 100], duration: 0});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -100.5, lat: 45.6619});
+            expect(fixedLngLat(transform.center, 4)).toEqual({lng: -103.3761, lat: 43.0929});
         });
 
         test('unable to fit', () => {
@@ -1441,7 +1473,7 @@ describe('camera', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             camera.fitBounds(bb, {padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            expect(fixedLngLat(camera.getCenter(), 4)).toEqual({lng: -100.5, lat: 34.7171});
+            expect(fixedLngLat(camera.getCenter(), 4)).toEqual({lng: -96.5558, lat: 32.0833});
         });
 
         test('padding object with pitch', () => {
@@ -1452,7 +1484,7 @@ describe('camera', () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             camera.fitBounds(bb, {padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0, pitch: 30});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            expect(fixedLngLat(camera.getCenter(), 4)).toEqual({lng: -100.5, lat: 34.7171});
+            expect(fixedLngLat(camera.getCenter(), 4)).toEqual({lng: -96.5558, lat: 32.4408});
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             expect(camera.getPitch()).toEqual(30);
         });


### PR DESCRIPTION
## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [ ] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.

## Description

Fixes #13645

`cameraForBounds` was not accounting for asymmetrical padding when computing the camera center. This was a regression introduced in v3.4.0.

### Root Cause

In the `_extendAABB` method in `src/ui/camera.ts`, the padding values were being averaged (symmetrized) before being applied to the AABB extension:

```typescript
// Before (broken):
const halfScreenPadX = (padL + padR) * 0.5;
const halfScreenPadY = (padT + padB) * 0.5;
const top = halfScreenPadY;
const left = halfScreenPadX;
const right = halfScreenPadX;
const bottom = halfScreenPadY;
```

This meant both sides of the bounding box received equal padding extension, so the AABB center (which determines the resulting camera center) never shifted regardless of padding asymmetry. The zoom was correctly affected because the total padding was preserved, but the center was not.

### Fix

Use the actual asymmetric padding values directly:

```typescript
// After (fixed):
const top = padT;
const left = padL;
const right = padR;
const bottom = padB;
```

The available viewport `width = tr.width - (left + right)` and `height = tr.height - (top + bottom)` calculations remain identical since `left + right = padL + padR` in both cases. So the zoom calculation is unaffected. The difference is that the AABB now extends asymmetrically, shifting its center to properly account for the padding difference.

### Testing

- Updated 7 existing test expectations that incorrectly expected no center shift with asymmetric padding
- Added 2 new tests:
  - `asymmetrical left padding shifts center`: verifies that left-only padding shifts the camera center and reduces zoom
  - `symmetric padding does not shift center`: verifies that equal padding on all sides does not shift the center (regression guard)