### PR TITLE
Disable dist sourcemaps for publish builds to prevent src 404s (internal-1596)

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "test-expressions": "tsx ./test/expression.test.ts",
     "test-typings": "tsx ./build/generate-typed-style-spec.ts && npm run tsc",
     "test-style-spec": "npm test --workspace src/style-spec",
-    "prepublishOnly": "run-s build-dev build-prod-min build-esm-prod-min build-csp build-css build-style-spec build-dts",
+    "prepublishOnly": "NO_DIST_SOURCEMAPS=true run-s build-dev build-prod-min build-esm-prod-min build-csp build-css build-style-spec build-dts",
     "print-release-url": "node build/print-release-url.js",
     "size": "size-limit",
     "check-size": "tsx build/check-size.ts",

--- a/rollup.config.csp.js
+++ b/rollup.config.csp.js
@@ -1,6 +1,9 @@
 import {plugins} from './build/rollup_plugins.js';
 import banner from './build/banner.js';
 
+const {NO_DIST_SOURCEMAPS} = process.env;
+const disableDistSourcemaps = NO_DIST_SOURCEMAPS === 'true';
+
 // a config for generating a special GL JS bundle with static web worker code (in a separate file)
 // https://github.com/mapbox/mapbox-gl-js/issues/6058
 
@@ -13,7 +16,8 @@ const config = (input, file, format) => ({
         file,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         format,
-        sourcemap: true,
+        // Allows publish/build scripts to suppress distributable sourcemaps.
+        sourcemap: !disableDistSourcemaps,
         indent: false,
         banner
     },

--- a/rollup.config.esm.js
+++ b/rollup.config.esm.js
@@ -1,8 +1,9 @@
 import {plugins} from './build/rollup_plugins.js';
 
-const {BUILD, MINIFY} = process.env;
+const {BUILD, MINIFY, NO_DIST_SOURCEMAPS} = process.env;
 const minified = MINIFY === 'true';
 const production = BUILD === 'production';
+const disableDistSourcemaps = NO_DIST_SOURCEMAPS === 'true';
 
 export default () => [
     {
@@ -26,7 +27,8 @@ export default () => [
             exports: 'named',
             minifyInternalExports: true,
             externalLiveBindings: false,
-            sourcemap: true,
+            // Allows publish/build scripts to suppress distributable sourcemaps.
+            sourcemap: !disableDistSourcemaps,
         },
         treeshake: production ? {
             preset: 'smallest',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,9 +7,10 @@ import browserslistToEsbuild from 'browserslist-to-esbuild';
 import {plugins} from './build/rollup_plugins.js';
 import banner from './build/banner.js';
 
-const {BUILD, MINIFY} = process.env;
+const {BUILD, MINIFY, NO_DIST_SOURCEMAPS} = process.env;
 const minified = MINIFY === 'true';
 const production = BUILD === 'production';
+const disableDistSourcemaps = NO_DIST_SOURCEMAPS === 'true';
 
 function buildType(build, minified) {
     switch (build) {
@@ -71,7 +72,8 @@ export default ({watch}) => {
             name: 'mapboxgl',
             file: outputFile,
             format: 'umd',
-            sourcemap: production ? true : 'inline',
+            // Allows publish/build scripts to suppress distributable sourcemaps.
+            sourcemap: disableDistSourcemaps ? false : production ? true : 'inline',
             indent: false,
             intro: bundlePrelude,
             banner


### PR DESCRIPTION
Prevent sourcemap-related 404s in production error reporting by disabling distributable sourcemaps during publish builds.

Background:

Root cause was introduced in: Do not include source in NPM package (internal-1596) Commit: 8bbf4bd8165fde9c2d52ef24847ce4cc0321a3c3
Since src/ is no longer shipped in the npm package, sourcemap sources pointing to src/* cause Honeybadger/browser fetch attempts to return 404. Changes:

Add env-controlled sourcemap toggle for Rollup dist outputs. Set NO_DIST_SOURCEMAPS=true in prepublishOnly so publish artifacts are generated without .map files. Keep compiled JS output unchanged.
Impact:

Eliminates noisy Honeybadger 404s caused by missing src paths referenced by distributed sourcemaps. Maintains existing runtime behavior and bundle contents.

## Launch Checklist

 - [X] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [X] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [X] Manually test the debug page.
 - [X] Write tests for all new functionality and make sure the CI checks pass.
 - [X] Document any changes to public APIs.
 - [X] Post benchmark scores if the change could affect performance.
 - [X] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [X] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [X] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [X] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.
