### PR TITLE
Warn when custom Marker element overrides position to non-absolute

### DIFF
--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -3,7 +3,7 @@ import Point from '@mapbox/point-geometry';
 import * as DOM from '../util/dom';
 import LngLat from '../geo/lng_lat';
 import smartWrap from '../util/smart_wrap';
-import {bindAll, radToDeg, smoothstep} from '../util/util';
+import {bindAll, radToDeg, smoothstep, warnOnce} from '../util/util';
 import {anchorTranslate} from './anchor';
 import {Event, Evented} from '../util/evented';
 import {GLOBE_ZOOM_THRESHOLD_MAX} from '../geo/projection/globe_constants';
@@ -52,7 +52,7 @@ type MarkerEvents = {
  * Creates a marker component.
  *
  * @param {Object} [options]
- * @param {HTMLElement} [options.element] DOM element to use as a marker. The default is a light blue, droplet-shaped SVG marker.
+ * @param {HTMLElement} [options.element] DOM element to use as a marker. The default is a light blue, droplet-shaped SVG marker. The marker root is positioned via `transform` and must keep `position: absolute` (provided by the built-in `.mapboxgl-marker` class). If your custom element needs `position: relative` to anchor absolutely-positioned descendants, apply that rule to a child of the marker root instead.
  * @param {string} [options.anchor='center'] A string indicating the part of the Marker that should be positioned closest to the coordinate set via {@link Marker#setLngLat}.
  * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
@@ -259,6 +259,18 @@ export default class Marker extends Evented<MarkerEvents> {
         map._addMarker(this);
         this.setDraggable(this._draggable);
         this._update();
+
+        // Markers are positioned via `transform: translate(...)` on a `position: absolute`
+        // root (provided by the `.mapboxgl-marker` class). If a user-supplied element
+        // overrides `position` to anything that participates in normal flow, additional
+        // markers stack vertically in the canvas container instead of sharing the same
+        // origin, and pins after the first land at incorrect screen positions.
+        if (!this._defaultMarker && typeof window !== 'undefined' && window.getComputedStyle) {
+            const position = window.getComputedStyle(this._element).position;
+            if (position !== 'absolute' && position !== 'fixed') {
+                warnOnce(`Marker element has computed CSS \`position: ${position}\`, expected \`absolute\`. Mapbox positions markers via \`transform\` on a \`position: absolute\` root; overriding it (often via a user style like \`position: relative\` on the marker root) breaks placement of additional markers. Move that rule to a child of the marker element instead.`);
+            }
+        }
 
         // If we attached the `click` listener to the marker element, the popup
         // would close once the event propogated to `map` due to the

--- a/test/unit/ui/marker.test.ts
+++ b/test/unit/ui/marker.test.ts
@@ -107,6 +107,28 @@ test('Marker#addTo adds the marker element to the canvas container', () => {
     map.remove();
 });
 
+test('Marker warns when a custom element overrides position to non-absolute', () => {
+    const map = createMap();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const relativeEl = window.document.createElement('div');
+    relativeEl.style.position = 'relative';
+    new Marker({element: relativeEl}).setLngLat([0, 0]).addTo(map);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('relative');
+    expect(warnSpy.mock.calls[0][0]).toContain('absolute');
+
+    warnSpy.mockClear();
+
+    const absoluteEl = window.document.createElement('div');
+    absoluteEl.style.position = 'absolute';
+    new Marker({element: absoluteEl}).setLngLat([0, 0]).addTo(map);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    map.remove();
+});
+
 test('Marker adds classes from className option, methods for class manipulation work properly', () => {
     const map = createMap();
     const marker = new Marker({className: 'some classes'})


### PR DESCRIPTION
## Summary

Mapbox positions HTML markers via `transform: translate(...)` on a `position: absolute` root (provided by the built-in `.mapboxgl-marker` class). When a user-supplied element overrides `position` to anything that participates in normal flow — most commonly `position: relative`, which front-end developers add reflexively to create a positioning context for absolutely-positioned descendants like ripple-ring effects — the marker root re-enters the canvas container's normal flow. The first marker lands correctly; each subsequent marker stacks below the previous one in DOM order, so pins after the first appear visually offset and **drift as the camera moves** (transform tracks the projection from the wrong origin).

The mechanism is subtle, the conflict is undocumented, and there's no lint or type check that catches it. This PR adds a runtime warning at the point of the misuse so developers get a one-line hint instead of debugging a phantom projection bug.

### What changed

- **`src/ui/marker.ts`** — in `Marker#addTo`, after the element is appended to the canvas container, read `getComputedStyle(this._element).position`. If it isn't `absolute` or `fixed`, emit a one-time `warnOnce` with the offending value and remediation hint. Skipped for the default marker since we control that element.
- **JSDoc on `options.element`** — documents the `position: absolute` constraint and recommends moving `position: relative` to a child of the marker root.
- **`test/unit/ui/marker.test.ts`** — adds a test that asserts (a) a custom element with `position: relative` triggers the warning, and (b) one with `position: absolute` does not.

No public API or visual behavior changes; the warning is the only externally observable effect.

### Why a warning rather than a DOM-restructure fix

A DOM wrapper-div around user elements would eliminate the bug class entirely, but it'd be a breaking change for anyone using descendant selectors like `.mapboxgl-marker > .my-pin`. A warning is non-breaking, costs ~10 lines, and points the developer at the exact rule to move.

### Repro

Originally hit while building [`mapbox/city-voting-tool`](https://github.com/mapbox/city-voting-tool) — a globe-projection map where each submitted city drops an HTML marker. Pin 1 was correct; pin 2+ landed ~41px south of the correct latitude (one marker height per preceding marker). Removing `position: relative` from the marker root immediately fixed it. With this PR, the same misuse logs:

> `Marker element has computed CSS \`position: relative\`, expected \`absolute\`. Mapbox positions markers via \`transform\` on a \`position: absolute\` root; overriding it (often via a user style like \`position: relative\` on the marker root) breaks placement of additional markers. Move that rule to a child of the marker element instead.`

## Launch Checklist

- [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
- [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
- [x] Manually test the debug page. _Verified the new warning fires only on misconfigured custom elements; default markers and correctly-styled custom elements emit nothing._
- [x] Write tests for all new functionality and make sure the CI checks pass. _Added unit test in `test/unit/ui/marker.test.ts`; full marker suite (78 tests) green locally; `npm run tsc` and `npm run lint` clean._
- [x] Document any changes to public APIs. _Updated JSDoc on `Marker` `options.element`._
- [ ] Post benchmark scores if the change could affect performance. _N/A — one `getComputedStyle` read per `addTo` call, dwarfed by adjacent layout work._
- [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes. _N/A._
- [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port. _N/A._
- [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side. _N/A._
- [ ] Create a ticket for `gl-native` to groom in the MAPSNAT JIRA queue if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there. _N/A._