### PR TITLE
Fix transparency in webm videos

### DIFF
--- a/src/source/video_source.ts
+++ b/src/source/video_source.ts
@@ -212,6 +212,7 @@ class VideoSource extends ImageSource<'video'> {
             this.width = this.video.videoWidth;
             this.height = this.video.videoHeight;
         } else if (!this.video.paused) {
+            context.pixelStoreUnpackPremultiplyAlpha.set(true);
             this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.video);
         }


### PR DESCRIPTION
## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [ ] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.


## Description
Fixes #12662 
Browser version: Chrome 148.0.7778.217 (Official Build) (64-bit)

Premultiplied alpha is correctly applied on the video texture's initial load, however, loading other textures would disable it and cause subsequent frames to render white at high transparency.
<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/ca8a7a9d-db69-43a4-b1be-9a4dd12580fe" />

Setting premultiplied alpha to true before each video frame is rendered gives the desired result.
<img width="1920" height="970" alt="image" src="https://github.com/user-attachments/assets/a918368b-d27e-45cc-9224-60735e4f1e27" />


