### PR TITLE
fix(number-format): honor min/max-fraction-digits of 0

### DIFF
--- a/src/style-spec/expression/definitions/number_format.ts
+++ b/src/style-spec/expression/definitions/number_format.ts
@@ -61,13 +61,13 @@ export default class NumberFormat implements Expression {
         }
 
         let minFractionDigits = null;
-        if (options['min-fraction-digits']) {
+        if (options['min-fraction-digits'] !== undefined) {
             minFractionDigits = context.parseObjectValue(options['min-fraction-digits'], 2, 'min-fraction-digits', NumberType);
             if (!minFractionDigits) return null;
         }
 
         let maxFractionDigits = null;
-        if (options['max-fraction-digits']) {
+        if (options['max-fraction-digits'] !== undefined) {
             maxFractionDigits = context.parseObjectValue(options['max-fraction-digits'], 2, 'max-fraction-digits', NumberType);
             if (!maxFractionDigits) return null;
         }

--- a/test/integration/expression-tests/number-format/max-fraction-digits-zero/test.json
+++ b/test/integration/expression-tests/number-format/max-fraction-digits-zero/test.json
@@ -1,0 +1,28 @@
+{
+  "expression": [
+    "number-format",
+    3.7,
+    {
+      "max-fraction-digits": ["get", "max"]
+    }
+  ],
+  "inputs": [
+    [{}, {"properties": {"max": 0}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "string"
+    },
+    "outputs": ["4"],
+    "serialized": [
+      "number-format",
+      3.7,
+      {
+        "max-fraction-digits": ["number", ["get", "max"]]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The `number-format` expression dropped `min-fraction-digits` and
`max-fraction-digits` when they were set to `0`.

At parse time the option is read with a truthiness check:

    if (options['max-fraction-digits']) { ... }

`0` is a valid value (the style spec documents `max-fraction-digits` as the
maximum number of fractional digits, and `0` is in range), but it is falsy, so
the option was silently ignored and never passed to the formatter.

Concrete case: `["number-format", 3.7, {"max-fraction-digits": 0}]` returned
`"3.7"` instead of `"4"`. Formatting a value as an integer is a common need for
style authors, and they got the wrong label text with no error.

The fix checks `!== undefined` for the two numeric options. String options are
left unchanged.

Added an expression test covering `max-fraction-digits` of 0.
