### PR TITLE
Fix removeSource throwing TypeError in Terrain.update under globe projection

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -4306,6 +4306,10 @@ class Style extends Evented<MapEvents> {
         this._force3DLayerUpdate();
         const parameters = this._getTransitionParameters({duration: 0});
         terrain.updateTransitions(parameters);
+        // Evaluate the terrain properties synchronously so that consumers such as
+        // Terrain#update can access them before the next Style#update runs (#13665).
+        const evaluationParameters = new EvaluationParameters(this.z || 0, {...parameters, worldview: this.map.getWorldview()});
+        terrain.recalculate(evaluationParameters);
     }
 
     _force3DLayerUpdate() {

--- a/test/unit/terrain/terrain.test.ts
+++ b/test/unit/terrain/terrain.test.ts
@@ -163,6 +163,13 @@ describe('Elevation', () => {
         });
     });
 
+    test('mapbox-gl-js#13665: removeSource before the first render under globe projection does not throw', async () => {
+        const map = createMap({projection: 'globe'});
+        await waitFor(map, 'style.load');
+        map.addSource('repro-src', {type: 'geojson', data: {type: 'FeatureCollection', features: []}});
+        expect(() => map.removeSource('repro-src')).not.toThrowError();
+    });
+
     test('style diff=false removes dem source', async () => {
         const map = createMap();
         await waitFor(map, "style.load");


### PR DESCRIPTION
Fixes #13665
Fixes #13703

## Summary

Calling `map.removeSource(id)` on a globe-projection map whose style has no terrain block throws `TypeError: Cannot read properties of undefined (reading 'get')` synchronously, originating in `Terrain.update`.

## Root cause

`Style#_createTerrain` left `terrain.properties` uninitialised — it was only assigned by `Terrain#recalculate`, which first runs when `Style#update` is called from `Map#_render`. Under globe projection, `setTerrainForDraping()` creates a terrain on style load, so `Map#removeSource` → `Map#_updateTerrain` → `Terrain#update` could dereference `terrainProps.get('source')` before the first render frame evaluated the properties.

## Fix

Evaluate the terrain properties synchronously in `Style#_createTerrain`, so they are always available to consumers regardless of whether a render frame has run yet.

## Testing

Added a unit test in `test/unit/terrain/terrain.test.ts` that reproduces the report (globe projection, style without terrain, `addSource` + `removeSource` before the first render). It fails with the exact `TypeError` from the issue without the fix and passes with it.

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [x] Manually test the debug page.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [ ] Create a ticket for `gl-native` to groom in the MAPSNAT JIRA queue if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.