### PR TITLE
Tag events/v2 telemetry with X-Mapbox-Agent during agent-driven test runs

### DIFF
--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -39,6 +39,13 @@ declare global {
     interface Window {
         showSaveFilePicker?: (options?: FilePickerOptions) => Promise<FileSystemFileHandle>;
         showOpenFilePicker?: (options?: FilePickerOptions) => Promise<FileSystemFileHandle[]>;
+
+        // Test-only: set by test/integration/lib/agent-forwarding.ts before
+        // any page script runs, when this repo's own test suite is driven by
+        // an AI coding agent. Read defensively by
+        // `TelemetryEvent.postEvent` (src/util/mapbox.ts) to tag the
+        // events/v2 request; never set outside that test driver.
+        __mapboxAgent?: string;
     }
 
     // Safari-only compass heading on device orientation events.

--- a/src/util/mapbox.ts
+++ b/src/util/mapbox.ts
@@ -474,11 +474,25 @@ export class TelemetryEvent {
         };
 
         const finalPayload = additionalPayload ? Object.assign(payload, additionalPayload) : payload;
+        const headers: Record<string, string> = {
+            'Content-Type': 'text/plain' //Skip the pre-flight OPTIONS request
+        };
+
+        // Test tooling only: when this repo's own test suite is driven by an
+        // AI coding agent (e.g. Claude Code, Codex, Cursor), the Playwright/
+        // Cypress test driver sets `window.__mapboxAgent` before any page
+        // script runs (see test/integration/lib/agent-forwarding.ts). Tag the
+        // request so agent-driven test traffic is visibly attributed
+        // server-side. `window` is guarded defensively as it is absent in
+        // worker contexts, and the property is never set outside of that
+        // test driver, so this is a no-op everywhere else (e.g. `npm run dev`).
+        if (typeof window !== 'undefined' && window.__mapboxAgent) {
+            headers['X-Mapbox-Agent'] = window.__mapboxAgent;
+        }
+
         const request: RequestParameters = {
             url: formatUrl(eventsUrlObject),
-            headers: {
-                'Content-Type': 'text/plain' //Skip the pre-flight OPTIONS request
-            },
+            headers,
             body: JSON.stringify([finalPayload])
         };
 

--- a/test/integration/lib/agent-forwarding.ts
+++ b/test/integration/lib/agent-forwarding.ts
@@ -1,0 +1,157 @@
+// Test-only tooling. Detects the AI coding agent (if any) driving the
+// Node process that runs this repo's own test suite (Playwright/Cypress via
+// Vitest Browser Mode), and forwards the detected id into the browser page
+// as `window.__mapboxAgent` before any page script runs, so that
+// `TelemetryEvent.postEvent` (src/util/mapbox.ts) can tag the events/v2
+// request it fires during an agent-driven verification run of this repo.
+//
+// This module must never be imported by production GL JS code or bundled
+// into the shipped library - it is wired in only from the Vitest browser
+// config files (vitest.config.render.ts, vitest.config.query.ts).
+//
+// Ported from mapbox-sdk-js's `lib/helpers/agent-detect.js` (merged as
+// mapbox/mapbox-sdk-js#509) - kept in sync with that implementation and with
+// the Python sibling `agent_detect.py` in mapbox/tilesets-cli. Same
+// allowlist, same precedence order.
+
+import type {Plugin, HtmlTagDescriptor} from 'vite';
+
+// A safe charset for an agent id that ends up in a header/inline script: env
+// vars are not validated by whoever sets them, so a value like
+// "foo\nbar: injected" must be rejected here rather than being handed to the
+// page as an unvalidated string.
+const SAFE_FALLBACK_ID = /^[\w.-]{1,64}$/;
+
+type EnvCondition = [envVar: string, expectedValue: string | null];
+type AllowlistEntry = [agentId: string, conditions: EnvCondition[]];
+
+// (agentId, [[envVar, expectedValueOrNull], ...]) - table order is
+// precedence order; the first entry with any matching condition wins.
+// expectedValue null means a presence check (the key exists in
+// process.env with a non-empty, non-whitespace value); otherwise an exact
+// equality check.
+//
+// Keep this table in sync with mapbox-sdk-js's `lib/helpers/agent-detect.js`
+// and tilesets-cli's `agent_detect.py`. Canonical origin: HuggingFace's
+// public `agent-harnesses.ts` registry.
+const ALLOWLIST: AllowlistEntry[] = [
+    ['antigravity', [['ANTIGRAVITY_AGENT', null]]],
+    ['augment-cli', [['AUGMENT_AGENT', null]]],
+    ['cline', [['CLINE_ACTIVE', null]]],
+    ['cowork', [['CLAUDE_CODE_IS_COWORK', null]]],
+    ['claude-code', [['CLAUDECODE', null], ['CLAUDE_CODE', null]]],
+    ['codex', [['CODEX_SANDBOX', null], ['CODEX_CI', null], ['CODEX_THREAD_ID', null]]],
+    ['crush', [['CRUSH', null]]],
+    ['gemini-cli', [['GEMINI_CLI', null]]],
+    ['github-copilot', [['COPILOT_MODEL', null], ['COPILOT_ALLOW_ALL', null], ['COPILOT_GITHUB_TOKEN', null]]],
+    ['goose', [['GOOSE_TERMINAL', null]]],
+    ['hermes-agent', [['HERMES_SESSION_ID', null]]],
+    ['kilo-code', [['KILOCODE_FEATURE', null]]],
+    ['kiro', [['AGENT_CONTEXT_OUT', null]]],
+    ['openclaw', [['OPENCLAW_SHELL', null]]],
+    ['opencode', [['OPENCODE_CLIENT', null]]],
+    ['pi', [['PI_CODING_AGENT', null]]],
+    ['replit', [['REPL_ID', null]]],
+    ['trae', [['TRAE_AI_SHELL_ID', null]]],
+    ['vtcode', [['VTCODE', '1']]],
+    ['warp', [['TERM_PROGRAM', 'WarpTerminal']]],
+    ['zed', [['ZED_TERM', null]]],
+    ['cursor-cli', [['CURSOR_AGENT', null]]],
+    ['cursor', [['CURSOR_TRACE_ID', null]]]
+];
+
+// Checked only if nothing in ALLOWLIST matched. First one with a non-empty
+// (after trimming) value matching SAFE_FALLBACK_ID wins; an unsafe or empty
+// value falls through to the next var rather than being returned as-is.
+const FALLBACK_VARS = ['AI_AGENT', 'AGENT'];
+
+// Scans `env` for a matching agent indicator. Split out from `detectAgent`
+// so the individual key reads below (which could throw in an environment
+// where `process.env` is a permission-gated Proxy) are covered by a single
+// try/catch there, rather than one bare `typeof process` guard that only
+// checks the top-level object.
+function scanEnv(env: NodeJS.ProcessEnv): string | null {
+    for (const [agentId, conditions] of ALLOWLIST) {
+        for (const [envVar, expected] of conditions) {
+            if (expected === null) {
+                if ((env[envVar] || '').trim()) {
+                    return agentId;
+                }
+            } else if (env[envVar] === expected) {
+                return agentId;
+            }
+        }
+    }
+
+    for (const fallbackVar of FALLBACK_VARS) {
+        const value = (env[fallbackVar] || '').trim();
+        if (value && SAFE_FALLBACK_ID.test(value)) {
+            return value;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Detect the AI coding agent (if any) driving this process, from
+ * `process.env`. Node-only.
+ *
+ * Never reads or logs the full environment - only the matched id is used.
+ * Never throws: any error while reading `process.env` is treated as "no
+ * agent detected" rather than propagating out and breaking the test run.
+ *
+ * There is no `'unknown'` sentinel: when nothing matches, this returns
+ * `null` so that callers can omit any agent tagging entirely rather than
+ * emitting a misleading placeholder value.
+ */
+export function detectAgent(): string | null {
+    // The `process.env` accesses below (including the guard itself) must
+    // all be inside this try: in an environment where `process.env` is a
+    // permission-gated Proxy, even reading `process.env` to check it can
+    // throw, not just reading an individual key.
+    try {
+        if (typeof process === 'undefined' || !process.env) {
+            return null;
+        }
+        return scanEnv(process.env);
+    } catch (error) {
+        return null;
+    }
+}
+
+/**
+ * The HTML tags to inject into the Vitest Browser Mode tester page for the
+ * detected agent (if any). Equivalent to a raw Playwright test's
+ * `page.addInitScript(() => { window.__mapboxAgent = '<id>' })` called
+ * before navigation: `agentForwardingPlugin` injects the returned script at
+ * the very start of `<head>` so `window.__mapboxAgent` is set before any
+ * other page script (including the GL JS bundle under test) runs.
+ *
+ * When no agent is detected, this returns an empty array: no script tag is
+ * injected and `window.__mapboxAgent` is never set, so `postEvent`'s
+ * behavior is unchanged from today. Split out from `agentForwardingPlugin`
+ * so it can be unit-tested directly, without going through Vite's plugin
+ * machinery.
+ */
+export function agentForwardingTags(): HtmlTagDescriptor[] {
+    const agentId = detectAgent();
+    if (!agentId) return [];
+
+    return [{
+        tag: 'script',
+        injectTo: 'head-prepend',
+        children: `window.__mapboxAgent = ${JSON.stringify(agentId)};`
+    }];
+}
+
+/**
+ * Vite plugin that forwards the detected agent id into the Vitest Browser
+ * Mode tester page. See `agentForwardingTags` for the injected content.
+ */
+export function agentForwardingPlugin(): Plugin {
+    return {
+        name: 'agent-forwarding',
+        transformIndexHtml: agentForwardingTags
+    };
+}

--- a/test/unit/util/agent-forwarding.test.ts
+++ b/test/unit/util/agent-forwarding.test.ts
@@ -1,0 +1,180 @@
+import {describe, test, expect, afterEach, vi} from 'vitest';
+import {detectAgent, agentForwardingTags, agentForwardingPlugin} from '../../integration/lib/agent-forwarding';
+
+// `process` is stubbed rather than relying on the ambient Node global: this
+// test suite runs in Vitest Browser Mode (see vitest.config.unit.ts), so
+// `process` is not the real Node process from the driving CLI - stubbing it
+// exercises `detectAgent`'s logic against a controlled `env` object without
+// depending on (or leaking) the actual test-runner's environment.
+function withEnv(env: Record<string, string>) {
+    vi.stubGlobal('process', {env});
+}
+
+describe('detectAgent', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('returns null when process is unavailable', () => {
+        vi.stubGlobal('process', undefined);
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('returns null when process.env is unavailable', () => {
+        vi.stubGlobal('process', {});
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('returns null when nothing in the environment matches', () => {
+        withEnv({PATH: '/usr/bin', SHELL: '/bin/zsh'});
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('detects Claude Code via CLAUDECODE', () => {
+        withEnv({CLAUDECODE: '1'});
+        expect(detectAgent()).toBe('claude-code');
+    });
+
+    test('detects Claude Code via CLAUDE_CODE fallback within the same entry', () => {
+        withEnv({CLAUDE_CODE: 'true'});
+        expect(detectAgent()).toBe('claude-code');
+    });
+
+    test('distinguishes Cowork (Claude Code wrapper) from plain Claude Code by precedence', () => {
+        // cowork's entry precedes claude-code's in the allowlist, and both
+        // env vars can be present simultaneously in that harness.
+        withEnv({CLAUDE_CODE_IS_COWORK: '1', CLAUDECODE: '1'});
+        expect(detectAgent()).toBe('cowork');
+    });
+
+    test('detects Codex via any of its three indicators', () => {
+        withEnv({CODEX_SANDBOX: '1'});
+        expect(detectAgent()).toBe('codex');
+        withEnv({CODEX_CI: '1'});
+        expect(detectAgent()).toBe('codex');
+        withEnv({CODEX_THREAD_ID: 'abc123'});
+        expect(detectAgent()).toBe('codex');
+    });
+
+    test('detects Cursor CLI ahead of plain Cursor by table order', () => {
+        withEnv({CURSOR_AGENT: '1', CURSOR_TRACE_ID: 'trace-1'});
+        expect(detectAgent()).toBe('cursor-cli');
+    });
+
+    test('detects plain Cursor when only CURSOR_TRACE_ID is present', () => {
+        withEnv({CURSOR_TRACE_ID: 'trace-1'});
+        expect(detectAgent()).toBe('cursor');
+    });
+
+    test('detects GitHub Copilot via any of its indicators', () => {
+        withEnv({COPILOT_GITHUB_TOKEN: 'token'});
+        expect(detectAgent()).toBe('github-copilot');
+    });
+
+    test('detects Replit via REPL_ID', () => {
+        withEnv({REPL_ID: 'repl-123'});
+        expect(detectAgent()).toBe('replit');
+    });
+
+    test('requires an exact value match for vtcode', () => {
+        withEnv({VTCODE: '0'});
+        expect(detectAgent()).toBeNull();
+        withEnv({VTCODE: '1'});
+        expect(detectAgent()).toBe('vtcode');
+    });
+
+    test('requires an exact value match for warp', () => {
+        withEnv({TERM_PROGRAM: 'iTerm.app'});
+        expect(detectAgent()).toBeNull();
+        withEnv({TERM_PROGRAM: 'WarpTerminal'});
+        expect(detectAgent()).toBe('warp');
+    });
+
+    test('treats a whitespace-only presence value as absent', () => {
+        withEnv({CLAUDECODE: '   '});
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('falls back to AI_AGENT when nothing in the allowlist matched', () => {
+        withEnv({AI_AGENT: 'my-custom-agent'});
+        expect(detectAgent()).toBe('my-custom-agent');
+    });
+
+    test('falls back to AGENT when AI_AGENT is absent', () => {
+        withEnv({AGENT: 'another-agent'});
+        expect(detectAgent()).toBe('another-agent');
+    });
+
+    test('prefers AI_AGENT over AGENT', () => {
+        withEnv({AI_AGENT: 'first', AGENT: 'second'});
+        expect(detectAgent()).toBe('first');
+    });
+
+    test('allowlist entries win over the fallback vars', () => {
+        withEnv({CLAUDECODE: '1', AI_AGENT: 'should-be-ignored'});
+        expect(detectAgent()).toBe('claude-code');
+    });
+
+    test('rejects an empty fallback value', () => {
+        withEnv({AI_AGENT: ''});
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('rejects a fallback value containing unsafe characters (e.g. an embedded newline)', () => {
+        withEnv({AI_AGENT: 'agent\nX-Injected: true'});
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('rejects a fallback value exceeding the 64-character safe length', () => {
+        withEnv({AI_AGENT: 'a'.repeat(65)});
+        expect(detectAgent()).toBeNull();
+    });
+
+    test('accepts a fallback value with dots, dashes and underscores', () => {
+        withEnv({AI_AGENT: 'my-agent_v1.2'});
+        expect(detectAgent()).toBe('my-agent_v1.2');
+    });
+
+    test('falls through to AGENT when AI_AGENT is unsafe', () => {
+        withEnv({AI_AGENT: 'bad value with spaces', AGENT: 'good-value'});
+        expect(detectAgent()).toBe('good-value');
+    });
+
+    test('never throws when process.env access itself throws', () => {
+        vi.stubGlobal('process', {
+            get env() {
+                throw new Error('permission denied');
+            }
+        });
+        expect(() => detectAgent()).not.toThrow();
+        expect(detectAgent()).toBeNull();
+    });
+});
+
+describe('agentForwardingTags', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('injects window.__mapboxAgent as the first thing in <head> when an agent is detected', () => {
+        withEnv({CLAUDECODE: '1'});
+        expect(agentForwardingTags()).toEqual([{
+            tag: 'script',
+            injectTo: 'head-prepend',
+            children: 'window.__mapboxAgent = "claude-code";'
+        }]);
+    });
+
+    test('injects nothing (not "unknown") when no agent is detected', () => {
+        withEnv({});
+        expect(agentForwardingTags()).toEqual([]);
+    });
+});
+
+describe('agentForwardingPlugin', () => {
+    test('wires agentForwardingTags up as a named Vite plugin', () => {
+        const plugin = agentForwardingPlugin();
+        expect(plugin.name).toEqual('agent-forwarding');
+        expect(plugin.transformIndexHtml).toBe(agentForwardingTags);
+    });
+});

--- a/test/unit/util/mapbox.test.ts
+++ b/test/unit/util/mapbox.test.ts
@@ -596,6 +596,37 @@ describe("mapbox", () => {
         });
     });
 
+    describe('postEvent X-Mapbox-Agent header', () => {
+        afterEach(() => {
+            delete window.__mapboxAgent;
+        });
+
+        test('adds the header when window.__mapboxAgent is set (e.g. by the test-only agent-forwarding driver)', async () => {
+            window.__mapboxAgent = 'claude-code';
+            const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new window.Response());
+            const event = new mapbox.TelemetryEvent('map.load');
+
+            await new Promise<void>((resolve) => {
+                event.postEvent(Date.now(), {}, () => resolve());
+            });
+
+            const request = fetchSpy.mock.calls[0][0] as Request;
+            expect(request.headers.get('X-Mapbox-Agent')).toEqual('claude-code');
+        });
+
+        test('omits the header entirely (never sends "unknown") when window.__mapboxAgent is not set', async () => {
+            const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new window.Response());
+            const event = new mapbox.TelemetryEvent('map.load');
+
+            await new Promise<void>((resolve) => {
+                event.postEvent(Date.now(), {}, () => resolve());
+            });
+
+            const request = fetchSpy.mock.calls[0][0] as Request;
+            expect(request.headers.has('X-Mapbox-Agent')).toBe(false);
+        });
+    });
+
     describe('self-hosted telemetry suppression', () => {
         function makeExpirationToken(expiration: number): string {
             const header = btoa(JSON.stringify({typ: 'JWT', alg: 'ES256'}));

--- a/vitest.config.query.ts
+++ b/vitest.config.query.ts
@@ -1,6 +1,7 @@
 import {mergeConfig, defineConfig} from 'vitest/config';
 import baseConfig, {isCI, chromiumBrowser} from './vitest.config.base';
 import {integrationTests, setupIntegrationTestsMiddlewares, serveDistPlugin, suiteDirs} from './vitest.config.common';
+import {agentForwardingPlugin} from './test/integration/lib/agent-forwarding';
 
 export default mergeConfig(baseConfig, defineConfig({
     define: {
@@ -28,5 +29,6 @@ export default mergeConfig(baseConfig, defineConfig({
         }),
         integrationTests({suiteDirs: suiteDirs('query-tests')}),
         serveDistPlugin(),
+        agentForwardingPlugin(),
     ],
 }));

--- a/vitest.config.render.ts
+++ b/vitest.config.render.ts
@@ -3,6 +3,7 @@ import {mergeConfig, defineConfig} from 'vitest/config';
 import {playwright} from '@vitest/browser-playwright';
 import baseConfig, {isCI, chromiumBrowser} from './vitest.config.base';
 import {integrationTests, setupIntegrationTestsMiddlewares, serveDistPlugin, suiteDirs} from './vitest.config.common';
+import {agentForwardingPlugin} from './test/integration/lib/agent-forwarding';
 
 import type {BrowserConfigOptions} from 'vitest/node';
 
@@ -56,5 +57,6 @@ export default mergeConfig(baseConfig, defineConfig({
         }),
         integrationTests({suiteDirs: suiteDirs('render-tests'), includeImages: true}),
         serveDistPlugin(),
+        agentForwardingPlugin(),
     ],
 }));


### PR DESCRIPTION
This adds test-only tooling that lets this repo's own test suite tag the telemetry `events/v2` request it fires when running under an AI coding agent (Claude Code, Codex, Cursor, etc.), so agent-driven test/CI traffic can be told apart from normal usage.

Browsers won't let scripts set the `User-Agent` header, and GL JS running in a page has no way to know it's being driven by a coding agent: that signal only exists in the Node process running the Playwright/Vitest test driver, via env vars the agent sets (e.g. `CLAUDECODE` for Claude Code). To get that signal from Node into the browser:

- `test/integration/lib/agent-forwarding.ts` (new, test-only) checks `process.env` against an allowlist of about 20 known agent env-var indicators, first match wins by table order, with a validated fallback to a generic `AI_AGENT`/`AGENT` env var. It never throws. If nothing matches, it returns nothing rather than a vague `"unknown"`, so no header gets sent.
- A small Vite `transformIndexHtml` plugin, wired into the render and query integration test configs, forwards that id into the browser as `window.__mapboxAgent` before any other page script runs (same idea as a Playwright `page.addInitScript`).
- `TelemetryEvent.postEvent` (`src/util/mapbox.ts`) reads `window.__mapboxAgent` defensively and, if it's present, adds an `X-Mapbox-Agent` header to the events/v2 request.

`agent-forwarding.ts` is never imported by production code and isn't part of the shipped bundle. The `postEvent` change is a no-op anywhere `window.__mapboxAgent` isn't set (`npm run dev`, a consuming app, or a worker context without `window`), so behavior there is unchanged.

## Testing

- Unit tests cover the agent-detection logic (allowlist precedence, exact-match vs. presence-check entries, charset validation on the fallback env vars, and the never-throws/no-"unknown" guarantees) and `postEvent` (header added when `window.__mapboxAgent` is set, absent otherwise).
- `npm run lint`, `npm run test-typings`, and `npm run test-unit` pass locally.
- I couldn't run the full browser-driven render/query integration suite in my environment (needs a built `dist` bundle and a real browser session), so an actual end-to-end capture of the header on an `events/v2` request is unverified beyond the unit tests above.

## Downstream impact

None for consuming applications: this only touches this repo's own test tooling and adds one conditional header to a telemetry request that's already unauthenticated and opt-in via access token configuration.

## Operational considerations

The `X-Mapbox-Agent` header won't be visible/actionable server-side until the events ingestion endpoint is updated to accept and record it (tracked separately, outside this repo).

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [ ] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.
