### PR TITLE
fix: disable compass interaction on non-interactive maps

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -865,3 +865,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 .mapboxgl-ctrl button.mapboxgl-ctrl-level-button-selected:hover {
     background-color: #ccc;
 }
+
+.mapboxgl-ctrl button.mapboxgl-ctrl-compass:disabled .mapboxgl-ctrl-icon {
+    opacity: 1;
+}

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -70,7 +70,7 @@ class NavigationControl implements IControl {
             ], this);
             this._compass = this._createButton('mapboxgl-ctrl-compass', (e) => {
                 const map = this._map;
-                if (!map) return;
+                if (!map || !map._interactive) return;
                 if (this.options.visualizePitch) {
                     map.resetNorthPitch({}, {originalEvent: e});
                 } else {
@@ -120,12 +120,14 @@ class NavigationControl implements IControl {
         }
         if (this.options.showCompass) {
             this._setButtonTitle(this._compass, 'ResetBearing');
+            this._compass.disabled = !map._interactive;
+            if (!map._interactive) this._compassIcon.removeAttribute('title');
             if (this.options.visualizePitch) {
                 map.on('pitch', this._rotateCompassArrow);
             }
             map.on('rotate', this._rotateCompassArrow);
             this._rotateCompassArrow();
-            this._handler = new MouseRotateWrapper(map, this._compass, this.options.visualizePitch);
+            if (map._interactive) this._handler = new MouseRotateWrapper(map, this._compass, this.options.visualizePitch);
         }
         return this._container;
     }

--- a/test/unit/ui/control/navigation_control.test.ts
+++ b/test/unit/ui/control/navigation_control.test.ts
@@ -5,7 +5,7 @@ import NavigationControl from '../../../../src/ui/control/navigation_control';
 import simulate from '../../../util/simulate_interaction';
 
 describe('NavigationControl', () => {
-    describe('compass drag', () => {
+    describe('compass interaction', () => {
         test('mouse drag on compass updates bearing', () => {
             const map = createMap({interactive: true});
             const nav = new NavigationControl({showCompass: true});
@@ -70,6 +70,31 @@ describe('NavigationControl', () => {
             simulate.mouseup(window.document, {button: 0, buttons: 0});
 
             expect(setPitchSpy).not.toHaveBeenCalled();
+
+            map.remove();
+        });
+
+        test('compass does not respond when the map is non-interactive', () => {
+            const map = createMap({interactive: false, bearing: 30});
+            const nav = new NavigationControl({showCompass: true});
+            map.addControl(nav);
+
+            const compass = map.getContainer().querySelector('.mapboxgl-ctrl-compass');
+            expect(compass).toBeTruthy();
+            expect(compass.disabled).toBe(true);
+            expect(compass.firstElementChild.hasAttribute('title')).toBe(false);
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            simulate.click(compass);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            simulate.mousedown(compass, {button: 0, buttons: 1, clientX: 0, clientY: 0});
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            simulate.mousemove(window.document, {buttons: 1, clientX: 10, clientY: 0});
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            simulate.mouseup(window.document, {button: 0, buttons: 0});
+
+            expect(map.getBearing()).toBe(30);
+            expect(map.isEasing()).toBe(false);
 
             map.remove();
         });


### PR DESCRIPTION
Fixes #8618

Disables the navigation compass when `interactive: false`, prevents both reset and drag interactions, removes the misleading hover tooltip, and preserves the compass as a fully visible bearing indicator.

## Launch Checklist

 - [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
   - The disabled compass intentionally keeps its existing visual opacity, so no screenshot is needed.
 - [ ] Manually test the debug page.
   - Not run; the behavior is covered by the focused browser unit test.
 - [x] Write tests for all new functionality and make sure the CI checks pass.
   - `CI=true npm run test-unit -- test/unit/ui/control/navigation_control.test.ts`
   - `npm run tsc`
   - `npm run lint`
   - `npm run lint-css`
 - [x] Document any changes to public APIs.
   - N/A — this changes existing `interactive: false` behavior without adding or changing an API.
 - [x] Post benchmark scores if the change could affect performance.
   - N/A — the change only skips compass event setup for non-interactive maps.
 - [x] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
   - N/A — there is no style-spec API or visual design change.
 - [x] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
   - N/A — there are no shader changes and no native port is needed.
 - [x] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
   - N/A — no tests are disabled.
 - [x] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.
   - N/A — this PR has no shader changes, native feature work, or disabled tests.
