### PR TITLE
Increase map control button target sizes to 44px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes 🐞
 
+- Improve accessibility of standard map control buttons by increasing their pointer target size
 - Fix raster-array out of bounds assertion error for non-mecator projections
 - Fix error when object-property strings were used in expressions
 - Fix wrong access token used on multi-map environments

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -97,8 +97,8 @@
 }
 
 .mapboxgl-ctrl-group button {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     display: block;
     padding: 0;
     outline: none;


### PR DESCRIPTION
## Summary

This PR increases the pointer target size of buttons inside `.mapboxgl-ctrl-group` from 32×32px to 44×44px.

This applies to:

* NavigationControl zoom and compass buttons
* GeolocateControl
* FullscreenControl
* IndoorControl

The visual size of the icons remains unchanged.

Partially addresses #11037.

## Scope

This PR only updates buttons that share the `.mapboxgl-ctrl-group button` styles.

The following targets from #11037 are intentionally left for separate changes:

* Attribution control
* Popup close button
* Marker

## Testing

Automated checks:

* `npm run lint-css`
* `npm run tsc`
* `npm run lint`
* `git diff --check`

Manual testing:

* Verified that Zoom in, Zoom out, Compass, Geolocate, and Fullscreen buttons have a 44×44px bounding box.
* Verified click interactions for the affected standard controls and IndoorControl floor buttons.
* Verified keyboard focus and Tab navigation.
* Verified Compass click and drag interactions.
* Verified the controls at a 320px viewport width.
* Verified that IndoorControl floor buttons have a 44×44px bounding box and remain operable.
* Confirmed that the icons are not visually enlarged.

No automated test was added because the existing unit tests do not load the production CSS or measure rendered element dimensions. The resulting 44×44px bounding boxes were verified manually in the browser using `getBoundingClientRect()`.

## Screenshots

### Standard controls at a 320px viewport

<img width="321" alt="Standard map controls at a 320px viewport width" src="https://github.com/user-attachments/assets/73fa85da-2d1f-4e43-a4b2-10ed71329192" />

### IndoorControl

<img width="600" alt="IndoorControl floor buttons and navigation controls with 44px pointer targets" src="https://github.com/user-attachments/assets/0d9d000d-8c06-41ac-81fa-244df8b231f4" />

## Additional notes

Custom controls that place buttons inside `.mapboxgl-ctrl-group` will also inherit the new 44×44px dimensions.

There are no public API, performance, shader, or Mapbox GL Native changes.

cc @mapbox/map-design-team @mapbox/static-apis

## Launch Checklist

* [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
* [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
* [x] Manually test the debug page.
* [ ] Write tests for all new functionality and make sure the CI checks pass.
* [x] Document any changes to public APIs.
* [x] Post benchmark scores if the change could affect performance.
* [x] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
* [x] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
* [x] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
* [x] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.