### PR TITLE
Fix terrain projection with orthographic cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Reduce redundant repaints and checks during initial load.
 
 ### Bug fixes 🐞
+- Fix inaccurate coordinate projection and feature queries when terrain is used with an orthographic camera projection.
 - Fix double rotation of the FF5C character in vertical text rendering.
 - Preserve live gesture when camera setter is called from inside a drag/move handler.
 - Stop overwriting the `pointerEvents` of markers set by the user.

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -131,9 +131,15 @@ class Transform {
     // Same as projMatrix, pixel-aligned to avoid fractional pixels for raster tiles
     alignedProjMatrix: mat4;
 
-    // From world coordinates to screen pixel coordinates (projMatrix premultiplied by labelPlaneMatrix)
+    // From world coordinates to screen pixel coordinates using the perspective projection.
+    // Flat-map interactions intentionally keep this projection when the camera is orthographic.
     pixelMatrix: mat4;
     pixelMatrixInverse: mat4;
+
+    // From world coordinates to screen pixel coordinates using the render projection.
+    // Terrain projection and raycasting use this matrix so elevated geometry stays aligned.
+    terrainPixelMatrix: mat4;
+    terrainPixelMatrixInverse: mat4;
 
     worldToFogMatrix!: mat4;
     skyboxMatrix: mat4;
@@ -286,6 +292,8 @@ class Transform {
         this.glCoordMatrix = new Float32Array(16);
         this.pixelMatrix = new Float64Array(16);
         this.pixelMatrixInverse = new Float64Array(16);
+        this.terrainPixelMatrix = new Float64Array(16);
+        this.terrainPixelMatrixInverse = new Float64Array(16);
     }
 
     clone(): Transform {
@@ -2009,7 +2017,7 @@ class Transform {
     _coordinatePoint(coord: MercatorCoordinate, sampleTerrainIn3D: boolean): Point {
         const elevation = sampleTerrainIn3D && this.elevation ? this.elevation.getAtPointOrZero(coord, this._centerAltitude) : this._centerAltitude;
         const p: [number, number, number, number] = [coord.x * this.worldSize, coord.y * this.worldSize, elevation + coord.toAltitude(), 1];
-        vec4.transformMat4(p, p, this.pixelMatrix);
+        vec4.transformMat4(p, p, sampleTerrainIn3D && this.elevation ? this.terrainPixelMatrix : this.pixelMatrix);
         return p[3] > 0 ?
             new Point(p[0] / p[3], p[1] / p[3]) :
             new Point(Number.MAX_VALUE, Number.MAX_VALUE);
@@ -2647,12 +2655,14 @@ class Transform {
 
         // matrix for conversion from location to screen coordinates
         mat4.multiply(this.pixelMatrix, this.labelPlaneMatrix, worldToClipPerspective);
+        mat4.multiply(this.terrainPixelMatrix, this.labelPlaneMatrix, m);
 
         this._calcFogMatrices();
         this._distanceTileDataCache = {};
 
         // inverse matrix for conversion from screen coordinates to location
         if (!mat4.invert(this.pixelMatrixInverse, this.pixelMatrix)) throw new Error("failed to invert matrix");
+        if (!mat4.invert(this.terrainPixelMatrixInverse, this.terrainPixelMatrix)) throw new Error("failed to invert terrain matrix");
 
         if (this.projection.name === 'globe' || this.mercatorFromTransition) {
             this.globeMatrix = calculateGlobeMatrix(this);

--- a/src/terrain/terrain.ts
+++ b/src/terrain/terrain.ts
@@ -1514,14 +1514,22 @@ export class Terrain extends Elevation {
         }
 
         const far: [number, number, number, number] = [screenPoint.x, screenPoint.y, 1, 1];
-        vec4.transformMat4(far, far, transform.pixelMatrixInverse);
+        vec4.transformMat4(far, far, transform.isOrthographic ? transform.terrainPixelMatrixInverse : transform.pixelMatrixInverse);
         vec4.scale(far, far, 1.0 / far[3]);
         // x & y in pixel coordinates, z is altitude in meters
         far[0] /= transform.worldSize;
         far[1] /= transform.worldSize;
-        const camera = transform._camera.position;
         const mercatorZScale = mercatorZfromAltitude(1, transform.center.lat);
-        const p: [number, number, number, number] = [camera[0], camera[1], camera[2] / mercatorZScale, 0.0];
+        let p: [number, number, number, number];
+        if (transform.isOrthographic) {
+            const near: [number, number, number, number] = [screenPoint.x, screenPoint.y, 0, 1];
+            vec4.transformMat4(near, near, transform.terrainPixelMatrixInverse);
+            vec4.scale(near, near, 1.0 / near[3]);
+            p = [near[0] / transform.worldSize, near[1] / transform.worldSize, near[2], 0.0];
+        } else {
+            const camera = transform._camera.position;
+            p = [camera[0], camera[1], camera[2] / mercatorZScale, 0.0];
+        }
         const dir = vec3.subtract([], far.slice(0, 3), p);
         vec3.normalize(dir, dir);
 

--- a/test/unit/geo/transform.test.ts
+++ b/test/unit/geo/transform.test.ts
@@ -9,7 +9,7 @@ import {FAR_TL, FAR_TR} from '../../../src/util/primitives';
 import {fixedNum, fixedLngLat, fixedCoord, fixedPoint, fixedVec3, fixedVec4} from '../../util/fixed';
 import {FreeCameraOptions} from '../../../src/ui/free_camera';
 import MercatorCoordinate, {mercatorZfromAltitude, altitudeFromMercatorZ, MAX_MERCATOR_LATITUDE} from '../../../src/geo/mercator_coordinate';
-import {vec3, quat} from 'gl-matrix';
+import {vec3, vec4, mat4, quat} from 'gl-matrix';
 import {degToRad, radToDeg} from '../../../src/util/util';
 
 describe('transform', () => {
@@ -53,6 +53,41 @@ describe('transform', () => {
         const transform = new Transform();
         transform.resize(500, 500);
         transform.center = {lng: 50, lat: -90};
+    });
+
+    test('projects terrain with the rendered camera projection', () => {
+        const transform = new Transform();
+        transform.resize(400, 300);
+        transform.zoom = 12;
+        transform.pitch = 10;
+        transform.bearing = 30;
+        transform.setOrthographicProjectionAtLowPitch(true);
+
+        const lngLat = new LngLat(0.01, 0.01);
+        const flatPoint = transform.locationPoint3D(lngLat);
+        transform._elevation = {getAtPointOrZero: () => 5000};
+
+        const coordinate = transform.locationCoordinate(lngLat);
+        const worldPoint: [number, number, number, number] = [
+            coordinate.x * transform.worldSize,
+            coordinate.y * transform.worldSize,
+            5000,
+            1
+        ];
+        const renderedPixelMatrix = mat4.multiply([], transform.labelPlaneMatrix, transform.projMatrix);
+        vec4.transformMat4(worldPoint, worldPoint, renderedPixelMatrix);
+        const renderedPoint = new Point(worldPoint[0] / worldPoint[3], worldPoint[1] / worldPoint[3]);
+
+        expect(transform.locationPoint3D(lngLat)).toEqual(renderedPoint);
+
+        transform._elevation = null;
+        expect(transform.locationPoint3D(lngLat)).toEqual(flatPoint);
+
+        transform.setOrthographicProjectionAtLowPitch(false);
+        transform._elevation = {getAtPointOrZero: () => 5000};
+        const perspectivePoint = transform.locationPoint3D(lngLat);
+        transform._elevation = null;
+        expect(transform.locationPoint3D(lngLat, 5000)).toEqual(perspectivePoint);
     });
 
     test('setLocationAt', () => {

--- a/test/unit/terrain/terrain.test.ts
+++ b/test/unit/terrain/terrain.test.ts
@@ -32,6 +32,7 @@ import {Map, AVERAGE_ELEVATION_SAMPLING_INTERVAL, AVERAGE_ELEVATION_EASE_TIME} f
 import {createConstElevationDEM, setMockElevationTerrain} from '../../util/dem_mock';
 import RasterDEMTileSource from '../../../src/source/raster_dem_tile_source';
 import vectorStub from '../../util/fixtures/10/301/384.pbf?arraybuffer';
+import {mat4, vec4} from 'gl-matrix';
 
 function createStyle() {
     return {
@@ -1053,6 +1054,43 @@ describe('Drag pan ortho', () => {
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         map.remove();
+    });
+
+    test('orthographic terrain projection and raycast stay aligned', async () => {
+        mockDem(createConstElevationDEM(1000, TILE_SIZE), cache);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const terrainMap: Map = map;
+        terrainMap.setTerrain({"source": "mapbox-dem"});
+        terrainMap.setZoom(12);
+        terrainMap.setPitch(10);
+        terrainMap.setCamera({"camera-projection": "orthographic"});
+        await waitFor(terrainMap, "render");
+        terrainMap._updateTerrain();
+
+        const lngLat = new LngLat(0.01, 0.01);
+        terrainMap.addSource('point', {
+            type: 'geojson',
+            data: {type: 'Point', coordinates: lngLat.toArray()}
+        });
+        terrainMap.addLayer({
+            id: 'circle',
+            type: 'circle',
+            source: 'point',
+            paint: {'circle-radius': 3}
+        });
+        await waitFor(terrainMap, 'idle');
+
+        const transform = terrainMap.transform;
+        const coordinate = transform.locationCoordinate(lngLat);
+        const worldPoint = [coordinate.x * transform.worldSize, coordinate.y * transform.worldSize, 1000, 1];
+        const renderedPixelMatrix = mat4.multiply([], transform.labelPlaneMatrix, transform.projMatrix);
+        vec4.transformMat4(worldPoint, worldPoint, renderedPixelMatrix);
+        const renderedPoint = new Point(worldPoint[0] / worldPoint[3], worldPoint[1] / worldPoint[3]);
+        const unprojected = terrainMap.unproject(renderedPoint);
+
+        expect(nearlyEquals(unprojected, lngLat, 0.00001)).toBeTruthy();
+        expect(terrainMap.queryRenderedFeatures(terrainMap.project(lngLat), {layers: ['circle']})).toHaveLength(1);
+        terrainMap.remove();
     });
 });
 


### PR DESCRIPTION
## Issue

We discovered this issue while implementing drawing tools that convert cursor positions into feature coordinates.

When using the cursor to drive placement of drawn features, such as drawing a line, the feature geometry was significantly offset under the following conditions:

- Terrain was active.
- The camera projection was set to `orthographic`.
- We were attempting to draw onto terrain rather than a flat map.

We then discovered that manually forcing the camera projection to `perspective` while drawing resolved the issue. This provided the clue that the rendering and CPU-side screen-space interaction paths were using inconsistent projections.

The mismatch came from two projection paths in `Transform#_calcMatrices`:

- `projMatrix`, used by terrain-aware rendering such as the circle shader, is built from the active blended orthographic/perspective camera projection.
- `pixelMatrix` and `pixelMatrixInverse`, used by elevated `map.project()` and terrain raycasting, are built from the perspective-only projection. This inconsistency can consequently cause pointer-based `queryRenderedFeatures()` calls to miss geometry that visibly overlaps the cursor.

Those matrices are equivalent in perspective mode and diverge for elevated coordinates in orthographic mode. The perspective-only `pixelMatrix` was introduced intentionally with the orthographic camera property so flat-map interaction behavior would remain unchanged, so this PR does not replace it globally.

## Fix

Add separately preallocated terrain screen matrices derived from the projection actually used for rendering. Elevation-aware forward projection uses the forward matrix while terrain is active; flat-map projection continues using the existing perspective matrix.

Orthographic terrain raycasting now inverse-projects both the near and far screen points and casts the resulting ray. Perspective raycasting keeps its existing camera-origin path unchanged. This makes forward terrain projection and inverse terrain picking use the same camera projection without changing the established flat or perspective paths.

I found #13618 while looking for related fixes. It addresses overzoomed DEM proxy-tile raycasting, whereas this PR addresses the orthographic render/interaction projection-matrix mismatch. The fixes therefore appear complementary rather than overlapping.

This also appears to address the bug reported in #13604.

## Tests

- Added a transform regression test proving elevated orthographic coordinates match the rendered projection while flat and perspective behavior stay unchanged.
- Added a terrain regression test using the actual map/terrain raycast path with an in-memory raster DEM. It verifies rendered-coordinate unprojection and the public `map.project(lngLat)` to `queryRenderedFeatures()` flow.
- `npm run test-unit -- test/unit/geo/transform.test.ts test/unit/terrain/terrain.test.ts` (170 passed)
- `npm run test-render -- -t 'terrain/symbol-orthographic-camera'` (passed)
- `npm test` (208 test files passed; 3,302 tests passed, 18 skipped)
- `npm run tsc` (passed)
- `npm run lint` (passed)

I did not manually run any benchmarking for this change, but I am happy to do so if additional evidence is needed. We _did_ create a one-off build from this branch and tested it with our existing application, and found the issue to be resolved.

## AI Disclosure

GPT-5.6 Sol was used to help investigate and author this PR, with strict oversight and review by me (@jeffypooo).

## Launch Checklist

- [x] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
- [x] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
- [x] Manually test the debug page.
- [x] Write tests for all new functionality and make sure the relevant checks pass locally.
- [x] Document any changes to public APIs. (No public API changes.)
- [ ] Post benchmark scores if the change could affect performance.
- [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
- [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
- [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
- [ ] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.
