### PR TITLE
Document the parameters computeOverzoomCoords actually takes

### DIFF
--- a/src/data/mrt/overzoom_util.ts
+++ b/src/data/mrt/overzoom_util.ts
@@ -29,12 +29,8 @@ function dtypeFromArray(array: Uint8Array | Uint16Array | Uint32Array): DType {
  * Compute relative offset of proposed overzoom
  *
  * @param tileSize - source tile size
- * @param sx - source x coordinate
- * @param sy - source y coordinate
- * @param sz - source z coordinate
- * @param dx - destination x coordinate
- * @param dy - destination y coordinate
- * @param dz - destination z coordinate
+ * @param source - source tile coordinates
+ * @param dest - destination tile coordinates
  * @returns offset - relative offset of overzoomed tile
  */
 export function computeOverzoomCoords(


### PR DESCRIPTION
The six names are still there as locals right below, `const {x: sx, y: sy, z: sz} = source`, so the block reads fine until you line it up against the signature. Looks like it predates `source` and `dest` being grouped into objects.
