### PR TITLE
add more exported types to esm

### DIFF
--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -59,6 +59,7 @@ export type {
     MapEventType,
     MapEventOf,
     MapEvent,
+    MapEvents,
 } from './ui/events';
 
 // Style specification types — used with addLayer(), addSource(), setStyle(), etc.
@@ -149,6 +150,9 @@ export type {
     ClipLayerSpecification,
     ClipLayout,
     LayerSpecification,
+    Layer,
+    LayoutSpecification,
+    PaintSpecification,
 } from './style-spec/types';
 
 // Named value exports — classes, functions, constants


### PR DESCRIPTION
Trying to migrate to the esm variant of mapbox in our angular application.
I guess that these types where merely forgotten and not intentionally omitted from esm