### PR TITLE
Fix crash when a symbol layer without feature-state paint gets a pain…

### DIFF
--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -797,11 +797,6 @@ class Tile {
             const imagePositions: SpritePositions = this.imageAtlas ? Object.fromEntries(this.imageAtlas.patternPositions) : {};
             const withStateUpdates = Object.keys(sourceLayerStates).length > 0 && !isBrightnessChanged;
             bucket.hasAppearances = bucket.layers.some(layer => layer.appearances && layer.appearances.length > 0);
-            // withStateUpdates only means the source carries feature state; it says nothing about
-            // whether this bucket's layers actually read it (isStateDependent). A bucket can have
-            // withStateUpdates true and an empty stateDependentLayers, so the two must be checked
-            // together wherever stateDependentLayers is used, or bucket.update() below can be
-            // called with an empty layers array and crash on layers[0].
             const hasStateDependentLayers = withStateUpdates && bucket.stateDependentLayers.length !== 0;
             const layers = hasStateDependentLayers ? bucket.stateDependentLayers : bucket.layers;
             if (hasStateDependentLayers || isBrightnessChanged || hasPaintUpdate || needsSymbolUBOUpdate) {

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -797,8 +797,14 @@ class Tile {
             const imagePositions: SpritePositions = this.imageAtlas ? Object.fromEntries(this.imageAtlas.patternPositions) : {};
             const withStateUpdates = Object.keys(sourceLayerStates).length > 0 && !isBrightnessChanged;
             bucket.hasAppearances = bucket.layers.some(layer => layer.appearances && layer.appearances.length > 0);
-            const layers = withStateUpdates ? bucket.stateDependentLayers : bucket.layers;
-            if ((withStateUpdates && bucket.stateDependentLayers.length !== 0) || isBrightnessChanged || hasPaintUpdate || needsSymbolUBOUpdate) {
+            // withStateUpdates only means the source carries feature state; it says nothing about
+            // whether this bucket's layers actually read it (isStateDependent). A bucket can have
+            // withStateUpdates true and an empty stateDependentLayers, so the two must be checked
+            // together wherever stateDependentLayers is used, or bucket.update() below can be
+            // called with an empty layers array and crash on layers[0].
+            const hasStateDependentLayers = withStateUpdates && bucket.stateDependentLayers.length !== 0;
+            const layers = hasStateDependentLayers ? bucket.stateDependentLayers : bucket.layers;
+            if (hasStateDependentLayers || isBrightnessChanged || hasPaintUpdate || needsSymbolUBOUpdate) {
                 const vtLayers = this.latestFeatureIndex.loadVTLayers();
                 const sourceLayer = vtLayers[sourceLayerId];
                 bucket.update(sourceLayerStates, sourceLayer, images, imagePositions, layers, isBrightnessChanged, brightness, this.tileID.canonical);
@@ -849,15 +855,14 @@ class Tile {
                     }
                 }
             }
-            if ((withStateUpdates && bucket.stateDependentLayers.length !== 0) || isBrightnessChanged || bucket.hasAppearances) {
+            if (hasStateDependentLayers || isBrightnessChanged || bucket.hasAppearances) {
                 const globalProperties = {
                     zoom: painter.transform.zoom,
                     pitch: painter.transform.pitch,
                     brightness: painter.style.getBrightness() || 0,
                     worldview: painter.worldview
                 };
-                const featureStateChanged = withStateUpdates && bucket.stateDependentLayers.length !== 0;
-                const result = bucket.updateAppearances(this.tileID.canonical, sourceLayerStates, images, globalProperties, painter.imageManager, featureStateChanged);
+                const result = bucket.updateAppearances(this.tileID.canonical, sourceLayerStates, images, globalProperties, painter.imageManager, hasStateDependentLayers);
                 if (result && result.hasUboChanges) {
                     const context = painter.context;
                     if (bucket instanceof SymbolBucket && bucket.text && bucket.text.uboBinder) {

--- a/test/unit/source/tile.test.ts
+++ b/test/unit/source/tile.test.ts
@@ -284,6 +284,44 @@ describe('rtl text detection', () => {
     );
 });
 
+describe('Tile#updateBuckets', () => {
+    test('does not throw when feature state and a paint update land on a symbol layer with no state-dependent paint', () => {
+        const tile = new Tile(new OverscaledTileID(1, 0, 1, 1, 1), 512, 22);
+        const symbolBucket = createSymbolBucket('test', 'Test', 'test', new CollisionBoxArray());
+        // Force UBO binder creation: the crash only happens on the UBO-based update path in
+        // SymbolBucket#update, which is skipped entirely when text/icon.uboBinder is null.
+        symbolBucket.createArrays();
+
+        const layer = symbolBucket.layers[0];
+        const painter = createPainter({
+            hasLayer: () => true,
+            listImages: () => [],
+            getBrightness: () => 0,
+            getLayerSourceCache: () => undefined,
+            getLayer: () => layer,
+            getOwnLayer: () => layer
+        });
+
+        tile.loadVectorData(
+            createVectorData({rawTileData: rawTileData as ArrayBuffer, buckets: [symbolBucket]}),
+            painter
+        );
+
+        // createSymbolBucket() gives the layer only layout properties (text-font, text-field);
+        // its paint is left at defaults, so it never reads feature-state and stateDependentLayers
+        // stays empty even though the source below carries feature state.
+        expect(tile.buckets[layer.fqid].stateDependentLayers).toEqual([]);
+
+        expect(() => tile.updateBuckets(
+            painter,
+            false,                                      // isBrightnessChanged
+            {_geojsonTileLayer: {'1': {hover: true}}},   // states -> withStateUpdates = true
+            false,                                       // needsSymbolUBOUpdate
+            new Set([layer.fqid])                        // updatedPaintProps -> hasPaintUpdate = true
+        )).not.toThrow();
+    });
+});
+
 function createVectorData(options?: {buckets?: Bucket[]; rawTileData?: ArrayBuffer}): WorkerSourceVectorTileResult {
     const collisionBoxArray = new CollisionBoxArray();
     return ({collisionBoxArray: deserialize(serialize(collisionBoxArray)),


### PR DESCRIPTION
Fix crash when a symbol layer without feature-state paint gets a paint update

## What changed

`Tile#updateBuckets` selected `bucket.stateDependentLayers` whenever `withStateUpdates` was true, but the guard that decides whether to *use* that array checked a wider, independently-satisfiable set of conditions (`hasPaintUpdate`, `needsSymbolUBOUpdate`). When a source carries state but none of a symbol bucket's layers actually read it in their paint, `stateDependentLayers` is empty, but the block can possibly still run because of an unrelated paint-property change.  That passes an empty `layers` array ito `SymbolBucket#update`, whose UBO-based update path unconditionally does `layers[0] as SymbolStyleLayer` and dereferences `.paint`, throwing `TypeError: Cannot read properties of undefined (reading 'paint')`.

Fixed by factoring the check into one `hasStateDependentLayers` value and reusing it everywhere `stateDependentLayers` is consulted, so the array that gets used and the condition that permits using it can never disagree.

## Why this contribution

This is a real, currently-open, unclaimed bug report (#13714, labeled `bug`) with a clear, minimal repro: calling `setFeatureState` followed by `setPaintProperty` on a symbol layer with no `["feature-state", ...]` expression in its paint crashes the map. I verified the other bucket types (fill/line/circle/fill-extrusion) aren't affected — only `SymbolBucket` has a UBO-binder path that indexes `layers[0]` unconditionally; the others iterate the array safely.

## What problem it solves

Prevents an uncaught exception that breaks rendering entirely for any map that sets feature state on a source shared with a symbol layer that doesn't itself use feature-state in its paint — a fairly common pattern (e.g. a line layer using hover state, symbol layer on the same source not using it).

## Testing

- Added `test/unit/source/tile.test.ts` regression test: constructs a `Tile` + `SymbolBucket` with no state-dependent paint, calls `updateBuckets()` with feature state + a paint update, asserts it doesn't throw. Confirmed it fails without the fix and passes with it.
- `npm run tsc`, `npm run lint`, and the full `tile.test.ts` suite all pass with no regressions.
- Reproduced the original crash and confirmed the fix resolves it via a local debug page exercising the exact `setFeatureState` + `setPaintProperty` sequence from the issue.

Fixes #13714


## Launch Checklist

 - [ ] Make sure the PR title is descriptive and preferably reflects the change from the user's perspective.
 - [ ] Add additional detail and context in the PR description (with screenshots/videos if there are visual changes).
 - [ ] Manually test the debug page.
 - [ ] Write tests for all new functionality and make sure the CI checks pass.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores if the change could affect performance.
 - [ ] Tag `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes.
 - [ ] Tag `@mapbox/gl-native` if this PR includes shader changes or needs a native port.
 - [ ] Tag `@mapbox/gl-native` if this PR disables any test because it also needs to be disabled on their side.
 - [ ] Create a ticket for `gl-native` to groom in the [MAPSNAT JIRA queue](https://mapbox.atlassian.net/jira/software/c/projects/MAPSNAT/list) if this PR includes shader changes or features not present in the native side or if it disables a test that's not disabled there.
