### PR TITLE
Fix incorrect and missing metadata in style spec reference

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1894,7 +1894,9 @@
       "doc": "If true, the models will be reduced in density based on the zoom level. This is useful for large datasets that may be slow to render.",
       "sdk-support": {
         "basic functionality": {
-          "js": "3.18.0"
+          "js": "3.18.0",
+          "android": "11.20.0",
+          "ios": "11.18.0"
         }
       },
       "property-type": "data-constant"

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -8925,6 +8925,7 @@
       "default": 0.0,
       "minimum": 0.0,
       "transition": true,
+      "units": "pixels",
       "sdk-support": {
         "basic functionality": {
           "js": "3.0.0",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1894,9 +1894,7 @@
       "doc": "If true, the models will be reduced in density based on the zoom level. This is useful for large datasets that may be slow to render.",
       "sdk-support": {
         "basic functionality": {
-          "js": "0.10.0",
-          "android": "2.0.1",
-          "ios": "2.0.0"
+          "js": "3.18.0"
         }
       },
       "property-type": "data-constant"

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -7217,7 +7217,7 @@
         ]
       },
       "requires": [
-        "line-pattern"
+        "fill-pattern"
       ],
       "sdk-support": {
         "basic functionality": {
@@ -7491,7 +7491,7 @@
         ]
       },
       "requires": [
-        "line-pattern"
+        "fill-extrusion-pattern"
       ],
       "sdk-support": {
         "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2229,6 +2229,7 @@
       "minimum": 0,
       "maximum": 1,
       "doc": "Radius of a fill extrusion edge in meters. If not zero, rounds extrusion edges for a smoother appearance.",
+      "units": "meters",
       "sdk-support": {
         "basic functionality": {
           "js": "3.0.0",
@@ -2350,6 +2351,7 @@
       "maximum": 20.0,
       "default": 3.1,
       "doc": "Width of a floor. Think of this as measure how wide each unit should be. This effectively determines the number of units per each floor. Note that this does not affect the ground level facades (i.e. number of windows).",
+      "units": "meters",
       "private": true,
       "property-type": "data-driven",
       "sdk-support": {
@@ -2574,7 +2576,6 @@
       "property-type": "data-driven",
       "type": "boolean",
       "private": true,
-      "units": "meters",
       "default": false,
       "doc": "Flips the orientation of the roofs for the buildings. This only affects simple geometries. Namely buildings whose footprints form a quadrilateral. By default (false), the roof ridge takes the direction of the longer edge of the quadrilateral.",
       "transition": true,
@@ -2757,6 +2758,7 @@
       "type": "number",
       "doc": "Vertical offset from ground, in meters. Not supported for globe projection at the moment.",
       "default": 0,
+      "units": "meters",
       "requires": [
         "line-elevation-reference"
       ],
@@ -6118,6 +6120,7 @@
         "relaxZoomRestriction": true
       },
       "doc": "An array of two number values, specifying the vertical range, measured in meters, over which the fog should gradually fade out. When both parameters are set to zero, the fog will be rendered without any vertical constraints.",
+      "units": "meters",
       "sdk-support": {
         "basic functionality": {
           "js": "3.0.0",
@@ -7255,6 +7258,7 @@
     "fill-z-offset": {
       "type": "number",
       "doc": "Specifies an uniform elevation in meters. Note: If the value is zero, the layer will be rendered on the ground. Non-zero values will elevate the layer from the sea level, which can cause it to be rendered below the terrain.",
+      "units": "meters",
       "default": 0,
       "minimum": 0,
       "transition": true,
@@ -7717,6 +7721,7 @@
       },
       "transition": true,
       "doc": "The extent of the ambient occlusion effect on the ground beneath the extruded buildings in meters.",
+      "units": "meters",
       "requires": [
         "lights"
       ],
@@ -8147,6 +8152,7 @@
       },
       "transition": true,
       "doc": "The extent of the ambient occlusion effect on the ground beneath the procedural buildings in meters.",
+      "units": "meters",
       "sdk-support": {
         "basic functionality": {
           "js": "3.16.0",
@@ -10294,6 +10300,7 @@
     "symbol-z-offset": {
       "type": "number",
       "doc": "Specifies an uniform elevation from the ground, in meters.",
+      "units": "meters",
       "default": 0,
       "minimum": 0,
       "transition": true,
@@ -10725,6 +10732,7 @@
       "default": 0,
       "minimum": 0,
       "transition": true,
+      "units": "meters",
       "experimental": true,
       "sdk-support": {
         "basic functionality": {
@@ -10901,6 +10909,7 @@
       "default": 0,
       "minimum": 0,
       "transition": true,
+      "units": "meters",
       "sdk-support": {
         "basic functionality": {
           "js": "3.7.0",
@@ -10924,6 +10933,7 @@
       "minimum": 0,
       "maximum": 359,
       "doc": "The direction of the light source used to generate the hillshading with 0 as the top of the viewport if `hillshade-illumination-anchor` is set to `viewport` and due north if `hillshade-illumination-anchor` is set to `map` and no 3d lights enabled. If `hillshade-illumination-anchor` is set to `map` and 3d lights enabled, the direction from 3d lights is used instead.",
+      "units": "degrees",
       "transition": false,
       "sdk-support": {
         "basic functionality": {
@@ -11327,6 +11337,7 @@
       "maximum": 180,
       "transition": false,
       "doc": "The angular distance (measured in degrees) from `sky-gradient-center` up to which the gradient extends. A value of 180 causes the gradient to wrap around to the opposite direction from `sky-gradient-center`.",
+      "units": "degrees",
       "sdk-support": {
         "basic functionality": {
           "js": "2.0.0",
@@ -11545,6 +11556,7 @@
         }
       },
       "transition": true,
+      "units": "meters",
       "doc": "The translation of the model in meters in form of [longitudal, latitudal, altitude] offsets."
     },
     "model-color": {


### PR DESCRIPTION
**Fixed** `"requires"` entry for `fill-pattern-cross-fade` and `fill-extrusion-pattern-cross-fade` which were both falsely reporting `line-pattern` as a requirement.

**Fixed** `"sdk-support"`entry  for `model-allow-density-reduction`. This previously referenced very old versions where models were not supported.

**Added** `"units": "pixels"` to:
- `line-border-width`

**Added** `"units": "meters"` to:
- `symbol-z-offset`
- `fill-z-offset`
- `model-translation`
- `fill-extrusion-edge-radius`
- `building-facade-unit-width`
- `fill-extrusion-ambient-occlusion-ground-radius`
- `building-ambient-occlusion-ground-radius`
- `fog.vertical-range`

**Added** `"units": "degrees"` to:
- `sky-gradient-radius`
- `hillshade-illumination-direction`

**Removed** `"units": "pixels"` to:
- `building-flip-roof-orientation` as this is a boolean
